### PR TITLE
chore: sets gas limit for fusion quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/abstractjs
 
+## 1.0.9
+
+### Patch Changes
+
+- Fusion gasLimit
+
 ## 1.0.8
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/abstractjs",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "author": "Biconomy",
   "repository": "github:bcnmy/abstractjs",
   "main": "./dist/_cjs/index.js",

--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -110,7 +110,8 @@ export const getOnChainQuote = async (
       chainId: trigger.chainId,
       amount: transferFromAmount,
       recipient,
-      sender
+      sender,
+      gasLimit: 50_000n
     }
   }
 

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -153,16 +153,11 @@ describe("mee.getPermitQuote", () => {
       transport: transports[0]
     })
 
-    const totalBalance = await getBalance(
-      client,
-      eoaAccount.address,
-      tokenAddress
-    )
-
+    const totalAmount = 6000n
     const trigger: Trigger = {
       chainId: paymentChain.id,
       tokenAddress,
-      amount: 6000n,
+      amount: totalAmount,
       includeFee: true
     }
 
@@ -189,7 +184,7 @@ describe("mee.getPermitQuote", () => {
     expect(fusionQuote.trigger).toBeDefined()
 
     // The final amount should be the total balance
-    expect(fusionQuote.trigger.amount).toBe(totalBalance)
+    expect(fusionQuote.trigger.amount).toBe(totalAmount)
 
     // Verify that the amount is usable (not negative)
     expect(fusionQuote.trigger.amount).toBeGreaterThan(0n)

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -106,7 +106,8 @@ export const getPermitQuote = async (
       chainId: trigger.chainId,
       amount: transferFromAmount,
       recipient,
-      sender
+      sender,
+      gasLimit: 50_000n
     }
   }
 


### PR DESCRIPTION
Sets a fixed gas limit for generating on-chain and permit quotes for fusion swaps. This ensures sufficient gas is available for the transactions.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the version of the package, adding a `gasLimit` parameter to certain functions, and adjusting test cases to reflect changes in the amount calculation.

### Detailed summary
- Updated `CHANGELOG.md` to version `1.0.9` with a patch change note.
- Added `gasLimit: 50_000n` to `sender` in `getPermitQuote.ts` and `getOnChainQuote.ts`.
- Updated `package.json` version from `1.0.8` to `1.0.9`.
- Changed variable `totalBalance` to `totalAmount` in `getPermitQuote.test.ts`.
- Updated assertion in tests to compare `fusionQuote.trigger.amount` with `totalAmount`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->