### PR TITLE
chore: update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Biconomy
+Copyright (c) Biconomy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the copyright notice in the `LICENSE` file by removing the year 2024, making it reflect only "Biconomy" without the year.

### Detailed summary
- Changed the copyright line from `Copyright (c) 2024 Biconomy` to `Copyright (c) Biconomy`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->