### PR TITLE
refactor: sponsorship to isSponsored

### DIFF
--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -168,7 +168,7 @@ export const getOnChainQuote = async (
     ? 0n
     : BigInt(quote.paymentInfo.tokenWeiAmount)
 
-  if (rest.sponsorship) {
+  if (rest.isSponsored) {
     // For sponsorship, user will never pay fee. So the trigger amount never include fees
     fees = 0n
   }

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -165,7 +165,7 @@ export const getPermitQuote = async (
     ? 0n
     : BigInt(quote.paymentInfo.tokenWeiAmount)
 
-  if (rest.sponsorship) {
+  if (rest.isSponsored) {
     // For sponsorship, user will never pay fee. So the trigger amount never include fees
     fees = 0n
   }

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -263,7 +263,7 @@ describe("mee.getQuote", () => {
     })
 
     const quote = await meeClient.getQuote({
-      sponsorship: true,
+      isSponsored: true,
       sponsorshipOptions: {
         url: DEFAULT_STAGING_PATHFINDER_URL,
         gasTank: {
@@ -324,7 +324,7 @@ describe("mee.getQuote", () => {
       })
 
       await meeClient.getQuote({
-        sponsorship: true,
+        isSponsored: true,
         sponsorshipOptions: {
           url: "https://www.google.com",
           gasTank: {
@@ -367,7 +367,7 @@ describe("mee.getQuote", () => {
     })
 
     const quote = await meeClient.getQuote({
-      sponsorship: true,
+      isSponsored: true,
       instructions: [
         {
           calls: [
@@ -420,7 +420,7 @@ describe("mee.getQuote", () => {
     })
 
     const quote = await meeClient.getQuote({
-      sponsorship: true,
+      isSponsored: true,
       instructions: [
         {
           calls: [
@@ -480,7 +480,7 @@ describe("mee.getQuote", () => {
     })
 
     const quote = await meeClient.getQuote({
-      sponsorship: true,
+      isSponsored: true,
       delegate: true,
       instructions: [
         {
@@ -554,7 +554,7 @@ describe("mee.getQuote", () => {
     const amountToTrigger = 1n
 
     const fusionQuote = await meeClient.getFusionQuote({
-      sponsorship: true,
+      isSponsored: true,
       trigger: {
         amount: amountToTrigger,
         chainId: paymentChain.id,
@@ -624,7 +624,7 @@ describe("mee.getQuote", () => {
       })
 
       const quote = await meeClient.getQuote({
-        sponsorship: true,
+        isSponsored: true,
         sponsorshipOptions: {
           url: DEFAULT_STAGING_PATHFINDER_URL,
           gasTank: {
@@ -676,7 +676,7 @@ describe("mee.getQuote", () => {
       })
 
       const quote = await meeClient.getQuote({
-        sponsorship: true,
+        isSponsored: true,
         instructions: [
           {
             calls: [
@@ -726,7 +726,7 @@ describe("mee.getQuote", () => {
       })
 
       const quote = await meeClient.getQuote({
-        sponsorship: true,
+        isSponsored: true,
         sponsorshipOptions: {
           url: DEFAULT_STAGING_PATHFINDER_URL,
           gasTank: {
@@ -798,7 +798,7 @@ describe("mee.getQuote", () => {
       })
 
       const quote = await meeClient.getQuote({
-        sponsorship: true,
+        isSponsored: true,
         sponsorshipOptions: {
           url: DEFAULT_STAGING_PATHFINDER_URL,
           gasTank: {
@@ -877,7 +877,7 @@ describe("mee.getQuote", () => {
       })
 
       const quote = await meeClient.getFusionQuote({
-        sponsorship: true,
+        isSponsored: true,
         sponsorshipOptions: {
           url: DEFAULT_STAGING_PATHFINDER_URL,
           gasTank: {
@@ -967,7 +967,7 @@ describe("mee.getQuote", () => {
       })
 
       const quote = await meeClient.getFusionQuote({
-        sponsorship: true,
+        isSponsored: true,
         sponsorshipOptions: {
           url: DEFAULT_STAGING_PATHFINDER_URL,
           gasTank: {

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -482,7 +482,7 @@ export const getQuote = async (
     authorization,
     moduleAddress,
     shortEncodingSuperTxn = false,
-    sponsorship = false
+    isSponsored = false
   } = parameters
 
   const resolvedInstructions = await resolveInstructions(instructions)
@@ -506,7 +506,7 @@ export const getQuote = async (
   const hasProcessedInitData: string[] = []
   const paymentVerificationGasLimit = resolvePaymentUserOpVerificationGasLimit({
     moduleAddress,
-    sponsorship
+    isSponsored
   })
 
   const { paymentInfo, isInitDataProcessed } = await preparePaymentInfo(
@@ -578,7 +578,7 @@ export const getQuote = async (
 
         const verificationGasLimit = resolveVerificationGasLimit({
           moduleAddress,
-          sponsorship,
+          isSponsored,
           index: indexPerChainId.get(chainId)!,
           paymentChainId: paymentInfo.chainId,
           currentChainId: chainId
@@ -624,7 +624,7 @@ const preparePaymentInfo = async (
     delegate = false,
     gasLimit,
     authorization,
-    sponsorship,
+    isSponsored,
     sponsorshipOptions,
     shortEncodingSuperTxn,
     moduleAddress = zeroAddress as Address,
@@ -634,7 +634,7 @@ const preparePaymentInfo = async (
   let paymentInfo: PaymentInfo | undefined = undefined
   let isInitDataProcessed = false
 
-  if (sponsorship) {
+  if (isSponsored) {
     // For sponsorship, the sender should be the sponsorship SCA which will bare the gas payment for developers
     let sender = DEFAULT_MEE_SPONSORSHIP_PAYMASTER_ACCOUNT
     let token = DEFAULT_MEE_SPONSORSHIP_TOKEN_ADDRESS
@@ -951,12 +951,12 @@ const resolveVerificationGasLimit = (
     currentChainId: string
   }
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, sponsorship, index, paymentChainId, currentChainId } =
+  const { moduleAddress, isSponsored, index, paymentChainId, currentChainId } =
     parameters
   if (currentChainId === paymentChainId) {
     return resolveVerificationGasLimitForPaymentChain({
       moduleAddress,
-      sponsorship,
+      isSponsored,
       index
     })
   }
@@ -973,13 +973,13 @@ const resolveVerificationGasLimit = (
 const resolveVerificationGasLimitForPaymentChain = (
   parameters: resolveVerificationGasLimitParams
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, sponsorship, index } = parameters
+  const { moduleAddress, isSponsored, index } = parameters
   // if module address is not provided, the default verification gas limit will be applied
   if (!moduleAddress) {
     return undefined
   }
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
-    if (sponsorship) {
+    if (isSponsored) {
       if (index === 0) {
         // return increased verification gas limit for the first userOp
         // as it this userOp will be enabling the permission => requires more gas
@@ -1030,13 +1030,13 @@ const resolveVerificationGasLimitForNonPaymentChain = (
 const resolvePaymentUserOpVerificationGasLimit = (
   parameters: Omit<resolveVerificationGasLimitParams, "index">
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, sponsorship } = parameters
+  const { moduleAddress, isSponsored } = parameters
   // if module address is not provided, the default verification gas limit will be applied
   if (!moduleAddress) {
     return undefined
   }
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
-    if (!sponsorship) {
+    if (!isSponsored) {
       // return increased verification gas limit for payment userOp
       // in a non-sponsored superTxn
       return { verificationGasLimit: "1000000" }

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -244,7 +244,7 @@ export type GetQuoteParams = SupertransactionLike & {
         /**
          * sponsorship flag to enable the sponsored super transactions.
          */
-        sponsorship: true
+        isSponsored: true
         /**
          * Sponsorship options for overrides
          */
@@ -336,7 +336,7 @@ export type PaymentInfo = {
   /** Payment userop callGasLimit */
   callGasLimit?: bigint
   /** Sponsorship flag  */
-  sponsored?: boolean
+  isSponsored?: boolean
 }
 
 /**
@@ -681,7 +681,7 @@ const preparePaymentInfo = async (
     }
 
     paymentInfo = {
-      sponsored: true,
+      isSponsored: true,
       sender,
       token,
       nonce,
@@ -741,7 +741,7 @@ const preparePaymentInfo = async (
       : { initCode }
 
     paymentInfo = {
-      sponsored: false,
+      isSponsored: false,
       sender: validPaymentAccount.address,
       token: feeToken.address,
       nonce: nonce.nonce.toString(),
@@ -927,7 +927,7 @@ const prepareCleanUpUserOps = async (
  */
 export type resolveVerificationGasLimitParams = {
   moduleAddress?: Address
-  sponsorship: boolean
+  isSponsored: boolean
   index: number
 }
 

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -1001,7 +1001,7 @@ const resolveVerificationGasLimitForPaymentChain = (
  * 'undefined' means the node will apply the default verification gas limit
  */
 const resolveVerificationGasLimitForNonPaymentChain = (
-  parameters: Omit<resolveVerificationGasLimitParams, "sponsorship">
+  parameters: Omit<resolveVerificationGasLimitParams, "isSponsored">
 ): verificationGasLimitPayload | undefined => {
   const { moduleAddress, index } = parameters
   // if module address is not provided, the default verification gas limit will be applied

--- a/src/sdk/clients/decorators/mee/getSupertransactionReceipt.ts
+++ b/src/sdk/clients/decorators/mee/getSupertransactionReceipt.ts
@@ -149,7 +149,7 @@ export async function getSupertransactionReceipt(
     case "MINED_SUCCESS": {
       if (waitForReceipts) {
         const isSponsoredSupertransaction =
-          explorerResponse.paymentInfo.sponsored
+          explorerResponse.paymentInfo.isSponsored
 
         receipts = await Promise.all(
           explorerResponse.userOps

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
@@ -23,7 +23,7 @@ export type UseMeePermissionParams = {
       feeToken: FeeTokenInfo
     }
   | {
-      sponsorship: true
+      isSponsored: true
       sponsorshipOptions?: SponsorshipOptionsParams
     }
 >
@@ -52,7 +52,7 @@ export const useMeePermission = async (
     shortEncodingSuperTxn: true,
     ...(parameters.sponsorship
       ? {
-          sponsorship: parameters.sponsorship,
+          isSponsored: parameters.sponsorship,
           sponsorshipOptions: parameters.sponsorshipOptions
         }
       : { feeToken: parameters.feeToken })

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
@@ -50,9 +50,9 @@ export const useMeePermission = async (
     instructions,
     moduleAddress: SMART_SESSIONS_ADDRESS,
     shortEncodingSuperTxn: true,
-    ...(parameters.sponsorship
+    ...(parameters.isSponsored
       ? {
-          isSponsored: parameters.sponsorship,
+          isSponsored: parameters.isSponsored,
           sponsorshipOptions: parameters.sponsorshipOptions
         }
       : { feeToken: parameters.feeToken })

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -316,7 +316,7 @@ describe("mee.multichainSmartSessions", () => {
       const dappSessionClient = dappMeeClient.extend(meeSessionActions)
 
       const usePermissionPayload = await dappSessionClient.usePermission({
-        sponsorship: true,
+        isSponsored: true,
         sessionDetails,
         mode: "ENABLE_AND_USE",
         instructions: [


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on renaming the `sponsorship` flag to `isSponsored` across various files to improve clarity and consistency in the codebase.

### Detailed summary
- Renamed `sponsorship` to `isSponsored` in multiple files including:
  - `src/sdk/clients/decorators/mee/getPermitQuote.ts`
  - `src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts`
  - `src/sdk/clients/decorators/mee/getOnChainQuote.ts`
  - `src/sdk/clients/decorators/mee/getSupertransactionReceipt.ts`
  - `src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts`
  - Several test files in `src/sdk/clients/decorators/mee/getQuote.test.ts`
  - Updated type definitions in `src/sdk/clients/decorators/mee/getQuote.ts`
  - Adjusted logic in functions to reflect the new naming convention.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->