### PR TITLE
fix: fixed the gas limit override issue

### DIFF
--- a/src/sdk/account/decorators/instructions/buildApprove.ts
+++ b/src/sdk/account/decorators/instructions/buildApprove.ts
@@ -109,7 +109,8 @@ export const buildApprove = async (
       functionName: functionSig,
       args: args as unknown as Array<AnyData>,
       abi,
-      chainId
+      chainId,
+      ...(gasLimit ? { gasLimit } : {})
     }
 
     triggerCalls = await buildComposableCall(

--- a/src/sdk/account/decorators/instructions/buildTransfer.ts
+++ b/src/sdk/account/decorators/instructions/buildTransfer.ts
@@ -109,7 +109,8 @@ export const buildTransfer = async (
       functionName: functionSig,
       args: args as unknown as Array<AnyData>,
       abi,
-      chainId
+      chainId,
+      ...(gasLimit ? { gasLimit } : {})
     }
 
     triggerCalls = await buildComposableCall(

--- a/src/sdk/account/decorators/instructions/buildTransferFrom.ts
+++ b/src/sdk/account/decorators/instructions/buildTransferFrom.ts
@@ -117,7 +117,8 @@ export const buildTransferFrom = async (
       functionName: functionSig,
       args: args as unknown as Array<AnyData>,
       abi,
-      chainId
+      chainId,
+      ...(gasLimit ? { gasLimit } : {})
     }
 
     triggerCalls = await buildComposableCall(

--- a/src/sdk/account/decorators/instructions/buildWithdrawal.ts
+++ b/src/sdk/account/decorators/instructions/buildWithdrawal.ts
@@ -135,7 +135,8 @@ export const buildWithdrawal = async (
         functionName: functionSig,
         args: args as unknown as Array<AnyData>,
         abi,
-        chainId
+        chainId,
+        ...(gasLimit ? { gasLimit } : {})
       }
 
       triggerCalls = await buildComposableCall(


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on adding the `chainId` and optional `gasLimit` parameters to several functions in the `src/sdk/account/decorators/instructions` directory, enhancing the ability to specify transaction details when building composable calls.

### Detailed summary
- In `buildApprove.ts`, added `chainId` and conditional `gasLimit`.
- In `buildTransfer.ts`, added `chainId` and conditional `gasLimit`.
- In `buildWithdrawal.ts`, added `chainId` and conditional `gasLimit`.
- In `buildTransferFrom.ts`, added `chainId` and conditional `gasLimit`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->