### PR TITLE
feat: multichain support for 7702

### DIFF
--- a/src/sdk/account/toMultiChainNexusAccount.ts
+++ b/src/sdk/account/toMultiChainNexusAccount.ts
@@ -320,8 +320,8 @@ export async function toMultichainNexusAccount(
     waitForTransactionReceiptsDecorator({ ...parameters, account: baseAccount })
 
   // The specific deployment doesn't matter here because chainId = 0
-  const toDelegation = async () =>
-    await deployments[0].toDelegation({ multiChain: true })
+  const toDelegation = async (params?: Pick<DelegationParams, "multiChain">) =>
+    await deployments[0].toDelegation({ multiChain: !!params?.multiChain })
 
   return {
     ...baseAccount,

--- a/src/sdk/account/toNexusAccount.ts
+++ b/src/sdk/account/toNexusAccount.ts
@@ -633,7 +633,7 @@ export const toNexusAccount = async (
     params?: DelegationParams
   ): Promise<MeeAuthorization> {
     const {
-      authorization: authorization_,
+      authorization: manualAuthorization,
       multiChain,
       delegatedContract
     } = params || {}
@@ -641,13 +641,19 @@ export const toNexusAccount = async (
     const contractAddress = delegatedContract || implementationAddress
 
     const authorization: SignAuthorizationReturnType =
-      authorization_ ||
+      manualAuthorization ||
       (await walletClient.signAuthorization({
         contractAddress
       }))
 
+    const chainId = manualAuthorization
+      ? manualAuthorization.chainId
+      : multiChain
+        ? 0
+        : chain.id
+
     const eip7702Auth: MeeAuthorization = {
-      chainId: `0x${(multiChain ? 0 : chain.id).toString(16)}` as Hex,
+      chainId: `0x${(chainId).toString(16)}` as Hex,
       address: authorization.address as Hex,
       nonce: `0x${authorization.nonce.toString(16)}` as Hex,
       r: authorization.r as Hex,

--- a/src/sdk/account/utils/parseErrorMessage.ts
+++ b/src/sdk/account/utils/parseErrorMessage.ts
@@ -39,8 +39,15 @@ const extractRevertError = (message: string): string | null => {
 
 const handleErrorsArray = (errors: AnyData[]): string => {
   // Handle array of error objects with msg and path properties
-  if (typeof errors[0] === "object" && errors[0].msg) {
-    return errors.map(({ msg, path }: AnyData) => `${path}: ${msg}`).join("\n")
+  if (typeof errors[0] === "object" && (errors[0].msg || errors[0].message)) {
+    return errors
+      .map((error: AnyData) => {
+        const message = error.message || error.msg
+        return error.path && error.path !== ""
+          ? `${error.path}: ${message}`
+          : message
+      })
+      .join("\n")
   }
 
   const errorMessage = String(errors[0])

--- a/src/sdk/clients/createMeeClient.test.ts
+++ b/src/sdk/clients/createMeeClient.test.ts
@@ -14,7 +14,7 @@ import {
   generatePrivateKey,
   privateKeyToAccount
 } from "viem/accounts"
-import { gnosisChiado, sepolia } from "viem/chains"
+import { baseSepolia, gnosisChiado } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import { getTestChainConfig, toNetwork } from "../../test/testSetup"
 import { type NetworkConfig, getBalance } from "../../test/testUtils"
@@ -307,13 +307,12 @@ describe("mee.createMeeClient.delegated", async () => {
   let meeClient: MeeClient
 
   const eoaAccount = privateKeyToAccount(`0x${process.env.PRIVATE_KEY}`)
-  const rpc = `https://sepolia.infura.io/v3/${process.env.INFURA_KEY}`
 
   beforeAll(async () => {
     mcNexus = await toMultichainNexusAccount({
-      chains: [sepolia],
+      chains: [baseSepolia],
       signer: eoaAccount,
-      transports: [http(rpc)],
+      transports: [http()],
       accountAddress: eoaAccount.address
     })
 
@@ -331,9 +330,9 @@ describe("mee.createMeeClient.delegated", async () => {
 
   // This test has been fixed and tested multiple times. This is being skipped because of high gas cost.
   // Funds are draining quickly on test wallets
-  test.skip("should get a quote for a delegated account", async () => {
+  test("should get a quote for a delegated account", async () => {
     const balanceBefore = await getBalance(
-      mcNexus.deploymentOn(sepolia.id, true).publicClient,
+      mcNexus.deploymentOn(baseSepolia.id, true).publicClient,
       zeroAddress
     )
     const quote = await meeClient.getQuote({
@@ -346,12 +345,12 @@ describe("mee.createMeeClient.delegated", async () => {
               value: 1n
             }
           ],
-          chainId: sepolia.id
+          chainId: baseSepolia.id
         }
       ],
       feeToken: {
-        address: testnetMcUSDC.addressOn(sepolia.id), // usdc
-        chainId: sepolia.id
+        address: zeroAddress, // eth
+        chainId: baseSepolia.id
       }
     })
     expect(quote).toBeDefined()
@@ -367,7 +366,7 @@ describe("mee.createMeeClient.delegated", async () => {
     expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
 
     const balanceAfter = await getBalance(
-      mcNexus.deploymentOn(sepolia.id, true).publicClient,
+      mcNexus.deploymentOn(baseSepolia.id, true).publicClient,
       zeroAddress
     )
     expect(balanceAfter).toBeGreaterThan(balanceBefore)
@@ -385,7 +384,7 @@ describe("mee.createMeeClient.delegated", async () => {
 
   test("should override the authorization for delegation", async () => {
     const dummyAuth: SignAuthorizationReturnType = {
-      chainId: sepolia.id,
+      chainId: baseSepolia.id,
       address: zeroAddress,
       nonce: 1,
       r: "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -405,12 +404,12 @@ describe("mee.createMeeClient.delegated", async () => {
               value: 1n
             }
           ],
-          chainId: sepolia.id
+          chainId: baseSepolia.id
         }
       ],
       feeToken: {
-        address: testnetMcUSDC.addressOn(sepolia.id), // usdc
-        chainId: sepolia.id
+        address: zeroAddress, // eth
+        chainId: baseSepolia.id
       }
     })
 
@@ -436,5 +435,86 @@ describe("mee.createMeeClient.delegated", async () => {
         toHex(dummyAuth.yParity || 1)
       )
     }
+  })
+
+  test("Authorization should have a targetted chain id by default", async () => {
+    const quote = await meeClient.getQuote({
+      delegate: true,
+      instructions: [
+        {
+          calls: [
+            {
+              to: zeroAddress,
+              value: 1n
+            }
+          ],
+          chainId: baseSepolia.id
+        }
+      ],
+      feeToken: {
+        address: zeroAddress, // eth
+        chainId: baseSepolia.id
+      }
+    })
+
+    expect(quote).toBeDefined()
+
+    /**
+     * These are only expected the first time a user authorizes a delegate.
+     * If the user has already authorized a delegate, the quote will not contain this information.
+     */
+
+    if (quote.paymentInfo.eip7702Auth) {
+      expect(quote.paymentInfo.eip7702Auth.chainId).to.equal(
+        toHex(baseSepolia.id)
+      )
+    }
+  })
+
+  test("Authorization should have a zero chain id when multichain option is specified", async () => {
+    const quote = await meeClient.getQuote({
+      delegate: true,
+      multichainAuthorization: true,
+      instructions: [
+        {
+          calls: [
+            {
+              to: zeroAddress,
+              value: 1n
+            }
+          ],
+          chainId: baseSepolia.id
+        }
+      ],
+      feeToken: {
+        address: zeroAddress, // eth
+        chainId: baseSepolia.id
+      }
+    })
+
+    expect(quote).toBeDefined()
+
+    /**
+     * These are only expected the first time a user authorizes a delegate.
+     * If the user has already authorized a delegate, the quote will not contain this information.
+     */
+
+    if (quote.paymentInfo.eip7702Auth) {
+      expect(quote.paymentInfo.eip7702Auth.chainId).to.equal(toHex(0))
+    }
+  })
+
+  test("toDelegation should have targetted chain id by default", async () => {
+    const delegation = await mcNexus.toDelegation()
+
+    expect(delegation).toBeDefined()
+    expect(delegation.chainId).to.equal(toHex(baseSepolia.id))
+  })
+
+  test("toDelegation should have zero chain id when multichain option is specified ", async () => {
+    const delegation = await mcNexus.toDelegation({ multiChain: true })
+
+    expect(delegation).toBeDefined()
+    expect(delegation.chainId).to.equal(toHex(0))
   })
 })

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -181,6 +181,16 @@ export type GetQuoteParams = SupertransactionLike & {
          */
         delegate: true
         /**
+         * multichainAuthorization flag enables multichain authorization with chainId 0.
+         */
+        multichainAuthorization: true
+      }
+    | {
+        /**
+         * Whether to delegate the transaction to the account
+         */
+        delegate: true
+        /**
          * The authorization data for the transaction. Should be a valid Viem compatible Authorization param on chainId 0
          * If not provided, the account will be delegated to the implementation address, using chainId 0.
          */
@@ -375,7 +385,8 @@ export const getQuote = async (
     upperBoundTimestamp: upperBoundTimestamp_ = lowerBoundTimestamp_ +
       USEROP_MIN_EXEC_WINDOW_DURATION,
     delegate = false,
-    authorization
+    authorization,
+    multichainAuthorization
   } = parameters
 
   const resolvedInstructions = await resolveInstructions(instructions)
@@ -443,7 +454,10 @@ export const getQuote = async (
     ? undefined
     : delegate
       ? {
-          eip7702Auth: await validPaymentAccount.toDelegation({ authorization })
+          eip7702Auth: await validPaymentAccount.toDelegation({
+            authorization,
+            multiChain: !!multichainAuthorization
+          })
         }
       : { initCode }
 
@@ -477,7 +491,10 @@ export const getQuote = async (
           hasProcessedInitData.push(chainId)
           initDataOrUndefined = delegate
             ? {
-                eip7702Auth: await nexusAccount.toDelegation({ authorization })
+                eip7702Auth: await nexusAccount.toDelegation({
+                  authorization,
+                  multiChain: !!multichainAuthorization
+                })
               }
             : { initCode }
         }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing multi-chain support and error handling in the SDK, specifically in the `toDelegation` functionality and error message parsing. It introduces new parameters and refines existing methods to accommodate multi-chain operations.

### Detailed summary
- Updated `toDelegation` in `toMultiChainNexusAccount.ts` to accept optional parameters for multi-chain.
- Enhanced error handling in `parseErrorMessage.ts` to accommodate both `msg` and `message` properties.
- Modified `toNexusAccount` to determine `chainId` based on authorization.
- Updated `getQuote` in `getQuote.ts` to handle multi-chain authorization.
- Changed test configurations in `createMeeClient.test.ts` to use `baseSepolia` instead of `sepolia`.
- Added tests to validate chain ID behavior for delegation and multi-chain scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->