### PR TITLE
feat: mee ss plus sponsorship

### DIFF
--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -49,6 +49,8 @@ export const grantMeePermission = async <
         (deployment) => deployment?.client?.chain?.id === chainId
       )
 
+      // if no fee token is provided, the payment action policy is not added
+      // as it is not needed for the sponsored mode
       const paymentActionPolicy =
         feeToken && feeToken.chainId === chainId
           ? {

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
@@ -3,7 +3,10 @@ import type {
   BaseMeeClient,
   MeeClient
 } from "../../../../../clients/createMeeClient"
-import type { Instruction } from "../../../../../clients/decorators/mee"
+import type {
+  Instruction,
+  SponsorshipOptionsParams
+} from "../../../../../clients/decorators/mee"
 import type { FeeTokenInfo } from "../../../../../clients/decorators/mee"
 import {
   SMART_SESSIONS_ADDRESS,
@@ -16,6 +19,8 @@ export type UseMeePermissionParams = {
   instructions: Instruction[]
   feeToken: FeeTokenInfo
   sessionDetails: GrantMeePermissionPayload
+  sponsorship?: true
+  sponsorshipOptions?: SponsorshipOptionsParams
 }
 
 export type UseMeePermissionPayload = { hash: Hash }
@@ -28,7 +33,9 @@ export const useMeePermission = async (
     sessionDetails: sessionDetailsArray,
     mode: mode_,
     instructions,
-    feeToken
+    feeToken,
+    sponsorship,
+    sponsorshipOptions
   } = parameters
   const meeClient = meeClient_ as MeeClient
   // const mcAccount = meeClient.account
@@ -42,7 +49,9 @@ export const useMeePermission = async (
     instructions,
     feeToken,
     moduleAddress: SMART_SESSIONS_ADDRESS,
-    shortEncodingSuperTxn: true
+    shortEncodingSuperTxn: true,
+    sponsorship,
+    sponsorshipOptions
   })
 
   const signedQuote = await meeClient.signQuote({ quote })

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -61,7 +61,7 @@ describe("mee.multichainSmartSessions", () => {
 
     meeClient = await createMeeClient({
       account: mcNexus,
-      url: DEFAULT_MEE_NODE_URL
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
     })
     smartSessionsValidator = toSmartSessionsModule({ signer: mcNexus.signer })
   })
@@ -232,6 +232,69 @@ describe("mee.multichainSmartSessions", () => {
     const dappSessionClient = dappMeeClient.extend(meeSessionActions)
 
     const { hash } = await dappSessionClient.usePermission({
+      sessionDetails,
+      mode: "ENABLE_AND_USE",
+      instructions: [
+        {
+          calls: [
+            {
+              to: COUNTER_ON_OPTIMISM,
+              data: "0x273ea3e3"
+            }
+          ],
+          chainId: paymentChain.id
+        }
+      ],
+      feeToken
+    })
+  })
+
+  it("should grant and use multichain permissions with sponsorship", async () => {
+    const sessionMeeClient = meeClient.extend(meeSessionActions)
+
+    const prepareForPermissionsPayload =
+      await sessionMeeClient.prepareForPermissions({
+        smartSessionsValidator,
+        feeToken
+      })
+    expect(prepareForPermissionsPayload).toBeUndefined()
+
+    const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
+    const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
+
+    const sessionDetails = await sessionMeeClient.grantPermission({
+      redeemer: redeemerAddress,
+      actions: [
+        {
+          actionTargetSelector: "0x273ea3e3",
+          actionPolicies: [getSudoPolicy()],
+          chainId: paymentChain.id,
+          actionTarget: COUNTER_ON_OPTIMISM
+        },
+        {
+          actionTargetSelector: "0x273ea3e3",
+          actionPolicies: [getSudoPolicy()],
+          chainId: targetChain.id,
+          actionTarget: COUNTER_ON_BASE
+        }
+      ]
+    })
+
+    const dappNexusAccount = await toMultichainNexusAccount({
+      accountAddress: mcNexus.addressOn(paymentChain.id),
+      chains: [paymentChain, targetChain],
+      transports,
+      signer: redeemerAccount
+    })
+
+    const dappMeeClient = await createMeeClient({
+      account: dappNexusAccount,
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
+    })
+    const dappSessionClient = dappMeeClient.extend(meeSessionActions)
+
+    const { hash } = await dappSessionClient.usePermission({
+      sponsorship: true,
       sessionDetails,
       mode: "ENABLE_AND_USE",
       instructions: [


### PR DESCRIPTION
- ss work with sponsorship
- test

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces sponsorship options for granting permissions in the `useMeePermission` function, enhancing the smart sessions functionality to support sponsored transactions. It also updates the related test cases to ensure proper handling of these new features.

### Detailed summary
- Added `sponsorship` and `sponsorshipOptions` to `UseMeePermissionParams`.
- Updated `useMeePermission` to handle `sponsorship` parameters.
- Enhanced the test to include a case for granting and using multichain permissions with sponsorship.
- Included an API key in the test setup for `meeClient`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->