### PR TITLE
feat: typos in code comments and variable names

### DIFF
--- a/src/sdk/account/decorators/instructions/buildComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.ts
@@ -37,7 +37,7 @@ import type { BaseInstructionsParams } from "../build"
 export type BuildComposableParameters = {
   to: Address
   functionName: string
-  args: Array<AnyData> // This is being a generic function, if we add generic type, it is affecting previous parent function whihc can be handled later
+  args: Array<AnyData> // This is being a generic function, if we add generic type, it is affecting previous parent function which can be handled later
   abi: Abi
   chainId: number
   gasLimit?: bigint

--- a/src/sdk/clients/createBicoBundlerClient.ts
+++ b/src/sdk/clients/createBicoBundlerClient.ts
@@ -133,7 +133,7 @@ export const createBicoBundlerClient = (
     : bundlerUrl
       ? http(bundlerUrl)
       : http(
-          // @ts-ignore: Type saftey provided by the if statement above
+          // @ts-ignore: Type safety provided by the if statement above
           `https://bundler.biconomy.io/api/v3/${chain?.id}/${
             apiKey ?? "nJPK7B3ru.dd7f7861-190d-41bd-af80-6877f74b8f14"
           }`

--- a/src/sdk/modules/utils/runtimeAbiEncoding.ts
+++ b/src/sdk/modules/utils/runtimeAbiEncoding.ts
@@ -232,7 +232,7 @@ const encodeArray = <const param extends AbiParameter>(
 
     // If the main array itself dynamic and has a atleast one element, the encoding will be
     // length + list of elements appended one after other based on the internal data type encoding
-    // If it is a emtpy dynamic arrray ? zero length is added as encoding
+    // If it is a empty dynamic arrray ? zero length is added as encoding
     if (dynamic) {
       const length = numberToHex(preparedParams.length, { size: 32 })
       return {


### PR DESCRIPTION

This PR fixes three typos across the codebase:
- Corrects "whihc" to "which" in buildComposable.ts
- Corrects "saftey" to "safety" in createBicoBundlerClient.ts
- Corrects "emty" to "empty" in runtimeAbiEncoding.ts

These changes improve code readability and maintain consistent spelling throughout the project.


<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on correcting typos in comments throughout the codebase, enhancing clarity without altering functionality.

### Detailed summary
- Fixed typo in comment at `src/sdk/clients/createBicoBundlerClient.ts`: changed "saftey" to "safety".
- Fixed typo in comment at `src/sdk/account/decorators/instructions/buildComposable.ts`: changed "whihc" to "which".
- Fixed typo in comment at `src/sdk/modules/utils/runtimeAbiEncoding.ts`: changed "emtpy" to "empty".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->