### PR TITLE
chore: converted multichain ss tests as paid tests

### DIFF
--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -2,7 +2,7 @@ import { getSudoPolicy } from "@rhinestone/module-sdk"
 import type { Address, Chain, Client, LocalAccount, Transport } from "viem"
 import { http, createPublicClient, erc20Abi, parseUnits } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
-import { beforeAll, describe, expect, it } from "vitest"
+import { beforeAll, describe, expect, inject, test } from "vitest"
 import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
 import type { NetworkConfig } from "../../../../test/testUtils"
 import {
@@ -21,6 +21,9 @@ import type { ModularSmartAccount } from "../../utils/Types"
 import type { Validator } from "../toValidator"
 import { meeSessionActions } from "./decorators/mee"
 import { toSmartSessionsModule } from "./toSmartSessionsModule"
+
+// @ts-ignore
+const { runPaidTests } = inject("settings")
 
 describe("mee.multichainSmartSessions", () => {
   let network: NetworkConfig
@@ -67,262 +70,274 @@ describe("mee.multichainSmartSessions", () => {
     smartSessionsValidator = toSmartSessionsModule({ signer: mcNexus.signer })
   })
 
-  it("should prepare the undeployed account for permissions", async () => {
-    const sessionMeeClient = meeClient.extend(meeSessionActions)
+  test.runIf(runPaidTests)(
+    "should prepare the undeployed account for permissions",
+    async () => {
+      const sessionMeeClient = meeClient.extend(meeSessionActions)
 
-    const transferToNexusTrigger = {
-      tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Base chain
-      amount: parseUnits("0.07", 6), // 0.07 usdc => so Nexus is able to pay for the next SuperTxns
-      chainId: paymentChain.id // Which chain this trigger executes on
-    }
-
-    // make random address
-    const aliceAddress = privateKeyToAccount(generatePrivateKey()).address
-
-    const additionalInstructions = await mcNexus.build({
-      type: "approve",
-      data: {
-        tokenAddress: mcUSDC.addressOn(targetChain.id),
-        amount: 12345n,
-        chainId: targetChain.id,
-        spender: aliceAddress
+      const transferToNexusTrigger = {
+        tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Base chain
+        amount: parseUnits("0.07", 6), // 0.07 usdc => so Nexus is able to pay for the next SuperTxns
+        chainId: paymentChain.id // Which chain this trigger executes on
       }
-    })
 
-    const preparePayload = await sessionMeeClient.prepareForPermissions({
-      smartSessionsValidator,
-      feeToken,
-      trigger: transferToNexusTrigger,
-      additionalInstructions
-    })
+      // make random address
+      const aliceAddress = privateKeyToAccount(generatePrivateKey()).address
 
-    const receipt = await meeClient.waitForSupertransactionReceipt({
-      hash: preparePayload?.hash!
-    })
+      const additionalInstructions = await mcNexus.build({
+        type: "approve",
+        data: {
+          tokenAddress: mcUSDC.addressOn(targetChain.id),
+          amount: 12345n,
+          chainId: targetChain.id,
+          spender: aliceAddress
+        }
+      })
 
-    for (const receipt_ of receipt.receipts) {
-      expect(receipt_.status).toBe("success")
-      expect(receipt_.logs).toBeDefined()
-    }
+      const preparePayload = await sessionMeeClient.prepareForPermissions({
+        smartSessionsValidator,
+        feeToken,
+        trigger: transferToNexusTrigger,
+        additionalInstructions
+      })
 
-    for (const deployment of mcNexus.deployments) {
-      expect(await deployment.isDeployed()).toBe(true)
-      const isInstalled = await isModuleInstalled(
-        deployment.client as Client<
-          Transport,
-          Chain | undefined,
-          ModularSmartAccount
-        >,
-        {
-          account: deployment,
-          module: {
-            address: smartSessionsValidator.address,
-            initData: "0x",
-            type: smartSessionsValidator.type
+      const receipt = await meeClient.waitForSupertransactionReceipt({
+        hash: preparePayload?.hash!
+      })
+
+      for (const receipt_ of receipt.receipts) {
+        expect(receipt_.status).toBe("success")
+        expect(receipt_.logs).toBeDefined()
+      }
+
+      for (const deployment of mcNexus.deployments) {
+        expect(await deployment.isDeployed()).toBe(true)
+        const isInstalled = await isModuleInstalled(
+          deployment.client as Client<
+            Transport,
+            Chain | undefined,
+            ModularSmartAccount
+          >,
+          {
+            account: deployment,
+            module: {
+              address: smartSessionsValidator.address,
+              initData: "0x",
+              type: smartSessionsValidator.type
+            }
           }
-        }
+        )
+        expect(isInstalled).toBe(true)
+      }
+      // check approved amount on the target chain
+      const client = createPublicClient({
+        chain: targetChain,
+        transport: http()
+      })
+      const approvedAmount = await client.readContract({
+        address: mcUSDC.addressOn(targetChain.id),
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [mcNexus.addressOn(targetChain.id)!, aliceAddress]
+      })
+      expect(approvedAmount).toBe(12345n)
+    }
+  )
+
+  test.runIf(runPaidTests)(
+    "should not prepare the account that is already deployed and has the module installed",
+    async () => {
+      // check that all deployments are deployed
+      const isDeployed = await Promise.all(
+        mcNexus.deployments.map((deployment) => deployment.isDeployed())
       )
+      expect(isDeployed.every(Boolean)).toBe(true)
+
+      const sessionMeeClient = meeClient.extend(meeSessionActions)
+      expect(Object.keys(sessionMeeClient)).toContain("prepareForPermissions")
+      expect(Object.keys(sessionMeeClient)).toContain("grantPermission")
+      expect(Object.keys(sessionMeeClient)).toContain("usePermission")
+
+      // check that the module is installed on all chains
+      const isInstalledPayload = await mcNexus.read({
+        type: "toIsModuleInstalledReads",
+        parameters: smartSessionsValidator
+      })
+      const isInstalled = isInstalledPayload.every(Boolean)
       expect(isInstalled).toBe(true)
+
+      // check that prepareForPermissions returns undefined => means no preparation was done
+      const prepareForPermissionsPayload =
+        await sessionMeeClient.prepareForPermissions({
+          smartSessionsValidator,
+          feeToken
+        })
+      expect(prepareForPermissionsPayload).toBeUndefined()
     }
-    // check approved amount on the target chain
-    const client = createPublicClient({
-      chain: targetChain,
-      transport: http()
-    })
-    const approvedAmount = await client.readContract({
-      address: mcUSDC.addressOn(targetChain.id),
-      abi: erc20Abi,
-      functionName: "allowance",
-      args: [mcNexus.addressOn(targetChain.id)!, aliceAddress]
-    })
-    expect(approvedAmount).toBe(12345n)
-  })
+  )
 
-  it("should not prepare the account that is already deployed and has the module installed", async () => {
-    // check that all deployments are deployed
-    const isDeployed = await Promise.all(
-      mcNexus.deployments.map((deployment) => deployment.isDeployed())
-    )
-    expect(isDeployed.every(Boolean)).toBe(true)
+  test.runIf(runPaidTests)(
+    "should grant and use multichain permissions for the account that is already deployed on all chains",
+    async () => {
+      const sessionMeeClient = meeClient.extend(meeSessionActions)
 
-    const sessionMeeClient = meeClient.extend(meeSessionActions)
-    expect(Object.keys(sessionMeeClient)).toContain("prepareForPermissions")
-    expect(Object.keys(sessionMeeClient)).toContain("grantPermission")
-    expect(Object.keys(sessionMeeClient)).toContain("usePermission")
+      // ======== At this point the Nexus SA is already deployed and SS is installed ==============
 
-    // check that the module is installed on all chains
-    const isInstalledPayload = await mcNexus.read({
-      type: "toIsModuleInstalledReads",
-      parameters: smartSessionsValidator
-    })
-    const isInstalled = isInstalledPayload.every(Boolean)
-    expect(isInstalled).toBe(true)
+      const prepareForPermissionsPayload =
+        await sessionMeeClient.prepareForPermissions({
+          smartSessionsValidator,
+          feeToken
+        })
+      expect(prepareForPermissionsPayload).toBeUndefined()
 
-    // check that prepareForPermissions returns undefined => means no preparation was done
-    const prepareForPermissionsPayload =
-      await sessionMeeClient.prepareForPermissions({
-        smartSessionsValidator,
+      const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
+      const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
+
+      const sessionDetails = await sessionMeeClient.grantPermission({
+        redeemer: redeemerAddress,
+        feeToken,
+        // Could add a helper function to build the actions array,
+        // this architecture allows for more flexibility and customizations
+        actions: [
+          {
+            actionTargetSelector: "0x273ea3e3",
+            actionPolicies: [getSudoPolicy()],
+            chainId: paymentChain.id,
+            actionTarget: COUNTER_ON_OPTIMISM
+          },
+          {
+            actionTargetSelector: "0x273ea3e3",
+            actionPolicies: [getSudoPolicy()],
+            chainId: targetChain.id,
+            actionTarget: COUNTER_ON_BASE
+          }
+        ],
+        maxPaymentAmount: parseUnits("3", 6)
+      })
+
+      // overload account to use the redeemer account as signer
+      // so using this entity one can sign userOps that have userOp.sender = mcNexus.address
+      // with the redeemer account (which is Session Key) as signer
+      // this would be a common pattern for signing userOps with a session key
+      const dappNexusAccount = await toMultichainNexusAccount({
+        accountAddress: mcNexus.addressOn(paymentChain.id),
+        chains: [paymentChain, targetChain],
+        transports,
+        signer: redeemerAccount
+      })
+
+      const dappMeeClient = await createMeeClient({
+        account: dappNexusAccount,
+        url: DEFAULT_MEE_NODE_URL
+      })
+      const dappSessionClient = dappMeeClient.extend(meeSessionActions)
+
+      const usePermissionPayload = await dappSessionClient.usePermission({
+        sessionDetails,
+        mode: "ENABLE_AND_USE",
+        instructions: [
+          {
+            calls: [
+              {
+                to: COUNTER_ON_OPTIMISM,
+                data: "0x273ea3e3"
+              }
+            ],
+            chainId: paymentChain.id
+          },
+          {
+            calls: [
+              {
+                to: COUNTER_ON_BASE,
+                data: "0x273ea3e3"
+              }
+            ],
+            chainId: targetChain.id
+          }
+        ],
         feeToken
       })
-    expect(prepareForPermissionsPayload).toBeUndefined()
-  })
 
-  it("should grant and use multichain permissions for the account that is already deployed on all chains", async () => {
-    const sessionMeeClient = meeClient.extend(meeSessionActions)
-
-    // ======== At this point the Nexus SA is already deployed and SS is installed ==============
-
-    const prepareForPermissionsPayload =
-      await sessionMeeClient.prepareForPermissions({
-        smartSessionsValidator,
-        feeToken
+      const receipt = await meeClient.waitForSupertransactionReceipt({
+        hash: usePermissionPayload?.hash!
       })
-    expect(prepareForPermissionsPayload).toBeUndefined()
 
-    const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
-    const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
-
-    const sessionDetails = await sessionMeeClient.grantPermission({
-      redeemer: redeemerAddress,
-      feeToken,
-      // Could add a helper function to build the actions array,
-      // this architecture allows for more flexibility and customizations
-      actions: [
-        {
-          actionTargetSelector: "0x273ea3e3",
-          actionPolicies: [getSudoPolicy()],
-          chainId: paymentChain.id,
-          actionTarget: COUNTER_ON_OPTIMISM
-        },
-        {
-          actionTargetSelector: "0x273ea3e3",
-          actionPolicies: [getSudoPolicy()],
-          chainId: targetChain.id,
-          actionTarget: COUNTER_ON_BASE
-        }
-      ],
-      maxPaymentAmount: parseUnits("3", 6)
-    })
-
-    // overload account to use the redeemer account as signer
-    // so using this entity one can sign userOps that have userOp.sender = mcNexus.address
-    // with the redeemer account (which is Session Key) as signer
-    // this would be a common pattern for signing userOps with a session key
-    const dappNexusAccount = await toMultichainNexusAccount({
-      accountAddress: mcNexus.addressOn(paymentChain.id),
-      chains: [paymentChain, targetChain],
-      transports,
-      signer: redeemerAccount
-    })
-
-    const dappMeeClient = await createMeeClient({
-      account: dappNexusAccount,
-      url: DEFAULT_MEE_NODE_URL
-    })
-    const dappSessionClient = dappMeeClient.extend(meeSessionActions)
-
-    const usePermissionPayload = await dappSessionClient.usePermission({
-      sessionDetails,
-      mode: "ENABLE_AND_USE",
-      instructions: [
-        {
-          calls: [
-            {
-              to: COUNTER_ON_OPTIMISM,
-              data: "0x273ea3e3"
-            }
-          ],
-          chainId: paymentChain.id
-        },
-        {
-          calls: [
-            {
-              to: COUNTER_ON_BASE,
-              data: "0x273ea3e3"
-            }
-          ],
-          chainId: targetChain.id
-        }
-      ],
-      feeToken
-    })
-
-    const receipt = await meeClient.waitForSupertransactionReceipt({
-      hash: usePermissionPayload?.hash!
-    })
-
-    for (const receipt_ of receipt.receipts) {
-      expect(receipt_.status).toBe("success")
-      expect(receipt_.logs).toBeDefined()
+      for (const receipt_ of receipt.receipts) {
+        expect(receipt_.status).toBe("success")
+        expect(receipt_.logs).toBeDefined()
+      }
     }
-  })
+  )
 
-  it("should grant and use multichain permissions with sponsorship", async () => {
-    const sessionMeeClient = meeClient.extend(meeSessionActions)
+  test.runIf(runPaidTests)(
+    "should grant and use multichain permissions with sponsorship",
+    async () => {
+      const sessionMeeClient = meeClient.extend(meeSessionActions)
 
-    const prepareForPermissionsPayload =
-      await sessionMeeClient.prepareForPermissions({
-        smartSessionsValidator,
+      const prepareForPermissionsPayload =
+        await sessionMeeClient.prepareForPermissions({
+          smartSessionsValidator,
+          feeToken
+        })
+      expect(prepareForPermissionsPayload).toBeUndefined()
+
+      const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
+      const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
+
+      const sessionDetails = await sessionMeeClient.grantPermission({
+        redeemer: redeemerAddress,
+        actions: [
+          {
+            actionTargetSelector: "0x273ea3e3",
+            actionPolicies: [getSudoPolicy()],
+            chainId: paymentChain.id,
+            actionTarget: COUNTER_ON_OPTIMISM
+          },
+          {
+            actionTargetSelector: "0x273ea3e3",
+            actionPolicies: [getSudoPolicy()],
+            chainId: targetChain.id,
+            actionTarget: COUNTER_ON_BASE
+          }
+        ]
+      })
+
+      const dappNexusAccount = await toMultichainNexusAccount({
+        accountAddress: mcNexus.addressOn(paymentChain.id),
+        chains: [paymentChain, targetChain],
+        transports,
+        signer: redeemerAccount
+      })
+
+      const dappMeeClient = await createMeeClient({
+        account: dappNexusAccount,
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
+      })
+      const dappSessionClient = dappMeeClient.extend(meeSessionActions)
+
+      const usePermissionPayload = await dappSessionClient.usePermission({
+        sponsorship: true,
+        sessionDetails,
+        mode: "ENABLE_AND_USE",
+        instructions: [
+          {
+            calls: [
+              {
+                to: COUNTER_ON_OPTIMISM,
+                data: "0x273ea3e3"
+              }
+            ],
+            chainId: paymentChain.id
+          }
+        ],
         feeToken
       })
-    expect(prepareForPermissionsPayload).toBeUndefined()
 
-    const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
-    const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
+      const receipt = await meeClient.waitForSupertransactionReceipt({
+        hash: usePermissionPayload?.hash!
+      })
 
-    const sessionDetails = await sessionMeeClient.grantPermission({
-      redeemer: redeemerAddress,
-      actions: [
-        {
-          actionTargetSelector: "0x273ea3e3",
-          actionPolicies: [getSudoPolicy()],
-          chainId: paymentChain.id,
-          actionTarget: COUNTER_ON_OPTIMISM
-        },
-        {
-          actionTargetSelector: "0x273ea3e3",
-          actionPolicies: [getSudoPolicy()],
-          chainId: targetChain.id,
-          actionTarget: COUNTER_ON_BASE
-        }
-      ]
-    })
-
-    const dappNexusAccount = await toMultichainNexusAccount({
-      accountAddress: mcNexus.addressOn(paymentChain.id),
-      chains: [paymentChain, targetChain],
-      transports,
-      signer: redeemerAccount
-    })
-
-    const dappMeeClient = await createMeeClient({
-      account: dappNexusAccount,
-      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
-    })
-    const dappSessionClient = dappMeeClient.extend(meeSessionActions)
-
-    const usePermissionPayload = await dappSessionClient.usePermission({
-      sponsorship: true,
-      sessionDetails,
-      mode: "ENABLE_AND_USE",
-      instructions: [
-        {
-          calls: [
-            {
-              to: COUNTER_ON_OPTIMISM,
-              data: "0x273ea3e3"
-            }
-          ],
-          chainId: paymentChain.id
-        }
-      ],
-      feeToken
-    })
-
-    const receipt = await meeClient.waitForSupertransactionReceipt({
-      hash: usePermissionPayload?.hash!
-    })
-
-    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
-  })
+      expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+    }
+  )
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the test cases in the `toMultichainSmartSessions.test.ts` file to improve the structure and clarity of the tests, and introduces new functionalities related to account permissions and multichain interactions.

### Detailed summary
- Changed import from `it` to `test` in `vitest`.
- Introduced `inject` for `runPaidTests`.
- Updated test descriptions for clarity.
- Refactored test cases to use `test.runIf(runPaidTests)`.
- Improved formatting for readability.
- Added checks for approved amounts and deployment statuses.
- Enhanced permission granting and usage logic with sponsorship options.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->