### PR TITLE
feat: explorer catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @biconomy/abstractjs
 
+## 1.0.12
+
+### Patch Changes
+
+- add explorer catch
+
 ## 1.0.11
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@biconomy/abstractjs",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "author": "Biconomy",
   "repository": "github:bcnmy/abstractjs",
   "main": "./dist/_cjs/index.js",

--- a/src/sdk/account/utils/explorer.ts
+++ b/src/sdk/account/utils/explorer.ts
@@ -29,12 +29,17 @@ export const getExplorerTxLink = (
   hash: Hex,
   chain_: Chain | number | string
 ): Url => {
-  const chain: Chain =
-    typeof chain_ === "number" || typeof chain_ === "string"
-      ? getChain(Number(chain_))
-      : chain_
+  try {
+    const chain: Chain =
+      typeof chain_ === "number" || typeof chain_ === "string"
+        ? getChain(Number(chain_))
+        : chain_
 
-  return `${chain.blockExplorers?.default.url}/tx/${hash}` as Url
+    return `${chain.blockExplorers?.default.url}/tx/${hash}` as Url
+  } catch (error) {
+    console.error(error)
+    return `https://v2.jiffyscan.xyz/tx/${hash}` as Url
+  }
 }
 
 /**


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new version `1.0.12` of the package `@biconomy/abstractjs`, updating the version in `package.json` and enhancing error handling in the `explorer.ts` file.

### Detailed summary
- Updated version in `package.json` from `1.0.11` to `1.0.12`.
- Added a try-catch block in `src/sdk/account/utils/explorer.ts` to handle potential errors when fetching the chain.
- In case of an error, it logs the error and returns a fallback URL.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->