### PR TITLE
reconfigure package details for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "@biconomy/abstractjs",
+  "name": "@magicnewton/newton-account-sdk",
   "version": "0.0.36",
-  "author": "Biconomy",
-  "repository": "github:bcnmy/abstractjs",
+  "author": "MagicLabs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/magiclabs/newton-account-sdk.git"
+  },
   "main": "./dist/_cjs/index.js",
   "module": "./dist/_esm/index.js",
-  "access": "public",
+  "publishConfig": {
+    "access": "restricted"
+  },
   "devDependencies": {
     "@biomejs/biome": "1.6.0",
     "@changesets/cli": "^2.27.1",
@@ -73,17 +78,12 @@
       "default": "./_cjs/modules/index.js"
     }
   },
-  "commitlint": {
-    "extends": [
-      "@commitlint/config-conventional"
-    ]
-  },
   "description": "SDK for Biconomy integration with support for account abstraction, smart accounts, ERC-4337.",
   "files": [
     "dist/*",
     "README.md"
   ],
-  "homepage": "https://biconomy.io",
+  "homepage": "https://magic.link",
   "keywords": [
     "erc-7579",
     "modular smart account",
@@ -124,10 +124,12 @@
   },
   "sideEffects": false,
   "simple-git-hooks": {
-    "pre-commit": "bun run format && bun run lint:fix",
-    "commit-msg": "npx --no -- commitlint --edit ${1}"
+    "pre-commit": "bun run format && bun run lint:fix"
   },
   "type": "module",
   "types": "./dist/_types/index.d.ts",
-  "typings": "./dist/_types/index.d.ts"
+  "typings": "./dist/_types/index.d.ts",
+  "bugs": {
+    "url": "https://github.com/magiclabs/newton-account-sdk/issues"
+  }
 }


### PR DESCRIPTION
change details for npm publishing
change git, website, bugs info

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `package.json` for a project, changing its name, author, repository details, and various configurations, reflecting a shift from `@biconomy/abstractjs` to `@magicnewton/newton-account-sdk`.

### Detailed summary
- Updated `name` from `@biconomy/abstractjs` to `@magicnewton/newton-account-sdk`.
- Changed `author` from `Biconomy` to `MagicLabs`.
- Modified `repository` details to point to MagicLabs' GitHub.
- Changed `publishConfig` access from `public` to `restricted`.
- Updated `homepage` from `https://biconomy.io` to `https://magic.link`.
- Removed `commitlint` configuration.
- Added `bugs` section with URL for issues.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->