### PR TITLE
feat: exclude gas fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/abstractjs
 
+## 1.0.4
+
+### Patch Changes
+
+- Added a useMaxAvailableAmount to trigger
+
 ## 1.0.3
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/abstractjs",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Biconomy",
   "repository": "github:bcnmy/abstractjs",
   "main": "./dist/_cjs/index.js",

--- a/src/sdk/account/decorators/instructions/buildWithdrawal.ts
+++ b/src/sdk/account/decorators/instructions/buildWithdrawal.ts
@@ -138,19 +138,27 @@ export const buildWithdrawal = async (
       }
 
       triggerCalls = await buildComposableCall(baseParams, composableCallParams)
-    } else {
-      triggerCalls = [
+
+      return [
+        ...currentInstructions,
         {
-          to: tokenAddress,
-          data: encodeFunctionData({
-            abi,
-            functionName: functionSig,
-            args: args as [`0x${string}`, bigint]
-          }),
-          ...(gasLimit ? { gasLimit } : {})
+          calls: triggerCalls,
+          chainId,
+          isComposable: true
         }
-      ] as AbstractCall[]
+      ]
     }
+    triggerCalls = [
+      {
+        to: tokenAddress,
+        data: encodeFunctionData({
+          abi,
+          functionName: functionSig,
+          args: args as [`0x${string}`, bigint]
+        }),
+        ...(gasLimit ? { gasLimit } : {})
+      }
+    ] as AbstractCall[]
   }
 
   return [

--- a/src/sdk/clients/decorators/mee/getGasToken.test.ts
+++ b/src/sdk/clients/decorators/mee/getGasToken.test.ts
@@ -22,7 +22,7 @@ describe("mee.getGasToken", () => {
 
   beforeAll(async () => {
     network = await toNetwork("MAINNET_FROM_ENV_VARS")
-      ;[[paymentChain, targetChain], transports] = getTestChainConfig(network)
+    ;[[paymentChain, targetChain], transports] = getTestChainConfig(network)
 
     eoaAccount = network.account!
     feeToken = {

--- a/src/sdk/clients/decorators/mee/getInfo.test.ts
+++ b/src/sdk/clients/decorators/mee/getInfo.test.ts
@@ -28,7 +28,7 @@ describe("mee.getInfo", () => {
 
   beforeAll(async () => {
     network = await toNetwork("MAINNET_FROM_ENV_VARS")
-      ;[[paymentChain, targetChain], transports] = getTestChainConfig(network)
+    ;[[paymentChain, targetChain], transports] = getTestChainConfig(network)
 
     eoaAccount = network.account!
     feeToken = {

--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -109,9 +109,12 @@ export const getOnChainQuote = async (
     instructions: batchedInstructions,
     ...rest
   })
+
   const trigger_ = {
     ...trigger,
-    amount: BigInt(trigger.amount) + BigInt(quote.paymentInfo.tokenWeiAmount)
+    amount:
+      BigInt(trigger.amount) +
+      BigInt(trigger.excludeGasFees ? 0n : quote.paymentInfo.tokenWeiAmount)
   }
 
   return { quote, trigger: trigger_ }

--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -112,9 +112,9 @@ export const getOnChainQuote = async (
 
   const trigger_ = {
     ...trigger,
-    amount:
-      BigInt(trigger.amount) +
-      BigInt(trigger.excludeGasFees ? 0n : quote.paymentInfo.tokenWeiAmount)
+    amount: trigger.useMaxAvailableAmount
+      ? BigInt(trigger.amount)
+      : BigInt(trigger.amount) + BigInt(quote.paymentInfo.tokenWeiAmount)
   }
 
   return { quote, trigger: trigger_ }

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -91,6 +91,9 @@ export const getPermitQuote = async (
     data: { ...trigger, recipient, sender }
   }
 
+  // The trigger transfer is the first instruction in the array.
+  // It draws funds from the eoa to the nexus account with a transferFrom call.
+  // If the instructions are composable, we build the composable transaction
   const triggerTransfer = await (isComposable
     ? account_.buildComposable(params)
     : account_.build(params))
@@ -107,11 +110,12 @@ export const getPermitQuote = async (
     ...rest
   })
 
+  // This trigger should have an amount that is the amount user wishes to spend, plus the gas fees
   const trigger_ = {
     ...trigger,
-    amount:
-      BigInt(trigger.amount) +
-      BigInt(trigger.excludeGasFees ? 0n : quote.paymentInfo.tokenWeiAmount)
+    amount: trigger.useMaxAvailableAmount
+      ? BigInt(trigger.amount)
+      : BigInt(trigger.amount) + BigInt(quote.paymentInfo.tokenWeiAmount)
   }
 
   return { quote, trigger: trigger_ }

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -109,7 +109,9 @@ export const getPermitQuote = async (
 
   const trigger_ = {
     ...trigger,
-    amount: BigInt(trigger.amount) + BigInt(quote.paymentInfo.tokenWeiAmount)
+    amount:
+      BigInt(trigger.amount) +
+      BigInt(trigger.excludeGasFees ? 0n : quote.paymentInfo.tokenWeiAmount)
   }
 
   return { quote, trigger: trigger_ }

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -32,6 +32,10 @@ export type Trigger = {
    * @example 1000000n // 1 USDC (6 decimals)
    */
   amount: bigint
+  /**
+   * Whether to exclude the gas amount from the total amount. Default is false.
+   */
+  excludeGasFees?: boolean
 }
 
 /**

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -33,9 +33,13 @@ export type Trigger = {
    */
   amount: bigint
   /**
-   * Whether to exclude the gas amount from the total amount. Default is false.
+   * Whether to use the maximum available token balance, automatically accounting for gas fees.
+   * When true, the specified amount will be ignored and the maximum available balance
+   * after deducting gas fees will be used. Should be used in combination with runtimeERC20BalanceOf
+   * in the instruction which uses the permitted token, so that the amount is the maximum available amount
+   * after deducting gas fees. Default is false.
    */
-  excludeGasFees?: boolean
+  useMaxAvailableAmount?: boolean
 }
 
 /**

--- a/src/sdk/modules/validators/smartSessions/decorators/usePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/usePermission.ts
@@ -100,6 +100,7 @@ export async function usePermission<
   sessionDetails.signature = await signer.signMessage({
     message: { raw: userOpHashToSign }
   })
+
   userOperation.signature = encodeSmartSessionSignature(sessionDetails)
   return await sendUserOperation(nexusClient, userOperation)
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new feature to utilize the maximum available token balance when making transactions, accounting for gas fees. It updates the version of the package and modifies several functions and tests to incorporate this feature.

### Detailed summary
- Updated `CHANGELOG.md` to include version `1.0.4` and a new feature description.
- Changed version in `package.json` from `1.0.3` to `1.0.4`.
- Added `useMaxAvailableAmount` option in `src/sdk/clients/decorators/mee/getOnChainQuote.ts` and `src/sdk/clients/decorators/mee/signPermitQuote.ts`.
- Modified trigger calculations in `getOnChainQuote.ts` and `getPermitQuote.ts` to consider `useMaxAvailableAmount`.
- Updated `buildWithdrawal.ts` to return composable instructions correctly.
- Added tests to `getPermitQuote.test.ts` for scenarios with and without `useMaxAvailableAmount`, verifying gas fee handling and total amounts.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->