### PR TITLE
feat: composability module

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -41,4 +41,5 @@ jobs:
           ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
           TESTNET_CHAIN_ID: 84532
           MAINNET_CHAIN_ID: 10
+          RUN_PAID_TESTS: false
           CI: true 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-[![Biconomy](https://img.shields.io/badge/Made_with_%F0%9F%8D%8A_by-Biconomy-ff4e17?style=flat)](https://biconomy.io) [![License MIT](https://img.shields.io/badge/License-MIT-blue?&style=flat)](./LICENSE) [![codecov](https://codecov.io/github/bcnmy/abstractjs/graph/badge.svg?token=DTdIR5aBDA)](https://codecov.io/github/bcnmy/abstractjs) [![install size](https://packagephobia.com/badge?p=@biconomy/abstractjs)](https://packagephobia.com/result?p=@biconomy/abstractjs)
+[![Biconomy](https://img.shields.io/badge/Made_with_%F0%9F%8D%8A_by-Biconomy-ff4e17?style=flat)](https://biconomy.io)
+[![Build](https://github.com/bcnmy/abstractjs/actions/workflows/build.yml/badge.svg)](https://github.com/bcnmy/abstractjs/actions)
+[![License MIT](https://img.shields.io/badge/License-MIT-blue?&style=flat)](./LICENSE) 
+[![codecov](https://codecov.io/github/bcnmy/abstractjs/graph/badge.svg?token=DTdIR5aBDA)](https://codecov.io/github/bcnmy/abstractjs) 
+[![install size](https://packagephobia.com/badge?p=@biconomy/abstractjs)](https://packagephobia.com/result?p=@biconomy/abstractjs)
 
 # abstractjs 🚀
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
-[![Biconomy](https://img.shields.io/badge/Made_with_%F0%9F%8D%8A_by-Biconomy-ff4e17?style=flat)](https://biconomy.io)
-[![Build](https://github.com/bcnmy/abstractjs/actions/workflows/build.yml/badge.svg)](https://github.com/bcnmy/abstractjs/actions)
-[![License MIT](https://img.shields.io/badge/License-MIT-blue?&style=flat)](./LICENSE) 
-[![codecov](https://codecov.io/github/bcnmy/abstractjs/graph/badge.svg?token=DTdIR5aBDA)](https://codecov.io/github/bcnmy/abstractjs) 
-[![install size](https://packagephobia.com/badge?p=@biconomy/abstractjs)](https://packagephobia.com/result?p=@biconomy/abstractjs)
+[![Biconomy](https://img.shields.io/badge/Made_with_%F0%9F%8D%8A_by-Biconomy-ff4e17?style=flat)](https://biconomy.io) [![License MIT](https://img.shields.io/badge/License-MIT-blue?&style=flat)](./LICENSE) [![codecov](https://codecov.io/github/bcnmy/abstractjs/graph/badge.svg?token=DTdIR5aBDA)](https://codecov.io/github/bcnmy/abstractjs) [![install size](https://packagephobia.com/badge?p=@biconomy/abstractjs)](https://packagephobia.com/result?p=@biconomy/abstractjs)
 
 # abstractjs 🚀
 

--- a/scripts/fund:nexus.ts
+++ b/scripts/fund:nexus.ts
@@ -23,6 +23,7 @@ dotenv.config()
 const NATIVE_TOKEN_AMOUNT = parseEther("0.0005")
 const USDC_TOKEN_AMOUNT = parseUnits("3", 6)
 const ACCOUNT_INDEX = 0n
+const ACCOUNT_INDEX_ONE = 1n
 
 async function main() {
   // Get chain IDs from command line arguments
@@ -48,13 +49,17 @@ async function main() {
 
   // Process each chain ID
   for (const chainId of chainIds) {
-    await processChain(chainId, account)
+    // Two account will be available from now. For collision issues in tests, use a fallback account with index one
+    // Default: Index zero will be used for most of the tests
+    await processChain(chainId, account, ACCOUNT_INDEX)
+    await processChain(chainId, account, ACCOUNT_INDEX_ONE)
   }
 }
 
 async function processChain(
   chainId: number,
-  account: ReturnType<typeof privateKeyToAccount>
+  account: ReturnType<typeof privateKeyToAccount>,
+  accountIndex: bigint
 ) {
   try {
     const chain = getChain(chainId)
@@ -94,7 +99,7 @@ async function processChain(
       chain,
       signer: account,
       transport: http(),
-      index: ACCOUNT_INDEX
+      index: accountIndex,
     })
 
     const nexusAddress = await nexus.getAddress()

--- a/src/sdk/account/decorators/build.ts
+++ b/src/sdk/account/decorators/build.ts
@@ -7,6 +7,9 @@ import {
 import buildBatch, {
   type BuildBatchParameters
 } from "./instructions/buildBatch"
+import buildComposable, {
+  type BuildComposableParameters
+} from "./instructions/buildComposable"
 import {
   type BuildDefaultParameters,
   buildDefaultInstructions
@@ -108,6 +111,16 @@ export type BuildBatchInstruction = {
 }
 
 /**
+ * Build action which is used to build instructions for a composable call
+ * @property type - Literal "composable" to identify the action type
+ * @property data - {@link BuildComposableParameters} The parameters for the composable action
+ */
+export type BuildComposableInstruction = {
+  type: "composable"
+  data: BuildComposableParameters
+}
+
+/**
  * Union type of all possible build instruction types
  */
 export type BuildInstructionTypes =
@@ -118,6 +131,7 @@ export type BuildInstructionTypes =
   | BuildApproveInstruction
   | BuildWithdrawalInstruction
   | BuildBatchInstruction
+  | BuildComposableInstruction
 /**
  * Builds transaction instructions based on the provided action type and parameters
  *
@@ -168,6 +182,9 @@ export const build = async (
     }
     case "default": {
       return buildDefaultInstructions(baseParams, data)
+    }
+    case "composable": {
+      return buildComposable(baseParams, data)
     }
     case "transferFrom": {
       return buildTransferFrom(baseParams, data)

--- a/src/sdk/account/decorators/build.ts
+++ b/src/sdk/account/decorators/build.ts
@@ -1,4 +1,6 @@
+import type { Address } from "viem"
 import type { Instruction } from "../../clients/decorators/mee/getQuote"
+import type { RuntimeValue } from "../../modules"
 import type { BaseMultichainSmartAccount } from "../toMultiChainNexusAccount"
 import {
   type BuildApproveParameters,
@@ -29,6 +31,28 @@ import {
 import buildWithdrawal, {
   type BuildWithdrawalParameters
 } from "./instructions/buildWithdrawal"
+
+/**
+ * Parameters for a token builders
+ */
+export type TokenParams = {
+  /**
+   * The address of the token to use on the relevant chain
+   * @example "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC
+   */
+  tokenAddress: Address
+  /**
+   * The chainId to use
+   * @example 1 // Ethereum Mainnet
+   */
+  chainId: number
+  /**
+   * Amount of the token to use, in the token's smallest unit
+   * @example 1000000n // 1 USDC (6 decimals)
+   * @example { isRuntime: true, inputParams: [], outputParams: [] }
+   */
+  amount: bigint | RuntimeValue
+}
 
 /**
  * Base parameters for building instructions

--- a/src/sdk/account/decorators/instructions/buildApprove.ts
+++ b/src/sdk/account/decorators/instructions/buildApprove.ts
@@ -1,13 +1,12 @@
 import { type Address, encodeFunctionData, erc20Abi } from "viem"
-import type {
-  AbstractCall,
-  Instruction,
-  Trigger
-} from "../../../clients/decorators/mee"
+import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
 import type { AnyData } from "../../../modules/utils/Types"
 import { isComposableCallRequired } from "../../../modules/utils/composabilityCalls"
-import { getFunctionContextFromAbi } from "../../../modules/utils/runtimeAbiEncoding"
-import type { BaseInstructionsParams } from "../build"
+import {
+  type RuntimeValue,
+  getFunctionContextFromAbi
+} from "../../../modules/utils/runtimeAbiEncoding"
+import type { BaseInstructionsParams, TokenParams } from "../build"
 import {
   type BuildComposableParameters,
   buildComposableCall
@@ -16,7 +15,7 @@ import {
 /**
  * Parameters for building an approval instruction
  */
-export type BuildApproveParameters = Trigger & {
+export type BuildApproveParameters = TokenParams & {
   /**
    * Gas limit for the approval transaction. Required when using the standard
    * approve function instead of permit.
@@ -81,7 +80,10 @@ export const buildApprove = async (
 
   const abi = erc20Abi
   const functionSig = "approve"
-  const args: readonly [`0x${string}`, bigint] = [spender, amount]
+  const args: readonly [`0x${string}`, bigint | RuntimeValue] = [
+    spender,
+    amount
+  ]
 
   const functionContext = getFunctionContextFromAbi(functionSig, abi)
 
@@ -115,7 +117,7 @@ export const buildApprove = async (
       data: encodeFunctionData({
         abi,
         functionName: functionSig,
-        args
+        args: args as [`0x${string}`, bigint]
       }),
       ...(gasLimit ? { gasLimit } : {})
     }

--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -1,54 +1,65 @@
 import {
+  Abi,
   type Address,
   type Chain,
   type LocalAccount,
-  type Transport,
   erc20Abi,
-  parseUnits
-} from "viem"
-import { beforeAll, describe, expect, it } from "vitest"
-import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
-import type { NetworkConfig } from "../../../../test/testUtils"
+  fromBytes,
+  http,
+  parseUnits,
+  toBytes,
+} from "viem";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { NetworkConfig } from "../../../../test/testUtils";
 import {
   type MeeClient,
-  createMeeClient
-} from "../../../clients/createMeeClient"
-import type { Instruction } from "../../../clients/decorators/mee/getQuote"
-import { mcUSDC } from "../../../constants/tokens"
-import { greaterThanOrEqualTo, runtimeERC20BalanceOf } from "../../../modules"
+  createMeeClient,
+} from "../../../clients/createMeeClient";
+import type { Instruction } from "../../../clients/decorators/mee/getQuote";
+import { testnetMcUSDC } from "../../../constants/tokens";
+import { greaterThanOrEqualTo, runtimeERC20BalanceOf } from "../../../modules";
 import {
   type MultichainSmartAccount,
-  toMultichainNexusAccount
-} from "../../toMultiChainNexusAccount"
-import buildComposable from "./buildComposable"
+  toMultichainNexusAccount,
+} from "../../toMultiChainNexusAccount";
+import buildComposable from "./buildComposable";
+import { COMPOSABILITY_RUNTIME_TRANSFER_ABI } from "../../../../test/__contracts/abi/ComposabilityRuntimeTransferAbi";
+import { baseSepolia } from "viem/chains";
+import { getMeeScanLink } from "../../utils/explorer";
+import { toNetwork } from "../../../../test/testSetup";
+import { testnetMcUniswapSwapRouter, UniswapSwapRouterAbi } from "../../../constants";
+import { getMultichainContract } from "../../utils";
 
 describe("mee.buildComposable", () => {
-  let network: NetworkConfig
-  let eoaAccount: LocalAccount
+  let network: NetworkConfig;
+  let eoaAccount: LocalAccount;
 
-  let mcNexus: MultichainSmartAccount
-  let meeClient: MeeClient
+  let mcNexus: MultichainSmartAccount;
+  let meeClient: MeeClient;
 
-  let tokenAddress: Address
-  let paymentChain: Chain
-  let targetChain: Chain
-  let transports: Transport[]
+  let tokenAddress: Address;
+  let runtimeTransferAddress: Address;
+  let chain: Chain;
 
   beforeAll(async () => {
-    network = await toNetwork("MAINNET_FROM_ENV_VARS")
-    ;[[paymentChain, targetChain], transports] = getTestChainConfig(network)
+    network = await toNetwork("TESTNET_FROM_ENV_VARS");
+    eoaAccount = network.account!;
 
-    eoaAccount = network.account!
+    chain = baseSepolia;
 
     mcNexus = await toMultichainNexusAccount({
-      chains: [paymentChain, targetChain],
-      transports,
-      signer: eoaAccount
-    })
+      chains: [chain],
+      transports: [http()],
+      signer: eoaAccount,
+      index: BigInt(1),
+    });
 
-    meeClient = await createMeeClient({ account: mcNexus })
-    tokenAddress = mcUSDC.addressOn(paymentChain.id)
-  })
+    meeClient = await createMeeClient({ account: mcNexus });
+    tokenAddress = testnetMcUSDC.addressOn(chain.id);
+
+    // Mock testing contract for composability testing
+    runtimeTransferAddress = "0xb46e85b8Bd24D1dca043811D5b8B18b2a8c5F95D";
+  });
 
   it("should highlight building composable instructions", async () => {
     const instructions: Instruction[] = await buildComposable(
@@ -61,20 +72,523 @@ describe("mee.buildComposable", () => {
           data: {
             args: [
               eoaAccount.address,
-              mcNexus.addressOn(targetChain.id, true),
+              mcNexus.addressOn(chain.id, true),
               runtimeERC20BalanceOf(
                 eoaAccount.address,
-                mcUSDC,
-                targetChain.id,
+                testnetMcUSDC,
+                chain.id,
                 [greaterThanOrEqualTo(parseUnits("0.01", 6))]
-              )
-            ]
-          }
+              ),
+            ],
+          },
         },
-        chainId: targetChain.id
+        chainId: chain.id,
       }
-    )
+    );
 
-    expect(instructions.length).toBeGreaterThan(0)
-  })
-})
+    expect(instructions.length).toBeGreaterThan(0);
+  });
+
+  it("should execute composable transaction for static args", async () => {
+    const amountToSupply = parseUnits("0.1", 6);
+
+    const trigger = {
+      chainId: chain.id,
+      tokenAddress: testnetMcUSDC.addressOn(chain.id),
+      amount: amountToSupply,
+    };
+
+    const transferInstruction = testnetMcUSDC.on(chain.id).transfer({
+      args: [runtimeTransferAddress, amountToSupply],
+    });
+
+    const instructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: runtimeTransferAddress,
+        abi: COMPOSABILITY_RUNTIME_TRANSFER_ABI as Abi,
+        params: {
+          type: "transferFunds",
+          data: {
+            args: [
+              eoaAccount.address,
+              runtimeERC20BalanceOf(
+                runtimeTransferAddress,
+                testnetMcUSDC,
+                chain.id,
+                [greaterThanOrEqualTo(parseUnits("0.01", 6))]
+              ),
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: await meeClient.getFusionQuote({
+        trigger,
+        instructions: [transferInstruction, ...instructions],
+        feeToken: {
+          chainId: chain.id,
+          address: testnetMcUSDC.addressOn(chain.id),
+        },
+      }),
+    });
+
+    console.log(
+      "Link for composable transaction for static args: ",
+      getMeeScanLink(hash)
+    );
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+    });
+
+    const execResult = receipt.receipts.map(
+      (receipt) => receipt.status === "fulfilled"
+    );
+
+    expect(new Array(receipt.receipts.length).fill(true).toString()).to.be.eq(
+      execResult.toString()
+    );
+  });
+
+  it("should execute composable transaction for struct args", async () => {
+    const amountToSupply = parseUnits("0.1", 6);
+
+    const trigger = {
+      chainId: chain.id,
+      tokenAddress: testnetMcUSDC.addressOn(chain.id),
+      amount: amountToSupply,
+    };
+
+    const transferInstruction = testnetMcUSDC.on(chain.id).transfer({
+      args: [runtimeTransferAddress, amountToSupply],
+    });
+
+    const instructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: runtimeTransferAddress,
+        abi: COMPOSABILITY_RUNTIME_TRANSFER_ABI as Abi,
+        params: {
+          type: "transferFundsWithStruct",
+          data: {
+            args: [
+              runtimeTransferAddress,
+              {
+                recipient: eoaAccount.address,
+                amount: runtimeERC20BalanceOf(
+                  runtimeTransferAddress,
+                  testnetMcUSDC,
+                  chain.id,
+                  [greaterThanOrEqualTo(parseUnits("0.01", 6))] // 6 decimals for USDC
+                ),
+              },
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: await meeClient.getFusionQuote({
+        trigger,
+        instructions: [transferInstruction, ...instructions],
+        feeToken: {
+          chainId: chain.id,
+          address: testnetMcUSDC.addressOn(chain.id),
+        },
+      }),
+    });
+
+    console.log(
+      "Link for composable transaction for struct args: ",
+      getMeeScanLink(hash)
+    );
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+    });
+
+    const execResult = receipt.receipts.map(
+      (receipt) => receipt.status === "fulfilled"
+    );
+
+    expect(new Array(receipt.receipts.length).fill(true).toString()).to.be.eq(
+      execResult.toString()
+    );
+  });
+
+  it("should execute composable transaction for dynamic array args", async () => {
+    const amountToSupply = parseUnits("0.1", 6);
+
+    const trigger = {
+      chainId: chain.id,
+      tokenAddress: testnetMcUSDC.addressOn(chain.id),
+      amount: amountToSupply,
+    };
+
+    const transferInstruction = testnetMcUSDC.on(chain.id).transfer({
+      args: [runtimeTransferAddress, amountToSupply],
+    });
+
+    const instructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: runtimeTransferAddress,
+        abi: COMPOSABILITY_RUNTIME_TRANSFER_ABI as Abi,
+        params: {
+          type: "transferFundsWithDynamicArray",
+          data: {
+            args: [
+              runtimeTransferAddress,
+              [runtimeTransferAddress, eoaAccount.address],
+              runtimeERC20BalanceOf(
+                runtimeTransferAddress,
+                testnetMcUSDC,
+                chain.id,
+                [greaterThanOrEqualTo(parseUnits("0.01", 6))] // 6 decimals for USDC
+              ),
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: await meeClient.getFusionQuote({
+        trigger,
+        instructions: [transferInstruction, ...instructions],
+        feeToken: {
+          chainId: chain.id,
+          address: testnetMcUSDC.addressOn(chain.id),
+        },
+      }),
+    });
+
+    console.log(
+      "Link for composable transaction for dynamic array args: ",
+      getMeeScanLink(hash)
+    );
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+    });
+
+    const execResult = receipt.receipts.map(
+      (receipt) => receipt.status === "fulfilled"
+    );
+
+    expect(new Array(receipt.receipts.length).fill(true).toString()).to.be.eq(
+      execResult.toString()
+    );
+  });
+
+  it("should execute composable transaction for string args", async () => {
+    const amountToSupply = parseUnits("0.1", 6);
+
+    const trigger = {
+      chainId: chain.id,
+      tokenAddress: testnetMcUSDC.addressOn(chain.id),
+      amount: amountToSupply,
+    };
+
+    const transferInstruction = testnetMcUSDC.on(chain.id).transfer({
+      args: [runtimeTransferAddress, amountToSupply],
+    });
+
+    const instructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: runtimeTransferAddress,
+        abi: COMPOSABILITY_RUNTIME_TRANSFER_ABI as Abi,
+        params: {
+          type: "transferFundsWithString",
+          data: {
+            args: [
+              "random_string_this_doesnt_matter",
+              [runtimeTransferAddress, eoaAccount.address],
+              runtimeERC20BalanceOf(
+                runtimeTransferAddress,
+                testnetMcUSDC,
+                chain.id,
+                [greaterThanOrEqualTo(parseUnits("0.01", 6))] // 6 decimals for USDC
+              ),
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: await meeClient.getFusionQuote({
+        trigger,
+        instructions: [transferInstruction, ...instructions],
+        feeToken: {
+          chainId: chain.id,
+          address: testnetMcUSDC.addressOn(chain.id),
+        },
+      }),
+    });
+
+    console.log(
+      "Link for composable transaction for string args: ",
+      getMeeScanLink(hash)
+    );
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+    });
+
+    const execResult = receipt.receipts.map(
+      (receipt) => receipt.status === "fulfilled"
+    );
+
+    expect(new Array(receipt.receipts.length).fill(true).toString()).to.be.eq(
+      execResult.toString()
+    );
+  });
+
+  it("should execute composable transaction for bytes args", async () => {
+    const amountToSupply = parseUnits("0.1", 6);
+
+    const trigger = {
+      chainId: chain.id,
+      tokenAddress: testnetMcUSDC.addressOn(chain.id),
+      amount: amountToSupply,
+    };
+
+    const transferInstruction = testnetMcUSDC.on(chain.id).transfer({
+      args: [runtimeTransferAddress, amountToSupply],
+    });
+
+    const instructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: runtimeTransferAddress,
+        abi: COMPOSABILITY_RUNTIME_TRANSFER_ABI as Abi,
+        params: {
+          type: "transferFundsWithBytes",
+          data: {
+            args: [
+              fromBytes(toBytes("random_string_this_doesnt_matter"), "hex"),
+              [runtimeTransferAddress, eoaAccount.address],
+              runtimeERC20BalanceOf(
+                runtimeTransferAddress,
+                testnetMcUSDC,
+                chain.id,
+                [greaterThanOrEqualTo(parseUnits("0.01", 6))] // 6 decimals for USDC
+              ),
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: await meeClient.getFusionQuote({
+        trigger,
+        instructions: [transferInstruction, ...instructions],
+        feeToken: {
+          chainId: chain.id,
+          address: testnetMcUSDC.addressOn(chain.id),
+        },
+      }),
+    });
+
+    console.log(
+      "Link for composable transaction for bytes args: ",
+      getMeeScanLink(hash)
+    );
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+    });
+
+    const execResult = receipt.receipts.map(
+      (receipt) => receipt.status === "fulfilled"
+    );
+
+    expect(new Array(receipt.receipts.length).fill(true).toString()).to.be.eq(
+      execResult.toString()
+    );
+  });
+
+  it("should execute composable transaction for runtime arg inside dynamic array args", async () => {
+    const amountToSupply = parseUnits("0.1", 6);
+
+    const trigger = {
+      chainId: chain.id,
+      tokenAddress: testnetMcUSDC.addressOn(chain.id),
+      amount: amountToSupply,
+    };
+
+    const transferInstruction = testnetMcUSDC.on(chain.id).transfer({
+      args: [runtimeTransferAddress, amountToSupply],
+    });
+
+    const instructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: runtimeTransferAddress,
+        abi: COMPOSABILITY_RUNTIME_TRANSFER_ABI as Abi,
+        params: {
+          type: "transferFundsWithRuntimeParamInsideArray",
+          data: {
+            args: [
+              [runtimeTransferAddress, eoaAccount.address],
+              [
+                runtimeERC20BalanceOf(
+                  runtimeTransferAddress,
+                  testnetMcUSDC,
+                  chain.id,
+                  [greaterThanOrEqualTo(parseUnits("0.01", 6))] // 6 decimals for USDC
+                ),
+              ],
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: await meeClient.getFusionQuote({
+        trigger,
+        instructions: [transferInstruction, ...instructions],
+        feeToken: {
+          chainId: chain.id,
+          address: testnetMcUSDC.addressOn(chain.id),
+        },
+      }),
+    });
+
+    console.log(
+      "Link for composable transaction for runtime arg inside dynamic array args: ",
+      getMeeScanLink(hash)
+    );
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+    });
+
+    const execResult = receipt.receipts.map(
+      (receipt) => receipt.status === "fulfilled"
+    );
+
+    expect(new Array(receipt.receipts.length).fill(true).toString()).to.be.eq(
+      execResult.toString()
+    );
+  });
+
+  it("should execute composable transaction for uniswap args", async () => {
+    const fusionToken = getMultichainContract<typeof erc20Abi>({
+      abi: erc20Abi,
+      deployments: [
+        ["0x232fb0469e5fc7f8f5a04eddbcc11f677143f715", chain.id], // Fusion
+      ],
+    });
+    
+    const inToken = testnetMcUSDC;
+    const outToken = fusionToken;
+
+    const amount = parseUnits("0.2", 6);
+
+    const trigger = {
+      chainId: chain.id,
+      tokenAddress: inToken.addressOn(chain.id),
+      amount: amount,
+    };
+
+    const approveInstructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: inToken.addressOn(chain.id),
+        abi: erc20Abi as Abi,
+        params: {
+          type: "approve",
+          data: {
+            args: [
+              testnetMcUniswapSwapRouter.addressOn(chain.id),
+              runtimeERC20BalanceOf(mcNexus.addressOn(chain.id, true), inToken, chain.id),
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const swapInstructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: testnetMcUniswapSwapRouter.addressOn(chain.id),
+        abi: UniswapSwapRouterAbi as Abi,
+        params: {
+          type: "exactInputSingle",
+          data: {
+            args: [
+              {
+                tokenIn: inToken.addressOn(chain.id),
+                tokenOut: outToken.addressOn(chain.id),
+                fee: 3000,
+                recipient: eoaAccount.address,
+                amountIn: runtimeERC20BalanceOf(mcNexus.addressOn(chain.id, true), inToken, chain.id),
+                amountOutMinimum: BigInt(1),
+                sqrtPriceLimitX96: BigInt(0),
+              },
+            ],
+          },
+        },
+        chainId: chain.id,
+      }
+    );
+
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: await meeClient.getFusionQuote({
+        trigger,
+        instructions: [...approveInstructions, ...swapInstructions],
+        feeToken: {
+          chainId: chain.id,
+          address: inToken.addressOn(chain.id),
+        },
+      }),
+    });
+
+    console.log(
+      "Link for composable transaction for uniswap args: ",
+      getMeeScanLink(hash)
+    );
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+    });
+
+    const execResult = receipt.receipts.map(
+      (receipt) => receipt.status === "fulfilled"
+    );
+
+    expect(new Array(receipt.receipts.length).fill(true).toString()).to.be.eq(
+      execResult.toString()
+    );
+  });
+
+  // it("should execute composable transaction for approval and transferFrom builders", async () => {
+  //   const amount = parseUnits("0.2", 6);
+
+  //   const approval = mcNexus.build({
+  //     type: "approve",
+  //     data: {
+  //       amount: runtimeERC20BalanceOf(mcNexus.addressOn(chain.id, true), testnetMcUSDC, chain.id),
+  //       chainId: chain.id,
+  //       tokenAddress: testnetMcUSDC.addressOn(chain.id),
+  //       spender: mcNexus.addressOn(chain.id, true)
+  //     }
+  //   })
+  // });
+});

--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -1,0 +1,80 @@
+import {
+  type Address,
+  type Chain,
+  type LocalAccount,
+  type Transport,
+  erc20Abi,
+  parseUnits
+} from "viem"
+import { beforeAll, describe, expect, it } from "vitest"
+import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
+import type { NetworkConfig } from "../../../../test/testUtils"
+import {
+  type MeeClient,
+  createMeeClient
+} from "../../../clients/createMeeClient"
+import type { Instruction } from "../../../clients/decorators/mee/getQuote"
+import { mcUSDC } from "../../../constants/tokens"
+import { greaterThanOrEqualTo, runtimeERC20BalanceOf } from "../../../modules"
+import {
+  type MultichainSmartAccount,
+  toMultichainNexusAccount
+} from "../../toMultiChainNexusAccount"
+import buildComposable from "./buildComposable"
+
+describe("mee.buildComposable", () => {
+  let network: NetworkConfig
+  let eoaAccount: LocalAccount
+
+  let mcNexus: MultichainSmartAccount
+  let meeClient: MeeClient
+
+  let tokenAddress: Address
+  let paymentChain: Chain
+  let targetChain: Chain
+  let transports: Transport[]
+
+  beforeAll(async () => {
+    network = await toNetwork("MAINNET_FROM_ENV_VARS")
+    ;[[paymentChain, targetChain], transports] = getTestChainConfig(network)
+
+    eoaAccount = network.account!
+
+    mcNexus = await toMultichainNexusAccount({
+      chains: [paymentChain, targetChain],
+      transports,
+      signer: eoaAccount
+    })
+
+    meeClient = await createMeeClient({ account: mcNexus })
+    tokenAddress = mcUSDC.addressOn(paymentChain.id)
+  })
+
+  it("should highlight building composable instructions", async () => {
+    const instructions: Instruction[] = await buildComposable(
+      { account: mcNexus },
+      {
+        to: tokenAddress,
+        abi: erc20Abi,
+        params: {
+          type: "transferFrom",
+          data: {
+            args: [
+              eoaAccount.address,
+              mcNexus.addressOn(targetChain.id, true),
+              runtimeERC20BalanceOf(
+                eoaAccount.address,
+                mcUSDC,
+                targetChain.id,
+                [greaterThanOrEqualTo(parseUnits("0.01", 6))]
+              )
+            ]
+          }
+        },
+        chainId: targetChain.id
+      }
+    )
+
+    expect(instructions.length).toBeGreaterThan(0)
+  })
+})

--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -53,7 +53,8 @@ describe("mee.buildComposable", () => {
     mcNexus = await toMultichainNexusAccount({
       chains: [chain],
       transports: [http()],
-      signer: eoaAccount
+      signer: eoaAccount,
+      index: 1n // Added based on the suggestion by Joe to prevent the collision with nonce
     })
 
     meeClient = await createMeeClient({ account: mcNexus })

--- a/src/sdk/account/decorators/instructions/buildTransfer.ts
+++ b/src/sdk/account/decorators/instructions/buildTransfer.ts
@@ -1,14 +1,13 @@
 import { type Address, encodeFunctionData } from "viem"
-import type {
-  AbstractCall,
-  Instruction,
-  Trigger
-} from "../../../clients/decorators/mee"
+import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
 import { TokenWithPermitAbi } from "../../../constants/abi/TokenWithPermitAbi"
 import type { AnyData } from "../../../modules/utils/Types"
 import { isComposableCallRequired } from "../../../modules/utils/composabilityCalls"
-import { getFunctionContextFromAbi } from "../../../modules/utils/runtimeAbiEncoding"
-import type { BaseInstructionsParams } from "../build"
+import {
+  type RuntimeValue,
+  getFunctionContextFromAbi
+} from "../../../modules/utils/runtimeAbiEncoding"
+import type { BaseInstructionsParams, TokenParams } from "../build"
 import {
   type BuildComposableParameters,
   buildComposableCall
@@ -17,7 +16,7 @@ import {
 /**
  * Parameters for building a transfer instruction
  */
-export type BuildTransferParameters = Trigger & {
+export type BuildTransferParameters = TokenParams & {
   /**
    * Gas limit for the transfer transaction. Required when using the standard
    * transfer function instead of permit.
@@ -81,7 +80,10 @@ export const buildTransfer = async (
 
   const abi = TokenWithPermitAbi
   const functionSig = "transfer"
-  const args: readonly [`0x${string}`, bigint] = [recipient, amount]
+  const args: readonly [`0x${string}`, bigint | RuntimeValue] = [
+    recipient,
+    amount
+  ]
 
   const functionContext = getFunctionContextFromAbi(functionSig, abi)
 
@@ -115,7 +117,7 @@ export const buildTransfer = async (
       data: encodeFunctionData({
         abi,
         functionName: functionSig,
-        args
+        args: args as [`0x${string}`, bigint]
       }),
       ...(gasLimit ? { gasLimit } : {})
     }

--- a/src/sdk/account/decorators/instructions/buildTransferFrom.ts
+++ b/src/sdk/account/decorators/instructions/buildTransferFrom.ts
@@ -4,7 +4,14 @@ import type {
   Instruction,
   Trigger
 } from "../../../clients/decorators/mee"
+import type { AnyData } from "../../../modules/utils/Types"
+import { isComposableCallRequired } from "../../../modules/utils/composabilityCalls"
+import { getFunctionContextFromAbi } from "../../../modules/utils/runtimeAbiEncoding"
 import type { BaseInstructionsParams } from "../build"
+import {
+  type BuildComposableParameters,
+  buildComposableCall
+} from "./buildComposable"
 
 /**
  * Parameters for building a transferFrom instruction
@@ -79,14 +86,50 @@ export const buildTransferFrom = async (
   const { chainId, tokenAddress, amount, gasLimit, sender, recipient } =
     parameters
 
-  const triggerCall: AbstractCall = {
-    to: tokenAddress,
-    data: encodeFunctionData({
-      abi: erc20Abi,
-      functionName: "transferFrom",
-      args: [sender, recipient, amount]
-    }),
-    ...(gasLimit ? { gasLimit } : {})
+  const abi = erc20Abi
+  const functionSig = "transferFrom"
+  const args: readonly [`0x${string}`, `0x${string}`, bigint] = [
+    sender,
+    recipient,
+    amount
+  ]
+
+  const functionContext = getFunctionContextFromAbi(functionSig, abi)
+
+  // Check for the runtime arguments and detect the need for composable call
+  const isComposableCall = isComposableCallRequired(
+    functionContext,
+    args as unknown as Array<AnyData>
+  )
+
+  let triggerCall: AbstractCall
+
+  // If the composable call is detected ? The call needs to composed with runtime encoding
+  if (isComposableCall) {
+    const composableCallParams: BuildComposableParameters = {
+      to: tokenAddress,
+      params: {
+        type: functionSig,
+        data: {
+          args: args as unknown as Array<AnyData>
+        }
+      },
+      abi,
+      chainId,
+      gasLimit
+    }
+
+    triggerCall = await buildComposableCall(baseParams, composableCallParams)
+  } else {
+    triggerCall = {
+      to: tokenAddress,
+      data: encodeFunctionData({
+        abi,
+        functionName: functionSig,
+        args
+      }),
+      ...(gasLimit ? { gasLimit } : {})
+    }
   }
 
   return [

--- a/src/sdk/account/decorators/instructions/buildTransferFrom.ts
+++ b/src/sdk/account/decorators/instructions/buildTransferFrom.ts
@@ -1,13 +1,12 @@
 import { type Address, encodeFunctionData, erc20Abi } from "viem"
-import type {
-  AbstractCall,
-  Instruction,
-  Trigger
-} from "../../../clients/decorators/mee"
+import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
 import type { AnyData } from "../../../modules/utils/Types"
 import { isComposableCallRequired } from "../../../modules/utils/composabilityCalls"
-import { getFunctionContextFromAbi } from "../../../modules/utils/runtimeAbiEncoding"
-import type { BaseInstructionsParams } from "../build"
+import {
+  type RuntimeValue,
+  getFunctionContextFromAbi
+} from "../../../modules/utils/runtimeAbiEncoding"
+import type { BaseInstructionsParams, TokenParams } from "../build"
 import {
   type BuildComposableParameters,
   buildComposableCall
@@ -16,7 +15,7 @@ import {
 /**
  * Parameters for building a transferFrom instruction
  */
-export type BuildTransferFromParameters = Trigger & {
+export type BuildTransferFromParameters = TokenParams & {
   /**
    * Gas limit for the transferFrom transaction. Required when using the standard
    * transferFrom function instead of permit.
@@ -88,7 +87,7 @@ export const buildTransferFrom = async (
 
   const abi = erc20Abi
   const functionSig = "transferFrom"
-  const args: readonly [`0x${string}`, `0x${string}`, bigint] = [
+  const args: readonly [`0x${string}`, `0x${string}`, bigint | RuntimeValue] = [
     sender,
     recipient,
     amount
@@ -126,7 +125,7 @@ export const buildTransferFrom = async (
       data: encodeFunctionData({
         abi,
         functionName: functionSig,
-        args
+        args: args as [`0x${string}`, `0x${string}`, bigint]
       }),
       ...(gasLimit ? { gasLimit } : {})
     }

--- a/src/sdk/account/decorators/instructions/buildWithdrawal.ts
+++ b/src/sdk/account/decorators/instructions/buildWithdrawal.ts
@@ -5,8 +5,15 @@ import type {
   Trigger
 } from "../../../clients/decorators/mee"
 import { TokenWithPermitAbi } from "../../../constants/abi/TokenWithPermitAbi"
+import type { AnyData } from "../../../modules/utils/Types"
+import { isComposableCallRequired } from "../../../modules/utils/composabilityCalls"
+import { getFunctionContextFromAbi } from "../../../modules/utils/runtimeAbiEncoding"
 import { addressEquals } from "../../utils"
 import type { BaseInstructionsParams } from "../build"
+import {
+  type BuildComposableParameters,
+  buildComposableCall
+} from "./buildComposable"
 
 /**
  * Parameters for building a transfer instruction
@@ -84,23 +91,55 @@ export const buildWithdrawal = async (
     "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
   )
 
-  const erc20TokenCall: AbstractCall = {
-    to: tokenAddress,
-    data: encodeFunctionData({
-      abi: TokenWithPermitAbi,
-      functionName: "transfer",
-      args: [recipient, amount]
-    }),
-    ...(gasLimit ? { gasLimit } : {})
-  }
+  let triggerCall: AbstractCall
 
-  const nativeTokenCall: AbstractCall = {
-    to: recipient,
-    value: amount,
-    ...(gasLimit ? { gasLimit } : {})
-  }
+  if (isNativeToken) {
+    triggerCall = {
+      to: recipient,
+      value: amount,
+      ...(gasLimit ? { gasLimit } : {})
+    }
+  } else {
+    const abi = TokenWithPermitAbi
+    const functionSig = "transfer"
+    const args: readonly [`0x${string}`, bigint] = [recipient, amount]
 
-  const triggerCall = isNativeToken ? nativeTokenCall : erc20TokenCall
+    const functionContext = getFunctionContextFromAbi(functionSig, abi)
+
+    // Check for the runtime arguments and detect the need for composable call
+    const isComposableCall = isComposableCallRequired(
+      functionContext,
+      args as unknown as Array<AnyData>
+    )
+
+    // If the composable call is detected ? The call needs to composed with runtime encoding
+    if (isComposableCall) {
+      const composableCallParams: BuildComposableParameters = {
+        to: tokenAddress,
+        params: {
+          type: functionSig,
+          data: {
+            args: args as unknown as Array<AnyData>
+          }
+        },
+        abi,
+        chainId,
+        gasLimit
+      }
+
+      triggerCall = await buildComposableCall(baseParams, composableCallParams)
+    } else {
+      triggerCall = {
+        to: tokenAddress,
+        data: encodeFunctionData({
+          abi,
+          functionName: functionSig,
+          args
+        }),
+        ...(gasLimit ? { gasLimit } : {})
+      }
+    }
+  }
 
   return [
     ...currentInstructions,

--- a/src/sdk/account/utils/toSigner.test.ts
+++ b/src/sdk/account/utils/toSigner.test.ts
@@ -4,6 +4,7 @@ import { privateKeyToAccount } from "viem/accounts"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import { toNetwork } from "../../../test/testSetup"
 import { type NetworkConfig, killNetwork, pKey } from "../../../test/testUtils"
+import type { AnyData } from "../../modules"
 import { type EthersWallet, addressEquals } from "./Utils"
 import { toSigner } from "./toSigner"
 
@@ -80,7 +81,7 @@ describe("utils.toSigner", () => {
   it("should work with ethers JsonRpcSigner", async () => {
     const provider = new JsonRpcProvider(network.rpcUrl)
     const signer = await provider.getSigner()
-    const nexusSigner = await toSigner({ signer: signer as any })
+    const nexusSigner = await toSigner({ signer: signer as AnyData })
     expect(nexusSigner.address).toBe(await signer.getAddress())
     const signedMessage = await nexusSigner.signMessage({
       message: "Hello World"

--- a/src/sdk/clients/createBundlerClient.test.ts
+++ b/src/sdk/clients/createBundlerClient.test.ts
@@ -103,7 +103,7 @@ describe.skipIf(!runPaidTests)("nexus.interoperability with 'MeeNode'", () => {
   })
 })
 
-describe.each(COMPETITORS)(
+describe.skipIf(!runPaidTests).each(COMPETITORS)(
   "nexus.interoperability with $name bundler",
   async ({ bundlerUrl, chain, mock }) => {
     const account = privateKeyToAccount(`0x${process.env.PRIVATE_KEY as Hex}`)

--- a/src/sdk/clients/createBundlerClient.test.ts
+++ b/src/sdk/clients/createBundlerClient.test.ts
@@ -50,7 +50,7 @@ const calls = [
   }
 ]
 
-describe.runIf(runPaidTests)("nexus.interoperability with 'MeeNode'", () => {
+describe.skipIf(!runPaidTests)("nexus.interoperability with 'MeeNode'", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
 

--- a/src/sdk/constants/abi/ComposabilityAbi.ts
+++ b/src/sdk/constants/abi/ComposabilityAbi.ts
@@ -1,191 +1,270 @@
 export const COMPOSABILITY_MODULE_ABI = [
+  { inputs: [], stateMutability: "nonpayable", type: "constructor" },
   {
-    type: "function",
-    name: "executeComposable",
     inputs: [
-      {
-        name: "to",
-        type: "address",
-        internalType: "address"
-      },
-      {
-        name: "value",
-        type: "uint256",
-        internalType: "uint256"
-      },
-      {
-        name: "functionSig",
-        type: "bytes4",
-        internalType: "bytes4"
-      },
-      {
-        name: "inputParams",
-        type: "tuple[]",
-        internalType: "struct ComposableFallbackHandler.InputParam[]",
-        components: [
-          {
-            name: "fetcherType",
-            type: "uint8",
-            internalType: "enum ComposableFallbackHandler.InputParamFetcherType"
-          },
-          {
-            name: "valueType",
-            type: "uint8",
-            internalType: "enum ComposableFallbackHandler.ParamValueType"
-          },
-          {
-            name: "paramData",
-            type: "bytes",
-            internalType: "bytes"
-          }
-        ]
-      },
-      {
-        name: "outputParams",
-        type: "tuple[]",
-        internalType: "struct ComposableFallbackHandler.OutputParam[]",
-        components: [
-          {
-            name: "fetcherType",
-            type: "uint8",
-            internalType:
-              "enum ComposableFallbackHandler.OutputParamFetcherType"
-          },
-          {
-            name: "valueType",
-            type: "uint8",
-            internalType: "enum ComposableFallbackHandler.ParamValueType"
-          },
-          {
-            name: "paramData",
-            type: "bytes",
-            internalType: "bytes"
-          }
-        ]
-      }
+      { internalType: "address", name: "smartAccount", type: "address" }
     ],
-    outputs: [],
-    stateMutability: "payable"
-  },
-  {
-    type: "function",
-    name: "isInitialized",
-    inputs: [
-      {
-        name: "",
-        type: "address",
-        internalType: "address"
-      }
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool"
-      }
-    ],
-    stateMutability: "view"
-  },
-  {
-    type: "function",
-    name: "isModuleType",
-    inputs: [
-      {
-        name: "moduleTypeId",
-        type: "uint256",
-        internalType: "uint256"
-      }
-    ],
-    outputs: [
-      {
-        name: "",
-        type: "bool",
-        internalType: "bool"
-      }
-    ],
-    stateMutability: "pure"
-  },
-  {
-    type: "function",
-    name: "onInstall",
-    inputs: [
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes"
-      }
-    ],
-    outputs: [],
-    stateMutability: "nonpayable"
-  },
-  {
-    type: "function",
-    name: "onUninstall",
-    inputs: [
-      {
-        name: "data",
-        type: "bytes",
-        internalType: "bytes"
-      }
-    ],
-    outputs: [],
-    stateMutability: "nonpayable"
-  },
-  {
-    type: "error",
     name: "AlreadyInitialized",
+    type: "error"
+  },
+  { inputs: [], name: "ComposableExecutionFailed", type: "error" },
+  {
     inputs: [
       {
-        name: "smartAccount",
-        type: "address",
-        internalType: "address"
+        internalType: "enum ConstraintType",
+        name: "constraintType",
+        type: "uint8"
       }
-    ]
+    ],
+    name: "ConstraintNotMet",
+    type: "error"
   },
+  { inputs: [], name: "FailedToReturnMsgValue", type: "error" },
+  { inputs: [], name: "InvalidConstraintType", type: "error" },
+  { inputs: [], name: "InvalidOutputParamFetcherType", type: "error" },
+  { inputs: [], name: "InvalidParameterEncoding", type: "error" },
   {
-    type: "error",
-    name: "ExecutionFailed",
-    inputs: []
-  },
-  {
-    type: "error",
-    name: "InvalidComposerInstructions",
-    inputs: []
-  },
-  {
-    type: "error",
-    name: "InvalidOutputParamFetcherType",
-    inputs: []
-  },
-  {
-    type: "error",
-    name: "InvalidParameterEncoding",
-    inputs: []
-  },
-  {
-    type: "error",
-    name: "InvalidReturnDataHandling",
-    inputs: []
-  },
-  {
-    type: "error",
-    name: "ModuleAlreadyInitialized",
-    inputs: []
-  },
-  {
-    type: "error",
+    inputs: [
+      { internalType: "address", name: "smartAccount", type: "address" }
+    ],
     name: "NotInitialized",
-    inputs: [
-      {
-        name: "smartAccount",
-        type: "address",
-        internalType: "address"
-      }
-    ]
+    type: "error"
+  },
+  { inputs: [], name: "OnlyEntryPointOrAccount", type: "error" },
+  { inputs: [], name: "Output_StaticCallFailed", type: "error" },
+  { inputs: [], name: "ZeroAddressNotAllowed", type: "error" },
+  {
+    inputs: [],
+    name: "ENTRY_POINT_V07_ADDRESS",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function"
   },
   {
-    type: "error",
-    name: "StorageReadFailed",
-    inputs: []
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "value", type: "uint256" },
+          { internalType: "bytes4", name: "functionSig", type: "bytes4" },
+          {
+            components: [
+              {
+                internalType: "enum InputParamFetcherType",
+                name: "fetcherType",
+                type: "uint8"
+              },
+              { internalType: "bytes", name: "paramData", type: "bytes" },
+              {
+                components: [
+                  {
+                    internalType: "enum ConstraintType",
+                    name: "constraintType",
+                    type: "uint8"
+                  },
+                  {
+                    internalType: "bytes",
+                    name: "referenceData",
+                    type: "bytes"
+                  }
+                ],
+                internalType: "struct Constraint[]",
+                name: "constraints",
+                type: "tuple[]"
+              }
+            ],
+            internalType: "struct InputParam[]",
+            name: "inputParams",
+            type: "tuple[]"
+          },
+          {
+            components: [
+              {
+                internalType: "enum OutputParamFetcherType",
+                name: "fetcherType",
+                type: "uint8"
+              },
+              { internalType: "bytes", name: "paramData", type: "bytes" }
+            ],
+            internalType: "struct OutputParam[]",
+            name: "outputParams",
+            type: "tuple[]"
+          }
+        ],
+        internalType: "struct ComposableExecution[]",
+        name: "executions",
+        type: "tuple[]"
+      }
+    ],
+    name: "executeComposable",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "value", type: "uint256" },
+          { internalType: "bytes4", name: "functionSig", type: "bytes4" },
+          {
+            components: [
+              {
+                internalType: "enum InputParamFetcherType",
+                name: "fetcherType",
+                type: "uint8"
+              },
+              { internalType: "bytes", name: "paramData", type: "bytes" },
+              {
+                components: [
+                  {
+                    internalType: "enum ConstraintType",
+                    name: "constraintType",
+                    type: "uint8"
+                  },
+                  {
+                    internalType: "bytes",
+                    name: "referenceData",
+                    type: "bytes"
+                  }
+                ],
+                internalType: "struct Constraint[]",
+                name: "constraints",
+                type: "tuple[]"
+              }
+            ],
+            internalType: "struct InputParam[]",
+            name: "inputParams",
+            type: "tuple[]"
+          },
+          {
+            components: [
+              {
+                internalType: "enum OutputParamFetcherType",
+                name: "fetcherType",
+                type: "uint8"
+              },
+              { internalType: "bytes", name: "paramData", type: "bytes" }
+            ],
+            internalType: "struct OutputParam[]",
+            name: "outputParams",
+            type: "tuple[]"
+          }
+        ],
+        internalType: "struct ComposableExecution[]",
+        name: "executions",
+        type: "tuple[]"
+      }
+    ],
+    name: "executeComposableCall",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    inputs: [
+      {
+        components: [
+          { internalType: "address", name: "to", type: "address" },
+          { internalType: "uint256", name: "value", type: "uint256" },
+          { internalType: "bytes4", name: "functionSig", type: "bytes4" },
+          {
+            components: [
+              {
+                internalType: "enum InputParamFetcherType",
+                name: "fetcherType",
+                type: "uint8"
+              },
+              { internalType: "bytes", name: "paramData", type: "bytes" },
+              {
+                components: [
+                  {
+                    internalType: "enum ConstraintType",
+                    name: "constraintType",
+                    type: "uint8"
+                  },
+                  {
+                    internalType: "bytes",
+                    name: "referenceData",
+                    type: "bytes"
+                  }
+                ],
+                internalType: "struct Constraint[]",
+                name: "constraints",
+                type: "tuple[]"
+              }
+            ],
+            internalType: "struct InputParam[]",
+            name: "inputParams",
+            type: "tuple[]"
+          },
+          {
+            components: [
+              {
+                internalType: "enum OutputParamFetcherType",
+                name: "fetcherType",
+                type: "uint8"
+              },
+              { internalType: "bytes", name: "paramData", type: "bytes" }
+            ],
+            internalType: "struct OutputParam[]",
+            name: "outputParams",
+            type: "tuple[]"
+          }
+        ],
+        internalType: "struct ComposableExecution[]",
+        name: "executions",
+        type: "tuple[]"
+      }
+    ],
+    name: "executeComposableDelegateCall",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "getEntryPoint",
+    outputs: [{ internalType: "address", name: "", type: "address" }],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "isInitialized",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function"
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "moduleTypeId", type: "uint256" }
+    ],
+    name: "isModuleType",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "pure",
+    type: "function"
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "data", type: "bytes" }],
+    name: "onInstall",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    inputs: [{ internalType: "bytes", name: "data", type: "bytes" }],
+    name: "onUninstall",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function"
+  },
+  {
+    inputs: [{ internalType: "address", name: "_entryPoint", type: "address" }],
+    name: "setEntryPoint",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function"
   }
 ]

--- a/src/sdk/modules/utils/composabilityCalls.ts
+++ b/src/sdk/modules/utils/composabilityCalls.ts
@@ -1,0 +1,252 @@
+import {
+  type Abi,
+  type Hex,
+  encodeAbiParameters,
+  encodeFunctionData
+} from "viem"
+import type { MultichainContract } from "../../account/utils/getMultichainContract"
+import type { AnyData } from "../../modules/utils/Types"
+import {
+  type FunctionContext,
+  type RuntimeValue,
+  encodeRuntimeFunctionData
+} from "./runtimeAbiEncoding"
+
+export type InputParam = {
+  fetcherType: InputParamFetcherType
+  paramData: string
+  constraints: Constraint[]
+}
+
+export type OutputParam = {
+  fetcherType: OutputParamFetcherType
+  paramData: string
+}
+
+export const InputParamFetcherType = {
+  RAW_BYTES: 0,
+  STATIC_CALL: 1
+} as const
+
+export const OutputParamFetcherType = {
+  EXEC_RESULT: 0,
+  STATIC_CALL: 1
+} as const
+
+export const ConstraintType = {
+  EQ: 0,
+  GTE: 1,
+  LTE: 2,
+  IN: 3
+} as const
+
+export type InputParamFetcherType =
+  (typeof InputParamFetcherType)[keyof typeof InputParamFetcherType]
+export type OutputParamFetcherType =
+  (typeof OutputParamFetcherType)[keyof typeof OutputParamFetcherType]
+export type ConstraintType =
+  (typeof ConstraintType)[keyof typeof ConstraintType]
+
+export type Constraint = {
+  constraintType: ConstraintType
+  referenceData: string
+}
+
+export type ComposableExecution = {
+  to: string
+  value: bigint
+  functionSig: string
+  inputParams: InputParam[]
+  outputParams: OutputParam[]
+}
+
+export type ConstraintField = {
+  type: ConstraintType
+  value: AnyData // type any is being implicitly used. The appropriate value validation happens in the runtime function
+}
+
+// Detects whether the value is runtime injected value or not
+export const isRuntimeComposableValue = (value: AnyData) => {
+  if (
+    value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    value.isRuntime
+  ) {
+    return true
+  }
+
+  return false
+}
+
+export const prepareInputParam = (
+  fetcherType: InputParamFetcherType,
+  paramData: string,
+  constraints: Constraint[] = []
+): InputParam => {
+  return { fetcherType, paramData, constraints }
+}
+
+export const prepareOutputParam = (
+  fetcherType: OutputParamFetcherType,
+  paramData: string
+): OutputParam => {
+  return { fetcherType, paramData }
+}
+
+export const prepareConstraint = (
+  constraintType: ConstraintType,
+  referenceData: string
+): Constraint => {
+  return { constraintType, referenceData }
+}
+
+// type any is being implicitly used. The appropriate value validation happens in the runtime function
+export const greaterThanOrEqualTo = (value: AnyData): ConstraintField => {
+  return { type: ConstraintType.GTE, value }
+}
+
+// type any is being implicitly used. The appropriate value validation happens in the runtime function
+export const lessThanOrEqualTo = (value: AnyData): ConstraintField => {
+  return { type: ConstraintType.LTE, value }
+}
+
+// type any is being implicitly used. The appropriate value validation happens in the runtime function
+export const equalTo = (value: AnyData): ConstraintField => {
+  return { type: ConstraintType.EQ, value }
+}
+
+export const runtimeERC20BalanceOf = <TAbi extends Abi>(
+  targetAddress: string,
+  token: MultichainContract<TAbi>,
+  chainId: number,
+  constraints: ConstraintField[] = []
+) => {
+  const defaultFunctionSig = "balanceOf"
+
+  const tokenAddress = token.addressOn(chainId)
+
+  const encodedParam = encodeAbiParameters(
+    [{ type: "address" }, { type: "bytes" }],
+    [
+      tokenAddress,
+      encodeFunctionData({
+        abi: token.abi as Abi,
+        functionName: defaultFunctionSig,
+        args: [targetAddress]
+      })
+    ]
+  )
+
+  const constraintsToAdd: Constraint[] = []
+
+  if (constraints.length > 0) {
+    for (const constraint of constraints) {
+      // Contraint type IN is ignored for the runtimeBalanceOf
+      // This is mostly a number/unit/int, so it makes sense to only have EQ, GTE, LTE
+      if (
+        !Object.values(ConstraintType).slice(0, 3).includes(constraint.type)
+      ) {
+        throw new Error("Invalid contraint type")
+      }
+
+      // Handle value validation in a appropriate to runtime function
+      if (
+        typeof constraint.value !== "bigint" ||
+        constraint.value < BigInt(0)
+      ) {
+        throw new Error("Invalid contraint value")
+      }
+
+      const valueHex = `0x${constraint.value.toString(16).padStart(64, "0")}`
+      const encodedConstraintValue = encodeAbiParameters(
+        [{ type: "bytes32" }],
+        [valueHex as Hex]
+      )
+
+      constraintsToAdd.push(
+        prepareConstraint(constraint.type, encodedConstraintValue)
+      )
+    }
+  }
+
+  return {
+    isRuntime: true,
+    inputParams: [
+      prepareInputParam(
+        InputParamFetcherType.STATIC_CALL,
+        encodedParam,
+        constraintsToAdd
+      )
+    ],
+    outputParams: []
+  }
+}
+
+export const isComposableCallRequired = (
+  functionContext: FunctionContext,
+  args: Array<AnyData>
+): boolean => {
+  if (!functionContext.inputs || functionContext.inputs.length <= 0)
+    return false
+
+  const isComposableCall = functionContext.inputs.some((input, inputIndex) => {
+    // Only struct and arrays has child elements and require iterating them internally.
+    // String and bytes are also dynamic but they are mostly treated as one single value for detection
+    if (input.type === "tuple") {
+      // Struct arguments are handled here
+
+      // Composable call detection
+      const isComposableCallDetected = Object.values(args[inputIndex]).some(
+        (internalArg: AnyData) => isRuntimeComposableValue(internalArg)
+      )
+
+      return isComposableCallDetected
+    }
+
+    if (input.type.match(/^(.*)\[(\d+)?\]$/)) {
+      // matches against both static and dynamic arrays.
+      // Array arguments are handled here
+
+      // Composable call detection
+      const isComposableCallDetected = args[inputIndex].some(
+        (internalArg: AnyData) => isRuntimeComposableValue(internalArg)
+      )
+
+      return isComposableCallDetected
+    }
+
+    // Below mentioned common values are handled here.
+    // intX, uintX, bytesX, bytes, string, bool, address are direct values and doesn't need iteration on child elements.
+
+    // Composable call detection
+    return isRuntimeComposableValue(args[inputIndex])
+  })
+
+  return isComposableCall
+}
+
+export const prepareComposableParams = (
+  functionContext: FunctionContext,
+  args: Array<AnyData>
+) => {
+  const composableParams = encodeRuntimeFunctionData(functionContext, args).map(
+    (calldata) => {
+      if (isRuntimeComposableValue(calldata)) {
+        // Just handling input params here. In future, we may need to add support for output params as well
+        return (calldata as RuntimeValue)?.inputParams
+      }
+
+      // These are non runtime values which are encoded by the encodeRuntimeFunctionData helper.
+      // These params are injected are individual raw bytes which will be combined on the composable contract
+      return [
+        prepareInputParam(InputParamFetcherType.RAW_BYTES, calldata as Hex)
+      ]
+    }
+  )
+
+  // Head Params,Head Params,Head Params + (len + Tail Params),(len + Tail Params),(len + Tail Params)
+  // Static type doesn't have tail
+  // Dynamic types have tail params where the head only have offset which points the dynamic param in tail
+  return composableParams.flat()
+}

--- a/src/sdk/modules/utils/index.ts
+++ b/src/sdk/modules/utils/index.ts
@@ -1,3 +1,5 @@
 export * from "./Types"
 export * from "./Helpers"
 export * from "./Uid"
+export * from "./composabilityCalls"
+export * from "./runtimeAbiEncoding"

--- a/src/sdk/modules/utils/runtimeAbiEncoding.ts
+++ b/src/sdk/modules/utils/runtimeAbiEncoding.ts
@@ -1,0 +1,522 @@
+// If anyone wanted to get comfortable with ABI encoding specification
+// Check this out: https://docs.soliditylang.org/en/develop/abi-spec.html
+// If you are a video person ?
+// Check this out: https://www.youtube.com/watch?v=upVloLUw5Z0
+
+// Author Information:
+// This code is created and audited by Venkatesh Rajendran
+// Github: https://github.com/vr16x
+// Reachout to me if there is any issues or doubts
+// X: https://x.com/vr16x
+// Slack: https://biconomyworkspace.slack.com/team/U08HJN728RM
+
+import {
+  type Abi,
+  AbiEncodingArrayLengthMismatchError,
+  AbiEncodingBytesSizeMismatchError,
+  AbiEncodingLengthMismatchError,
+  type AbiFunction,
+  type AbiParameter,
+  type AbiParameterToPrimitiveType,
+  BaseError,
+  ByteArray,
+  type Hex,
+  IntegerOutOfRangeError,
+  InvalidAbiEncodingTypeError,
+  InvalidAddressError,
+  InvalidArrayError,
+  boolToHex,
+  concat,
+  isAddress,
+  numberToHex,
+  padHex,
+  size,
+  slice,
+  stringToHex,
+  toFunctionSelector
+} from "viem"
+import type { AnyData } from "../../modules/utils/Types"
+import {
+  type InputParam,
+  type OutputParam,
+  isRuntimeComposableValue
+} from "./composabilityCalls"
+
+export type FunctionContext = {
+  inputs: readonly AbiParameter[]
+  outputs: readonly AbiParameter[]
+  name: string
+  functionType: "read" | "write"
+  functionSig: string
+}
+
+export type RuntimeValue = {
+  isRuntime: boolean
+  inputParams: InputParam[]
+  outputParams: OutputParam[]
+}
+
+type PreparedParam = { dynamic: boolean; data: (Hex | RuntimeValue)[] }
+type TupleAbiParameter = AbiParameter & { components: readonly AbiParameter[] }
+type Tuple = AbiParameterToPrimitiveType<TupleAbiParameter>
+
+// Total list of int and uint types used for regex matching against the data type
+const integerRegex =
+  /^(u?int)(8|16|24|32|40|48|56|64|72|80|88|96|104|112|120|128|136|144|152|160|168|176|184|192|200|208|216|224|232|240|248|256)?$/
+
+// length in hex (0x....5) + Right padded string hex (0x4j34ng2....0000)
+// Example: 0x00000.....50x4j34ng2....0000
+const encodeString = (value: string): PreparedParam => {
+  const hexValue = stringToHex(value)
+  const partsLength = Math.ceil(size(hexValue) / 32)
+  const parts: Hex[] = []
+  for (let i = 0; i < partsLength; i++) {
+    parts.push(
+      padHex(slice(hexValue, i * 32, (i + 1) * 32), {
+        dir: "right"
+      })
+    )
+  }
+
+  return {
+    dynamic: true,
+    data: [
+      concat([padHex(numberToHex(size(hexValue), { size: 32 })), ...parts]) // Concat string len + right padded string hex value
+    ]
+  }
+}
+
+// The encoding for bytes also treated same as string if it is a bytes value
+// Example: 0x00000.....50x4j34ng2....0000
+// Encoding for static bytes type is straight forward. It will be simply converted into hex with padding on right
+// No length is used for static bytes type
+// 0x50x4j34ng2....00000000
+const encodeBytes = <const param extends AbiParameter>(
+  value: AnyData,
+  { param }: { param: param }
+): PreparedParam => {
+  const [, paramSize] = param.type.split("bytes")
+
+  // Checks if the value is runtime value which means the appropriate encoding already happened in composability integration
+  // In this case, we just need to determine whether the bytes is a static or dynamic value
+  if (isRuntimeComposableValue(value)) {
+    if (paramSize) {
+      return { dynamic: false, data: [value] }
+    }
+
+    return { dynamic: true, data: [value] }
+  }
+
+  const bytesSize = size(value)
+
+  // If there is no param size, it is bytes data type and trearted as dynamic value
+  if (!paramSize) {
+    let value_ = value
+    // If the size is not divisible by 32 bytes, pad the end
+    // with empty bytes to the ceiling 32 bytes.
+    if (bytesSize % 32 !== 0)
+      value_ = padHex(value_, {
+        dir: "right",
+        size: Math.ceil((value.length - 2) / 2 / 32) * 32
+      })
+    return {
+      dynamic: true,
+      data: [padHex(numberToHex(bytesSize, { size: 32 })), value_] // Length + Value
+    }
+  }
+
+  // Check for param size which is extracted from type with actual byte size
+  if (bytesSize !== Number.parseInt(paramSize))
+    throw new AbiEncodingBytesSizeMismatchError({
+      expectedSize: Number.parseInt(paramSize),
+      value: value
+    })
+
+  return { dynamic: false, data: [padHex(value, { dir: "right" })] } // No length because of the static nature
+}
+
+// Number value is converted into 32 bytes hex
+// Example: 0x000...0000002
+const encodeNumber = (
+  value: number,
+  { signed, size = 256 }: { signed: boolean; size?: number | undefined }
+): PreparedParam => {
+  // Validating the boundry of uint and int types
+  if (typeof size === "number") {
+    const max =
+      BigInt(2) ** (BigInt(size) - (signed ? BigInt(1) : BigInt(0))) - BigInt(1)
+    const min = signed ? -max - BigInt(1) : BigInt(0)
+    if (value > max || value < min)
+      throw new IntegerOutOfRangeError({
+        max: max.toString(),
+        min: min.toString(),
+        signed,
+        size: size / 8,
+        value: value.toString()
+      })
+  }
+
+  // Simply converting a number into hex value
+  return {
+    dynamic: false,
+    data: [
+      numberToHex(value, {
+        size: 32,
+        signed
+      })
+    ]
+  }
+}
+
+// Boolean value is converted into 32 bytes hex
+// Example: 0x000...0000001 for true
+// Example: 0x000...0000000 for false
+const encodeBool = (value: boolean): PreparedParam => {
+  if (typeof value !== "boolean")
+    throw new BaseError(
+      `Invalid boolean value: "${value}" (type: ${typeof value}). Expected: \`true\` or \`false\`.`
+    )
+
+  // Simply converting a bool into hex value
+  return { dynamic: false, data: [padHex(boolToHex(value))] }
+}
+
+// Address value is converted into 32 bytes hex
+// Example: 0x000...g132gj1 for false
+const encodeAddress = (value: Hex): PreparedParam => {
+  if (!isAddress(value)) throw new InvalidAddressError({ address: value })
+
+  // Simply converting a address into hex value
+  return { dynamic: false, data: [padHex(value.toLowerCase() as Hex)] }
+}
+
+const encodeArray = <const param extends AbiParameter>(
+  value: AnyData,
+  {
+    length,
+    param
+  }: {
+    length: number | null
+    param: param
+  }
+): PreparedParam => {
+  // If there is no length mentioned in the array, it is a dynamic array
+  const dynamic = length === null
+
+  if (!Array.isArray(value)) throw new InvalidArrayError(value)
+
+  // If there is a length specified, the static array length is validated with its elements count
+  if (!dynamic && value.length !== length)
+    throw new AbiEncodingArrayLengthMismatchError({
+      expectedLength: length!,
+      givenLength: value.length,
+      type: `${param.type}[${length}]`
+    })
+
+  let dynamicChild = false
+  const preparedParams: PreparedParam[] = []
+
+  for (let i = 0; i < value.length; i++) {
+    // The internal elements are encoded according to its data type.
+    const preparedParam = prepareParam({ param, value: value[i] })
+
+    // If any internal data type is dynamic, the array will be treated as dynamic
+    // No matter what whether the main array is static or dynamic
+    if (preparedParam.dynamic) dynamicChild = true
+    preparedParams.push(preparedParam)
+  }
+
+  // if the array itself dynamic or child element is dynamic ? The array is treated as dynamic
+  if (dynamic || dynamicChild) {
+    // Encoding the internal elements
+    const data = encodeParams(preparedParams)
+
+    // If the main array itself dynamic and has a atleast one element, the encoding will be
+    // length + list of elements appended one after other based on the internal data type encoding
+    // If it is a emtpy dynamic arrray ? zero length is added as encoding
+    if (dynamic) {
+      const length = numberToHex(preparedParams.length, { size: 32 })
+      return {
+        dynamic: true,
+        data: preparedParams.length > 0 ? [length, ...data] : [length] // The entire array will be placed at the tail
+      }
+    }
+
+    // If the main array is not dynamic but the child is dynamic ? The child element encoding already
+    // handled the length + data while encoding itself. So no need for length here.
+    // Array will be placed in head but the element pointer is stored here which points to the values in tail
+    if (dynamicChild) return { dynamic: true, data: data }
+  }
+
+  // As the encoding for array can be nested as well. But finally we will flatten them
+  const data = preparedParams.flatMap(({ data }) => data)
+
+  // If the array is static, the elements are placed in the head with 32 bytes size per element
+  return {
+    dynamic: false,
+    data: data
+  }
+}
+
+// Static struct usually handled same as static data type and placed in head
+// A struct with dynamic data type will be considered as dynamic in nature
+const encodeTuple = <
+  const param extends AbiParameter & { components: readonly AbiParameter[] }
+>(
+  value: AbiParameterToPrimitiveType<param>,
+  { param }: { param: param }
+): PreparedParam => {
+  let dynamic = false
+  const preparedParams: PreparedParam[] = []
+
+  for (let i = 0; i < param.components.length; i++) {
+    const param_ = param.components[i]
+    const index = Array.isArray(value) ? i : param_.name
+    // The internal elements will be encoded based on its data type. It will handle the nested data type encoding as well
+    const preparedParam = prepareParam({
+      param: param_,
+      value: (value as AnyData)[index!] as readonly unknown[]
+    })
+    preparedParams.push(preparedParam)
+    // If any of the internal element of a tuple is dynamic ? The entire tuple is treated as dynamic tuple
+    if (preparedParam.dynamic) dynamic = true
+  }
+
+  return {
+    dynamic,
+    data: dynamic
+      ? encodeParams(preparedParams) // If the struct is dynamic, it will be placed in tail with a pointer/offset in head
+      : preparedParams.flatMap(({ data }) => data) // If the tuple is static, it is simply placed on after another in head
+  }
+}
+
+const getArrayComponents = (
+  type: string
+): [length: number | null, innerType: string] | undefined => {
+  const matches = type.match(/^(.*)\[(\d+)?\]$/)
+  return matches
+    ? // Return `null` if the array is dynamic.
+      [matches[2] ? Number(matches[2]) : null, matches[1]]
+    : undefined
+}
+
+const encodeParams = (
+  preparedParams: PreparedParam[]
+): (Hex | RuntimeValue)[] => {
+  // 1. Compute the size of the static part of the parameters.
+  let staticSize = 0
+
+  for (let i = 0; i < preparedParams.length; i++) {
+    const { dynamic, data } = preparedParams[i]
+
+    // If the data type is dynamic, only offset/pointer is placed in the head
+    // hence it only requires 32 bytes for head where the actual values will be placed in tail
+    if (dynamic) {
+      staticSize += 32
+    } else {
+      // Most probably the size of this data array will be one for this instance.
+      const len = data.reduce((acc, val) => {
+        // If the value is runtime ? We always assume it is static value. hence we are adding 32 bytes.
+        // Dynamic runtime values are not supported by composability stack as of now.
+        // In future, if the composability stack support dynamic runtime types, this needs to be changed
+        if (isRuntimeComposableValue(val)) {
+          return acc + 32
+        }
+
+        return acc + size(val as Hex)
+      }, 0)
+      staticSize += len
+    }
+  }
+
+  // 2. Split the parameters into static and dynamic parts.
+  const staticParams: (Hex | RuntimeValue)[] = []
+  const dynamicParams: (Hex | RuntimeValue)[] = []
+  let dynamicSize = 0
+
+  for (let i = 0; i < preparedParams.length; i++) {
+    const { dynamic, data } = preparedParams[i]
+
+    // If the param is dynamic ? Static param will be a offset and dynamic param is placed in tail
+    if (dynamic) {
+      // For the first dynamic param, there will be no dynamic value in tail. Which means the dynamic value will be place after all head elements
+      // length of all static type are calculated and dynamic value is placed after the calculated length
+      // From the next time, the static + dynamic length will be calculated to get a fresh pointer at the last where the dynamic value will be placed
+      staticParams.push(
+        numberToHex(staticSize + dynamicSize, { size: 32 }) as Hex
+      )
+      dynamicParams.push(...data)
+      const len = data.reduce((acc, val) => {
+        // If the dynamic value contains a runtime value ? The result of runtime value is expected to be 32 bytes.
+        // We don't support dynamic value to be output of runtime value. If the composability stack supports dynamic runtime values ?
+        // This need to be changed
+        if (isRuntimeComposableValue(val)) {
+          return acc + 32
+        }
+
+        // Actual size of dynamic value is calculated
+        return acc + size(val as Hex)
+      }, 0)
+
+      // Dynamic length is calculated. It will increase as the number of dynamic values present
+      // For second dynamic param, the pointer placed in head will sum the static size and existing dynamic values to find/point a new place after all
+      // dynamic values
+      dynamicSize += len
+    } else {
+      staticParams.push(...data)
+    }
+  }
+
+  // 3. Concatenate static and dynamic parts.
+  // Static params are placed in head and dynamic params are placed in tail
+  return [...staticParams, ...dynamicParams]
+}
+
+const prepareParams = <const params extends readonly AbiParameter[]>({
+  params,
+  values
+}: {
+  params: params
+  values: Array<AnyData>
+}): PreparedParam[] => {
+  const preparedParams: PreparedParam[] = []
+  for (let i = 0; i < params.length; i++) {
+    preparedParams.push(prepareParam({ param: params[i], value: values[i] }))
+  }
+  return preparedParams
+}
+
+const prepareParam = <const param extends AbiParameter>({
+  param,
+  value
+}: {
+  param: param
+  value: AnyData
+}): PreparedParam => {
+  const runtimeValue = { dynamic: false, data: [value as RuntimeValue] }
+
+  // Detect whether the data type is array or not
+  const arrayComponents = getArrayComponents(param.type)
+
+  if (arrayComponents) {
+    // If it is array, the length might be some number or null.
+    // Null => Dynamic array, Some number => Static array
+    const [length, type] = arrayComponents
+
+    // Runtime value is not required to be handled. As the internal types will be the runtime and it will be auto handled when
+    // handling the internal fields
+    return encodeArray(value, { length, param: { ...param, type } })
+  }
+
+  if (param.type === "address") {
+    // If the address is runtime value, the encoding is already happened in composability helper, simply return the runtime value
+    if (isRuntimeComposableValue(value)) return runtimeValue
+
+    return encodeAddress(value as unknown as Hex)
+  }
+
+  if (param.type === "bool") {
+    // If the bool is runtime value, the encoding is already happened in composability helper, simply return the runtime value
+    if (isRuntimeComposableValue(value)) return runtimeValue
+
+    return encodeBool(value as unknown as boolean)
+  }
+
+  if (param.type.startsWith("uint") || param.type.startsWith("int")) {
+    // If the uint/int is runtime value, the encoding is already happened in composability helper, simply return the runtime value
+    if (isRuntimeComposableValue(value)) return runtimeValue
+
+    const signed = param.type.startsWith("int")
+    const [, , size = "256"] = integerRegex.exec(param.type) ?? []
+    return encodeNumber(value as unknown as number, {
+      signed,
+      size: Number(size)
+    })
+  }
+
+  if (param.type.startsWith("bytes")) {
+    // Runtime value is handled inside this function itself
+    return encodeBytes(value, { param })
+  }
+
+  if (param.type === "string") {
+    // If the string is runtime value, the encoding is already happened in composability helper, simply return the runtime value
+    if (isRuntimeComposableValue(value)) return runtimeValue
+
+    return encodeString(value as unknown as string)
+  }
+
+  if (param.type === "tuple") {
+    // Runtime value is not required to be handled. As the internal types will be the runtime and it will be auto handled when
+    // handling the internal fields
+    return encodeTuple(value as unknown as Tuple, {
+      param: param as TupleAbiParameter
+    })
+  }
+
+  // If none of the type matches, invalid type is specified for encoding, so throw an error
+  throw new InvalidAbiEncodingTypeError(param.type, {
+    docsPath: "/docs/contract/encodeAbiParameters"
+  })
+}
+
+export const encodeRuntimeFunctionData = (
+  functionContext: FunctionContext,
+  args: Array<AnyData>
+) => {
+  // If there is no arguments to the function, no need for encoding at all.
+  if (!functionContext.inputs || functionContext.inputs.length === 0) {
+    return ["0x" as Hex]
+  }
+
+  // If the required inputs and arguments passed is not same, throw an error
+  if (functionContext.inputs.length !== args.length) {
+    throw new AbiEncodingLengthMismatchError({
+      expectedLength: functionContext?.inputs?.length as number,
+      givenLength: args.length
+    })
+  }
+
+  // Prepare the encoding
+  const preparedParams = prepareParams({
+    params: functionContext.inputs,
+    values: args as Array<AnyData>
+  })
+
+  // Encoding the prepared data types based on static and dynamic natrue
+  const data = encodeParams(preparedParams)
+
+  // If there is no data, which means no encoding happened, return 0x
+  if (data.length === 0) return ["0x" as Hex]
+
+  // Return theb encoded data. This is not a usual encoding function which returns the funSig + args encoding as a hex
+  // It returns only arguments in a array form which is very flexible to handle runtime values
+  return data
+}
+
+export const getFunctionContextFromAbi = (
+  functionSig: string,
+  abi: Abi
+): FunctionContext => {
+  if (abi.length === 0) {
+    throw new Error("Invalid ABI")
+  }
+
+  const [functionInfo] = abi.filter(
+    (item) => item.type === "function" && item.name === functionSig
+  )
+
+  if (!functionInfo) {
+    throw new Error(`${functionSig} not found on the ABI`)
+  }
+
+  const { inputs, name, outputs, stateMutability } = functionInfo as AbiFunction
+
+  return {
+    inputs,
+    name,
+    outputs,
+    functionType: ["view", "pure"].includes(stateMutability) ? "read" : "write",
+    functionSig: toFunctionSelector(functionInfo as AbiFunction)
+  }
+}

--- a/src/sdk/modules/utils/runtimeAbiEncoding.ts
+++ b/src/sdk/modules/utils/runtimeAbiEncoding.ts
@@ -19,7 +19,6 @@ import {
   type AbiParameter,
   type AbiParameterToPrimitiveType,
   BaseError,
-  ByteArray,
   type Hex,
   IntegerOutOfRangeError,
   InvalidAbiEncodingTypeError,

--- a/src/test/__contracts/abi/ComposabilityRuntimeTransferAbi.ts
+++ b/src/test/__contracts/abi/ComposabilityRuntimeTransferAbi.ts
@@ -1,0 +1,197 @@
+export const COMPOSABILITY_RUNTIME_TRANSFER_ABI = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "transferFunds",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes",
+        name: "",
+        type: "bytes",
+      },
+      {
+        internalType: "address[]",
+        name: "addresses",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "transferFundsWithBytes",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address[]",
+        name: "addresses",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "transferFundsWithDynamicArray",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address[]",
+        name: "addresses",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256[]",
+        name: "amounts",
+        type: "uint256[]",
+      },
+    ],
+    name: "transferFundsWithRuntimeParamInsideArray",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "string",
+        name: "",
+        type: "string",
+      },
+      {
+        internalType: "address[]",
+        name: "addresses",
+        type: "address[]",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+    ],
+    name: "transferFundsWithString",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "selfContractAddress",
+        type: "address",
+      },
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "recipient",
+            type: "address",
+          },
+          {
+            internalType: "uint256",
+            name: "amount",
+            type: "uint256",
+          },
+        ],
+        internalType: "struct RuntimeTransfer.Payload",
+        name: "payload",
+        type: "tuple",
+      },
+    ],
+    name: "transferFundsWithStruct",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "tokenAddress",
+        type: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [],
+    name: "token",
+    outputs: [
+      {
+        internalType: "contract IERC20",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+];

--- a/src/test/__contracts/abi/ComposabilityRuntimeTransferAbi.ts
+++ b/src/test/__contracts/abi/ComposabilityRuntimeTransferAbi.ts
@@ -4,182 +4,182 @@ export const COMPOSABILITY_RUNTIME_TRANSFER_ABI = [
       {
         internalType: "address",
         name: "recipient",
-        type: "address",
+        type: "address"
       },
       {
         internalType: "uint256",
         name: "amount",
-        type: "uint256",
-      },
+        type: "uint256"
+      }
     ],
     name: "transferFunds",
     outputs: [
       {
         internalType: "bool",
         name: "",
-        type: "bool",
-      },
+        type: "bool"
+      }
     ],
     stateMutability: "nonpayable",
-    type: "function",
+    type: "function"
   },
   {
     inputs: [
       {
         internalType: "bytes",
         name: "",
-        type: "bytes",
+        type: "bytes"
       },
       {
         internalType: "address[]",
         name: "addresses",
-        type: "address[]",
+        type: "address[]"
       },
       {
         internalType: "uint256",
         name: "amount",
-        type: "uint256",
-      },
+        type: "uint256"
+      }
     ],
     name: "transferFundsWithBytes",
     outputs: [
       {
         internalType: "bool",
         name: "",
-        type: "bool",
-      },
+        type: "bool"
+      }
     ],
     stateMutability: "nonpayable",
-    type: "function",
+    type: "function"
   },
   {
     inputs: [
       {
         internalType: "address",
         name: "",
-        type: "address",
+        type: "address"
       },
       {
         internalType: "address[]",
         name: "addresses",
-        type: "address[]",
+        type: "address[]"
       },
       {
         internalType: "uint256",
         name: "amount",
-        type: "uint256",
-      },
+        type: "uint256"
+      }
     ],
     name: "transferFundsWithDynamicArray",
     outputs: [
       {
         internalType: "bool",
         name: "",
-        type: "bool",
-      },
+        type: "bool"
+      }
     ],
     stateMutability: "nonpayable",
-    type: "function",
+    type: "function"
   },
   {
     inputs: [
       {
         internalType: "address[]",
         name: "addresses",
-        type: "address[]",
+        type: "address[]"
       },
       {
         internalType: "uint256[]",
         name: "amounts",
-        type: "uint256[]",
-      },
+        type: "uint256[]"
+      }
     ],
     name: "transferFundsWithRuntimeParamInsideArray",
     outputs: [
       {
         internalType: "bool",
         name: "",
-        type: "bool",
-      },
+        type: "bool"
+      }
     ],
     stateMutability: "nonpayable",
-    type: "function",
+    type: "function"
   },
   {
     inputs: [
       {
         internalType: "string",
         name: "",
-        type: "string",
+        type: "string"
       },
       {
         internalType: "address[]",
         name: "addresses",
-        type: "address[]",
+        type: "address[]"
       },
       {
         internalType: "uint256",
         name: "amount",
-        type: "uint256",
-      },
+        type: "uint256"
+      }
     ],
     name: "transferFundsWithString",
     outputs: [
       {
         internalType: "bool",
         name: "",
-        type: "bool",
-      },
+        type: "bool"
+      }
     ],
     stateMutability: "nonpayable",
-    type: "function",
+    type: "function"
   },
   {
     inputs: [
       {
         internalType: "address",
         name: "selfContractAddress",
-        type: "address",
+        type: "address"
       },
       {
         components: [
           {
             internalType: "address",
             name: "recipient",
-            type: "address",
+            type: "address"
           },
           {
             internalType: "uint256",
             name: "amount",
-            type: "uint256",
-          },
+            type: "uint256"
+          }
         ],
         internalType: "struct RuntimeTransfer.Payload",
         name: "payload",
-        type: "tuple",
-      },
+        type: "tuple"
+      }
     ],
     name: "transferFundsWithStruct",
     outputs: [
       {
         internalType: "bool",
         name: "",
-        type: "bool",
-      },
+        type: "bool"
+      }
     ],
     stateMutability: "nonpayable",
-    type: "function",
+    type: "function"
   },
   {
     inputs: [
       {
         internalType: "address",
         name: "tokenAddress",
-        type: "address",
-      },
+        type: "address"
+      }
     ],
     stateMutability: "nonpayable",
-    type: "constructor",
+    type: "constructor"
   },
   {
     inputs: [],
@@ -188,10 +188,10 @@ export const COMPOSABILITY_RUNTIME_TRANSFER_ABI = [
       {
         internalType: "contract IERC20",
         name: "",
-        type: "address",
-      },
+        type: "address"
+      }
     ],
     stateMutability: "view",
-    type: "function",
-  },
-];
+    type: "function"
+  }
+]


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces enhancements for composability in the SDK, including new utilities for building composable calls and updates to existing functions to support runtime arguments. It also modifies tests and configurations to accommodate these changes.

### Detailed summary
- Added `RUN_PAID_TESTS` to `.github/workflows/unit-tests.yml`.
- Exported new modules: `composabilityCalls` and `runtimeAbiEncoding` in `src/sdk/modules/utils/index.ts`.
- Increased `testTimeout` in `src/test/vitest.config.ts` from 200,000 to 500,000.
- Updated test descriptions to use `describe.skipIf(!runPaidTests)` instead of `describe.runIf(runPaidTests)`.
- Modified `build.ts` to include `BuildComposableParameters` and `BuildComposableInstruction`.
- Introduced a new `buildComposable` function to handle composable instructions in `buildComposable.ts`.
- Enhanced `buildApprove`, `buildTransferFrom`, and `buildTransfer` functions to support composable calls.
- Added `COMPOSABILITY_RUNTIME_TRANSFER_ABI` in `src/test/__contracts/abi/ComposabilityRuntimeTransferAbi.ts`.
- Updated `buildWithdrawal` to handle composable calls.
- Added runtime utilities in `composabilityCalls.ts` for handling input and output parameters.
- Created tests for composable transactions in `buildComposable.test.ts`.

> The following files were skipped due to too many changes: `src/sdk/modules/utils/runtimeAbiEncoding.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->