### PR TITLE
feat: custom gas limit for trigger and payment

### DIFF
--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -1217,9 +1217,7 @@ describe.runIf(runPaidTests)("mee.buildComposable", () => {
     console.log({ explorerLinks, hash })
   })
 
-  // This take long time to complete and also has conflict while running with others.
-  // Works when individually executed. Will skip this test
-  it.skip("should composable cleanup execute when main userops fails", async () => {
+  it("should composable cleanup execute when main userops fails", async () => {
     const amountToSupply = parseUnits("0.1", 6)
     const amountToTransfer = parseUnits("1", 6)
 

--- a/src/sdk/clients/createHttpClient.ts
+++ b/src/sdk/clients/createHttpClient.ts
@@ -1,4 +1,4 @@
-import type { Prettify } from "viem"
+import { stringify, type Prettify } from "viem"
 import { parseErrorMessage } from "../account/utils/parseErrorMessage"
 import type { AnyData } from "../modules"
 
@@ -63,7 +63,7 @@ export const createHttpClient = (url: Url, apiKey?: string): HttpClient => {
         "Content-Type": "application/json",
         ...(apiKey ? { "x-api-key": apiKey } : {})
       },
-      ...(body ? { body: JSON.stringify(body) } : {})
+      ...(body ? { body: stringify(body) } : {})
     })
 
     const json = (await result.json()) as AnyData

--- a/src/sdk/clients/createHttpClient.ts
+++ b/src/sdk/clients/createHttpClient.ts
@@ -1,4 +1,4 @@
-import { stringify, type Prettify } from "viem"
+import { type Prettify, stringify } from "viem"
 import { parseErrorMessage } from "../account/utils/parseErrorMessage"
 import type { AnyData } from "../modules"
 

--- a/src/sdk/clients/decorators/erc7579/index.ts
+++ b/src/sdk/clients/decorators/erc7579/index.ts
@@ -153,7 +153,7 @@ export function erc7579Actions() {
 }
 
 export type CallFn = (...args: AnyData[]) => Promise<Call[]>
-export type ReadFn = (...args: AnyData[]) => Promise<any>
+export type ReadFn = (...args: AnyData[]) => Promise<AnyData>
 export type CallDictionary = Record<string, CallFn>
 export type ReadDictionary = Record<string, ReadFn>
 

--- a/src/sdk/clients/decorators/mee/getGasToken.test.ts
+++ b/src/sdk/clients/decorators/mee/getGasToken.test.ts
@@ -50,20 +50,12 @@ describe("mee.getGasToken", () => {
   })
 
   test("should throw error for invalid chain id", async () => {
+    const chainId = Math.floor(Math.random() * 1000000)
     await expect(
       meeClient.getGasToken({
-        chainId: 999,
+        chainId,
         address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       })
-    ).rejects.toThrow("Gas token not found for chain 999")
-  })
-
-  test("should throw error for invalid chain id", async () => {
-    await expect(
-      meeClient.getGasToken({
-        chainId: 999,
-        address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-      })
-    ).rejects.toThrow("Gas token not found for chain 999")
+    ).rejects.toThrow(`Gas token not found for chain ${chainId}`)
   })
 })

--- a/src/sdk/clients/decorators/mee/getInfo.test.ts
+++ b/src/sdk/clients/decorators/mee/getInfo.test.ts
@@ -77,12 +77,13 @@ describe("mee.getInfo", () => {
   })
 
   test("should throw error for invalid chain id", async () => {
+    const chainId = Math.floor(Math.random() * 1000000)
     await expect(
       getGasToken(meeClient, {
-        chainId: 999,
+        chainId,
         address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       })
-    ).rejects.toThrow("Gas token not found for chain 999")
+    ).rejects.toThrow(`Gas token not found for chain ${chainId}`)
   })
 
   test("should return payment token and arbitrary token payment info for valid chain id and address", async () => {
@@ -127,11 +128,12 @@ describe("mee.getInfo", () => {
   })
 
   test("should throw error for invalid chain id", async () => {
+    const chainId = Math.floor(Math.random() * 1000000)
     await expect(
       getPaymentToken(meeClient, {
-        chainId: 999,
+        chainId,
         tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
       })
-    ).rejects.toThrow("Gas token not found for chain 999")
+    ).rejects.toThrow(`Gas token not found for chain ${chainId}`)
   })
 })

--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -82,6 +82,7 @@ export const getOnChainQuote = async (
     trigger,
     cleanUps,
     instructions,
+    gasLimit,
     ...rest
   } = parameters
 
@@ -132,7 +133,7 @@ export const getOnChainQuote = async (
     path: "quote-permit", // Use different endpoint for onchain quotes
     eoa: account_.signer.address,
     instructions: batchedInstructions,
-    gasLimit: triggerGasLimit,
+    gasLimit: gasLimit || triggerGasLimit,
     ...(cleanUps ? { cleanUps } : {}),
     ...rest
   })

--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -6,7 +6,7 @@ import {
   runtimeERC20AllowanceOf
 } from "../../../modules/utils/composabilityCalls"
 import type { BaseMeeClient } from "../../createMeeClient"
-import { type GetQuotePayload, getQuote } from "./getQuote"
+import { DEFAULT_GAS_LIMIT, type GetQuotePayload, getQuote } from "./getQuote"
 import type { GetQuoteParams } from "./getQuote"
 import type { Trigger } from "./signPermitQuote"
 
@@ -103,6 +103,10 @@ export const getOnChainQuote = async (
       })
     : trigger.amount
 
+  const triggerGasLimit = trigger.gasLimit
+    ? trigger.gasLimit
+    : DEFAULT_GAS_LIMIT
+
   const params: BuildInstructionTypes = {
     type: "transferFrom",
     data: {
@@ -111,7 +115,7 @@ export const getOnChainQuote = async (
       amount: transferFromAmount,
       recipient,
       sender,
-      gasLimit: 50_000n
+      gasLimit: triggerGasLimit
     }
   }
 
@@ -128,6 +132,7 @@ export const getOnChainQuote = async (
     path: "quote-permit", // Use different endpoint for onchain quotes
     eoa: account_.signer.address,
     instructions: batchedInstructions,
+    gasLimit: triggerGasLimit,
     ...(cleanUps ? { cleanUps } : {}),
     ...rest
   })
@@ -141,7 +146,8 @@ export const getOnChainQuote = async (
     trigger: {
       tokenAddress: trigger.tokenAddress,
       chainId: trigger.chainId,
-      amount
+      amount,
+      gasLimit: triggerGasLimit
     }
   }
 }

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -9,6 +9,7 @@ import {
 } from "viem"
 import { beforeAll, describe, expect, test } from "vitest"
 import {
+  DEFAULT_GAS_LIMIT,
   type FeeTokenInfo,
   type Instruction,
   type Trigger,
@@ -145,6 +146,73 @@ describe("mee.getPermitQuote", () => {
     expect(fusionQuote.quote).toBeDefined()
     expect(fusionQuote.trigger).toBeDefined()
     expect([3, 4].includes(fusionQuote.quote.userOps.length)).toBe(true) // 3 or 4 depending on if bridging is needed
+  })
+
+  test("should trigger have a default gas limit as 75K gas", async () => {
+    const trigger: Trigger = {
+      chainId: paymentChain.id,
+      tokenAddress,
+      amount: 1n
+    }
+
+    const transfer = mcNexus.build({
+      type: "transfer",
+      data: {
+        tokenAddress,
+        amount: 1n,
+        chainId: paymentChain.id,
+        recipient: eoaAccount.address
+      }
+    })
+
+    const fusionQuote = await getFusionQuote(meeClient, {
+      trigger,
+      instructions: [transfer],
+      feeToken
+    })
+
+    expect(fusionQuote).toBeDefined()
+    expect(fusionQuote.trigger).toBeDefined()
+    expect(fusionQuote.trigger.gasLimit).toBe(DEFAULT_GAS_LIMIT)
+
+    expect(fusionQuote.quote.paymentInfo.callGasLimit).toBe(
+      DEFAULT_GAS_LIMIT.toString()
+    )
+  })
+
+  test("should trigger have a custom gas limit", async () => {
+    const customGasLimit = 10_000n
+
+    const trigger: Trigger = {
+      chainId: paymentChain.id,
+      tokenAddress,
+      amount: 1n,
+      gasLimit: customGasLimit
+    }
+
+    const transfer = mcNexus.build({
+      type: "transfer",
+      data: {
+        tokenAddress,
+        amount: 1n,
+        chainId: paymentChain.id,
+        recipient: eoaAccount.address
+      }
+    })
+
+    const fusionQuote = await getFusionQuote(meeClient, {
+      trigger,
+      instructions: [transfer],
+      feeToken
+    })
+
+    expect(fusionQuote).toBeDefined()
+    expect(fusionQuote.trigger).toBeDefined()
+    expect(fusionQuote.trigger.gasLimit).toBe(customGasLimit)
+
+    expect(fusionQuote.quote.paymentInfo.callGasLimit).toBe(
+      customGasLimit.toString()
+    )
   })
 
   test("should reserve gas fees when using max available amount", async () => {

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -34,6 +34,7 @@ import {
   createMeeClient
 } from "../../createMeeClient"
 import getPermitQuote from "./getPermitQuote"
+import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 
 describe("mee.getPermitQuote", () => {
   let network: NetworkConfig
@@ -155,7 +156,7 @@ describe("mee.getPermitQuote", () => {
       amount: 1n
     }
 
-    const transfer = mcNexus.build({
+    const transfer = await mcNexus.build({
       type: "transfer",
       data: {
         tokenAddress,
@@ -178,10 +179,20 @@ describe("mee.getPermitQuote", () => {
     expect(fusionQuote.quote.paymentInfo.callGasLimit).toBe(
       DEFAULT_GAS_LIMIT.toString()
     )
+
+    const gasLimit = transfer[0].calls.reduce((acc, call) => {
+      const gas = call?.gasLimit || LARGE_DEFAULT_GAS_LIMIT
+      return gas + acc
+    }, 0n)
+
+    expect(fusionQuote.quote.userOps[1]).toBeDefined()
+    expect(fusionQuote.quote.userOps[1].userOp.callGasLimit).to.eq(
+      (DEFAULT_GAS_LIMIT + gasLimit).toString()
+    )
   })
 
   test("should trigger have a custom gas limit", async () => {
-    const customGasLimit = 10_000n
+    const customGasLimit = 100_000n
 
     const trigger: Trigger = {
       chainId: paymentChain.id,
@@ -190,7 +201,7 @@ describe("mee.getPermitQuote", () => {
       gasLimit: customGasLimit
     }
 
-    const transfer = mcNexus.build({
+    const transfer = await mcNexus.build({
       type: "transfer",
       data: {
         tokenAddress,
@@ -212,6 +223,16 @@ describe("mee.getPermitQuote", () => {
 
     expect(fusionQuote.quote.paymentInfo.callGasLimit).toBe(
       customGasLimit.toString()
+    )
+
+    const gasLimit = transfer[0].calls.reduce((acc, call) => {
+      const gas = call?.gasLimit || LARGE_DEFAULT_GAS_LIMIT
+      return gas + acc
+    }, 0n)
+
+    expect(fusionQuote.quote.userOps[1]).toBeDefined()
+    expect(fusionQuote.quote.userOps[1].userOp.callGasLimit).to.eq(
+      (customGasLimit + gasLimit).toString()
     )
   })
 

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -21,7 +21,7 @@ import {
   waitForSupertransactionReceipt
 } from "."
 import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
-import type { NetworkConfig } from "../../../../test/testUtils"
+import { getBalance, type NetworkConfig } from "../../../../test/testUtils"
 import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -20,7 +20,7 @@ import {
 } from "."
 import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
 import type { NetworkConfig } from "../../../../test/testUtils"
-import { getBalance } from "../../../../test/testUtils"
+import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { mcUSDC } from "../../../constants/tokens"
@@ -34,7 +34,6 @@ import {
   createMeeClient
 } from "../../createMeeClient"
 import getPermitQuote from "./getPermitQuote"
-import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 
 describe("mee.getPermitQuote", () => {
   let network: NetworkConfig

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -21,7 +21,7 @@ import {
   waitForSupertransactionReceipt
 } from "."
 import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
-import { getBalance, type NetworkConfig } from "../../../../test/testUtils"
+import { type NetworkConfig, getBalance } from "../../../../test/testUtils"
 import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -79,6 +79,7 @@ export const getPermitQuote = async (
     trigger,
     cleanUps,
     instructions,
+    gasLimit,
     ...rest
   } = parameters
 
@@ -128,7 +129,7 @@ export const getPermitQuote = async (
     path: "quote-permit", // Use different endpoint for permit enabled tokens
     eoa: account_.signer.address,
     instructions: batchedInstructions,
-    gasLimit: triggerGasLimit,
+    gasLimit: gasLimit || triggerGasLimit,
     ...(cleanUps ? { cleanUps } : {}),
     ...rest
   })

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -6,7 +6,7 @@ import {
   runtimeERC20AllowanceOf
 } from "../../../modules/utils/composabilityCalls"
 import type { BaseMeeClient } from "../../createMeeClient"
-import { type GetQuotePayload, getQuote } from "./getQuote"
+import { DEFAULT_GAS_LIMIT, type GetQuotePayload, getQuote } from "./getQuote"
 import type { GetQuoteParams } from "./getQuote"
 import type { Trigger } from "./signPermitQuote"
 
@@ -99,6 +99,10 @@ export const getPermitQuote = async (
       })
     : trigger.amount
 
+  const triggerGasLimit = trigger.gasLimit
+    ? trigger.gasLimit
+    : DEFAULT_GAS_LIMIT
+
   const params: BuildInstructionTypes = {
     type: "transferFrom",
     data: {
@@ -107,7 +111,7 @@ export const getPermitQuote = async (
       amount: transferFromAmount,
       recipient,
       sender,
-      gasLimit: 50_000n
+      gasLimit: triggerGasLimit
     }
   }
 
@@ -124,6 +128,7 @@ export const getPermitQuote = async (
     path: "quote-permit", // Use different endpoint for permit enabled tokens
     eoa: account_.signer.address,
     instructions: batchedInstructions,
+    gasLimit: triggerGasLimit,
     ...(cleanUps ? { cleanUps } : {}),
     ...rest
   })
@@ -137,7 +142,8 @@ export const getPermitQuote = async (
     trigger: {
       tokenAddress: trigger.tokenAddress,
       chainId: trigger.chainId,
-      amount
+      amount,
+      gasLimit: triggerGasLimit
     }
   }
 }

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -7,11 +7,13 @@ import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAcco
 import { mcUSDC } from "../../../constants/tokens"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import {
+  CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION,
   DEFAULT_GAS_LIMIT,
   type FeeTokenInfo,
   type Instruction,
   getQuote
 } from "./getQuote"
+import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 
 describe("mee.getQuote", () => {
   let network: NetworkConfig
@@ -149,5 +151,77 @@ describe("mee.getQuote", () => {
     expect(quote).toBeDefined()
 
     expect(quote.paymentInfo.callGasLimit).toBe(customGasLimit.toString())
+  })
+
+  test("Cleanup userOp should have extra time window", async () => {
+    const transfer = mcNexus.build({
+      type: "transfer",
+      data: {
+        tokenAddress: mcUSDC.addressOn(paymentChain.id),
+        amount: 1n,
+        chainId: paymentChain.id,
+        recipient: eoaAccount.address
+      }
+    })
+
+    const quote = await getQuote(meeClient, {
+      instructions: [transfer],
+      cleanUps: [
+        {
+          tokenAddress: mcUSDC.addressOn(paymentChain.id),
+          chainId: paymentChain.id,
+          recipientAddress: eoaAccount.address
+        }
+      ],
+      feeToken
+    })
+
+    expect(quote).toBeDefined()
+
+    // userOp 1 => user defined
+    // userOp 2 => cleanup which has 50% additional execution window from default execution window
+    expect(
+      quote.userOps[1].upperBoundTimestamp +
+        CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION
+    ).to.eq(quote.userOps[2].upperBoundTimestamp)
+
+    // If no custom gasLimit for userOp ? Default large gas limit will be used
+    expect(quote.userOps[2].userOp.callGasLimit).to.eq(
+      LARGE_DEFAULT_GAS_LIMIT.toString()
+    )
+  })
+
+  test("Cleanup userOp should have custom gas limit", async () => {
+    const customGasLimit = 100_000n
+
+    const transfer = mcNexus.build({
+      type: "transfer",
+      data: {
+        tokenAddress: mcUSDC.addressOn(paymentChain.id),
+        amount: 1n,
+        chainId: paymentChain.id,
+        recipient: eoaAccount.address
+      }
+    })
+
+    const quote = await getQuote(meeClient, {
+      instructions: [transfer],
+      cleanUps: [
+        {
+          tokenAddress: mcUSDC.addressOn(paymentChain.id),
+          chainId: paymentChain.id,
+          recipientAddress: eoaAccount.address,
+          gasLimit: customGasLimit
+        }
+      ],
+      feeToken
+    })
+
+    expect(quote).toBeDefined()
+
+    // userOp 2 => cleanup userOp
+    expect(quote.userOps[2].userOp.callGasLimit).to.eq(
+      customGasLimit.toString()
+    )
   })
 })

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -6,7 +6,12 @@ import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusA
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { mcUSDC } from "../../../constants/tokens"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
-import { type FeeTokenInfo, type Instruction, getQuote } from "./getQuote"
+import {
+  DEFAULT_GAS_LIMIT,
+  type FeeTokenInfo,
+  type Instruction,
+  getQuote
+} from "./getQuote"
 
 describe("mee.getQuote", () => {
   let network: NetworkConfig
@@ -99,5 +104,50 @@ describe("mee.getQuote", () => {
     })
 
     expect([2, 3].includes(quote.userOps.length)).toBe(true) // 2 or 3 depending on if bridging is needed
+  })
+
+  test("should payment info have a default gas limit", async () => {
+    const transfer = mcNexus.build({
+      type: "transfer",
+      data: {
+        tokenAddress: mcUSDC.addressOn(paymentChain.id),
+        amount: 1n,
+        chainId: paymentChain.id,
+        recipient: eoaAccount.address
+      }
+    })
+
+    const quote = await getQuote(meeClient, {
+      instructions: [transfer],
+      feeToken
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.paymentInfo.callGasLimit).toBe(DEFAULT_GAS_LIMIT.toString())
+  })
+
+  test("should payment info have a custom gas limit", async () => {
+    const customGasLimit = 100_000n
+
+    const transfer = mcNexus.build({
+      type: "transfer",
+      data: {
+        tokenAddress: mcUSDC.addressOn(paymentChain.id),
+        amount: 1n,
+        chainId: paymentChain.id,
+        recipient: eoaAccount.address
+      }
+    })
+
+    const quote = await getQuote(meeClient, {
+      instructions: [transfer],
+      gasLimit: customGasLimit,
+      feeToken
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.paymentInfo.callGasLimit).toBe(customGasLimit.toString())
   })
 })

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -2,6 +2,7 @@ import type { Chain, LocalAccount, Transport } from "viem"
 import { beforeAll, describe, expect, test } from "vitest"
 import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
 import type { NetworkConfig } from "../../../../test/testUtils"
+import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { mcUSDC } from "../../../constants/tokens"
@@ -13,7 +14,6 @@ import {
   type Instruction,
   getQuote
 } from "./getQuote"
-import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 
 describe("mee.getQuote", () => {
   let network: NetworkConfig

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -8,12 +8,8 @@ import {
 import { baseSepolia } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
-import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
-import {
-  CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION,
-  DEFAULT_GAS_LIMIT
-} from "./getQuote"
 import { type NetworkConfig, getBalance } from "../../../../test/testUtils"
+import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { mcUSDC, testnetMcUSDC } from "../../../constants/tokens"
@@ -28,6 +24,10 @@ import {
   type MeeClient,
   createMeeClient
 } from "../../createMeeClient"
+import {
+  CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION,
+  DEFAULT_GAS_LIMIT
+} from "./getQuote"
 import { type FeeTokenInfo, type Instruction, getQuote } from "./getQuote"
 
 const getRandomAccountIndex = (min: number, max: number) => {

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -16,6 +16,8 @@ import type { BaseMeeClient } from "../../createMeeClient"
 
 export const USEROP_MIN_EXEC_WINDOW_DURATION = 180
 
+export const DEFAULT_GAS_LIMIT = 75_000n
+
 /**
  * Represents an abstract call to be executed in the transaction.
  * Each call specifies a target contract and optional parameters.
@@ -165,6 +167,10 @@ export type GetQuoteParams = SupertransactionLike & {
    */
   upperBoundTimestamp?: number
   /**
+   * gasLimit option to override the default payment gas limit
+   */
+  gasLimit?: bigint
+  /**
    * token cleanup option to pull the funds on failure or dust cleanup
    */
   cleanUps?: CleanUp[]
@@ -243,6 +249,8 @@ export type PaymentInfo = {
   chainId: string
   /** EIP7702Auth */
   eip7702Auth?: MeeAuthorization
+  /** Payment userop callGasLimit */
+  callGasLimit?: bigint
 }
 
 /**
@@ -369,6 +377,7 @@ export const getQuote = async (
     instructions,
     cleanUps,
     feeToken,
+    gasLimit,
     path = "quote",
     eoa,
     lowerBoundTimestamp: lowerBoundTimestamp_ = Math.floor(Date.now() / 1000),
@@ -451,6 +460,7 @@ export const getQuote = async (
     sender: validPaymentAccount.address,
     token: feeToken.address,
     nonce: nonce.toString(),
+    callGasLimit: gasLimit || DEFAULT_GAS_LIMIT,
     chainId: feeToken.chainId.toString(),
     ...(eoa ? { eoa } : {}),
     ...initData

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -16,6 +16,9 @@ import type { BaseMeeClient } from "../../createMeeClient"
 
 export const USEROP_MIN_EXEC_WINDOW_DURATION = 180
 
+export const CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION =
+  USEROP_MIN_EXEC_WINDOW_DURATION / 2
+
 export const DEFAULT_GAS_LIMIT = 75_000n
 
 /**
@@ -127,6 +130,11 @@ export type CleanUp = {
    * @example 1000000n // 1 USDC (6 decimals)
    */
   amount?: bigint
+  /**
+   * Custom gas limit for cleanup userOp
+   * @example 1n
+   */
+  gasLimit?: bigint
   /**
    * The address of the receiver where the token to cleanup
    * @example "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // EVM address
@@ -493,7 +501,10 @@ export const getQuote = async (
         }
         return {
           lowerBoundTimestamp: lowerBoundTimestamp_,
-          upperBoundTimestamp: upperBoundTimestamp_,
+          upperBoundTimestamp: isCleanUpUserOp
+            ? upperBoundTimestamp_ +
+              CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION
+            : upperBoundTimestamp_,
           sender,
           callData,
           callGasLimit,
@@ -586,7 +597,8 @@ const prepareCleanUpUserOps = async (
             recipient: cleanUp.recipientAddress,
             tokenAddress: cleanUp.tokenAddress,
             amount,
-            chainId: cleanUp.chainId
+            chainId: cleanUp.chainId,
+            ...(cleanUp.gasLimit ? { gasLimit: cleanUp.gasLimit } : {})
           }
         }
       )

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -33,6 +33,10 @@ export type Trigger = {
    */
   amount: bigint
   /**
+   * custom gas limit can be added to override the default 50_000 gas limit
+   */
+  gasLimit?: bigint
+  /**
    * Whether to include the fee in the amount, or to add the fee to the amount.
    * default is false
    */


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces enhancements related to gas limits in the `mee` and `erc7579` modules, including custom gas limits for various operations, updates to type definitions, and modifications to tests to ensure proper functionality.

### Detailed summary
- Added `gasLimit` property to `signPermitQuote` type.
- Updated `ReadFn` type to return `Promise<AnyData>`.
- Removed skipped test in `buildComposable.test.ts`.
- Changed body serialization in `createHttpClient` from `JSON.stringify` to `stringify`.
- Introduced default gas limit constants in `getQuote`.
- Updated `getOnChainQuote` and `getPermitQuote` functions to utilize `gasLimit`.
- Added tests for default and custom gas limits in `getPermitQuote.test.ts` and `getQuote.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->