### PR TITLE
chore: signTransaction fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/abstractjs
 
+## 1.0.6
+
+### Patch Changes
+
+- signTransaction signer fix
+
 ## 1.0.5
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/abstractjs",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "author": "Biconomy",
   "repository": "github:bcnmy/abstractjs",
   "main": "./dist/_cjs/index.js",

--- a/src/sdk/account/utils/toSigner.ts
+++ b/src/sdk/account/utils/toSigner.ts
@@ -12,7 +12,7 @@ import {
   getAddress,
   hexToBytes
 } from "viem"
-import { toAccount } from "viem/accounts"
+import { signTransaction, toAccount } from "viem/accounts"
 
 import { signTypedData } from "viem/actions"
 import { getAction } from "viem/utils"
@@ -141,8 +141,12 @@ export async function toSigner<
         "signTypedData"
       )(typedData as AnyData)
     },
-    async signTransaction(_) {
-      throw new Error("Smart account signer doesn't need to sign transactions")
+    async signTransaction(transaction) {
+      return getAction(
+        walletClient,
+        signTransaction,
+        "signTransaction"
+      )(transaction as AnyData)
     }
   })
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the `@biconomy/abstractjs` package from version `1.0.5` to `1.0.6`. It includes a fix for the `signTransaction` function, which now properly handles transaction signing instead of throwing an error.

### Detailed summary
- Updated version in `package.json` from `1.0.5` to `1.0.6`.
- Added `signTransaction` import from `viem/accounts` in `src/sdk/account/utils/toSigner.ts`.
- Modified the `signTransaction` function to return the result of calling `getAction` instead of throwing an error.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->