### PR TITLE
chore: fix initCode

### DIFF
--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -1,4 +1,4 @@
-import type { Address, Hex, OneOf } from "viem"
+import { type Address, type Hex, type OneOf, concatHex } from "viem"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account/utils/getMultichainContract"
 import { resolveInstructions } from "../../../account/utils/resolveInstructions"
@@ -342,7 +342,7 @@ export const getQuote = async (
           : deployment.encodeExecute(userOp.calls[0]),
         deployment.getNonce(),
         deployment.isDeployed(),
-        deployment.getInitCode(),
+        deployment.getFactoryArgs(),
         deployment.address,
         userOp.calls
           .map((uo) => uo?.gasLimit ?? LARGE_DEFAULT_GAS_LIMIT)
@@ -358,20 +358,26 @@ export const getQuote = async (
       callData,
       nonce_,
       isAccountDeployed,
-      initCode,
+      factoryArgs,
       sender,
       callGasLimit,
       chainId
-    ]) => ({
-      lowerBoundTimestamp: lowerBoundTimestamp_,
-      upperBoundTimestamp: upperBoundTimestamp_,
-      sender,
-      callData,
-      callGasLimit,
-      nonce: nonce_.toString(),
-      chainId,
-      ...(!isAccountDeployed && initCode ? { initCode } : {})
-    })
+    ]) => {
+      const initCode =
+        factoryArgs.factory && factoryArgs.factoryData
+          ? concatHex([factoryArgs.factory, factoryArgs.factoryData])
+          : undefined
+      return {
+        lowerBoundTimestamp: lowerBoundTimestamp_,
+        upperBoundTimestamp: upperBoundTimestamp_,
+        sender,
+        callData,
+        callGasLimit,
+        nonce: nonce_.toString(),
+        chainId,
+        ...(!isAccountDeployed && initCode ? { initCode } : {})
+      }
+    }
   )
 
   const [nonce, isAccountDeployed, initCode] = await Promise.all([


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on restructuring and enhancing the modular SDK for smart accounts, introducing new utilities, improving error handling, and updating module configurations for better flexibility and type safety.

### Detailed summary
- Deleted numerous unused files and tests.
- Added `toDefaultModule`, `toOwnableModule`, and related utilities.
- Updated module initialization structure for universal support.
- Enhanced error handling in various modules.
- Renamed functions for clarity.
- Improved type safety in module configurations.
- Introduced new test cases for updated functionalities.
- Updated `package.json` and `CHANGELOG.md` for versioning.

> The following files were skipped due to too many changes: `CHANGELOG.md`, `README.md`, `src/sdk/clients/decorators/smartAccount/debugUserOperation.ts`, `src/sdk/clients/decorators/erc7579/uninstallFallback.ts`, `src/sdk/modules/validators/smartSessions/decorators/index.ts`, `src/sdk/clients/decorators/erc7579/uninstallModule.ts`, `src/sdk/account/decorators/instructions/buildMultichainInstructions.ts`, `src/sdk/account/toNexusAccount.test.ts`, `src/sdk/clients/decorators/erc7579/getFallbackBySelector.ts`, `src/sdk/modules/validators/toValidator.ts`, `src/sdk/clients/decorators/smartAccount/upgradeSmartAccount.ts`, `src/sdk/modules/ownableValidator/decorators/addOwner.ts`, `src/sdk/modules/ownableValidator/decorators/removeOwner.ts`, `src/sdk/account/decorators/instructions/buildApprove.ts`, `src/sdk/account/decorators/instructions/buildTransferFrom.ts`, `src/sdk/account/decorators/instructions/buildTransfer.ts`, `src/sdk/account/utils/getVersion.ts`, `src/sdk/clients/createMeeClient.ts`, `src/sdk/modules/validators/ownable/toOwnableModule.test.ts`, `src/sdk/clients/decorators/erc7579/getInstalledExecutors.ts`, `src/sdk/clients/decorators/erc7579/supportsModule.ts`, `src/sdk/modules/smartSessionsValidator/Helpers.ts`, `src/sdk/core.test.ts`, `src/sdk/clients/decorators/erc7579/supportsExecutionMode.ts`, `src/sdk/clients/decorators/mee/waitForSupertransactionReceipt.ts`, `src/test/__contracts/abi/ComposabilityRuntimeTransferAbi.ts`, `src/sdk/clients/decorators/erc7579/isModuleInstalled.ts`, `src/sdk/account/utils/toInstallData.test.ts`, `src/sdk/clients/createBicoPaymasterClient.test.ts`, `src/sdk/account/decorators/instructions/buildWithdrawal.ts`, `src/sdk/modules/utils/Types.ts`, `src/sdk/modules/validators/default/toDefaultModule.test.ts`, `src/sdk/clients/createMeeClient.test.ts`, `src/sdk/clients/decorators/erc7579/erc7579.decorators.test.ts`, `src/sdk/clients/decorators/erc7579/getInstalledValidators.ts`, `src/sdk/clients/decorators/erc7579/index.ts`, `src/sdk/clients/createBundlerClient.test.ts`, `src/sdk/modules/ownableValidator/decorators/index.ts`, `src/sdk/account/decorators/build.ts`, `src/sdk/modules/validators/smartSessions/decorators/usePermission.ts`, `src/sdk/account/utils/fromBundlerClient.test.ts`, `src/sdk/account/utils/fromBundlerClient.ts`, `src/sdk/account/decorators/getNexusAddress.test.ts`, `src/sdk/account/toNexusAccount.addresses.test.ts`, `src/sdk/clients/decorators/mee/getQuote.ts`, `src/sdk/constants/index.ts`, `src/sdk/clients/decorators/erc7579/installModule.ts`, `src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts`, `src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts`, `src/sdk/account/decorators/instructions/buildMultiChainInstructions.test.ts`, `src/sdk/account/decorators/getNexusAddress.ts`, `src/sdk/account/utils/parseTransactionStatus.ts`, `src/sdk/constants/abi/ComposabilityAbi.ts`, `src/sdk/clients/decorators/mee/getSupertransactionReceipt.ts`, `src/sdk/account/decorators/instructions/buildComposable.ts`, `src/sdk/account/decorators/getFactoryData.ts`, `src/sdk/modules/utils/composabilityCalls.ts`, `src/test/playground.test.ts`, `src/sdk/account/utils/parseTransactionStatus.test.ts`, `scripts/fund:nexus.ts`, `src/sdk/account/decorators/instructions/buildComposable.test.ts`, `src/sdk/account/toNexusAccount.ts`, `src/sdk/modules/utils/runtimeAbiEncoding.ts`, `src/sdk/constants/abi/NexusBootstrapAbi.ts`, `src/sdk/account/utils/parseErrorMessage.test.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->