### PR TITLE
fix: adjusted all the test cases to support new mee node and pathfinder changes

### DIFF
--- a/src/sdk/clients/createMeeClient.test.ts
+++ b/src/sdk/clients/createMeeClient.test.ts
@@ -14,7 +14,7 @@ import {
   generatePrivateKey,
   privateKeyToAccount
 } from "viem/accounts"
-import { gnosisChiado, sepolia } from "viem/chains"
+import { baseSepolia, gnosisChiado } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import { getTestChainConfig, toNetwork } from "../../test/testSetup"
 import { type NetworkConfig, getBalance } from "../../test/testUtils"
@@ -24,11 +24,7 @@ import {
 } from "../account/toMultiChainNexusAccount"
 import { aave, mcAaveV3Pool } from "../constants/protocols"
 import { mcAUSDC, mcUSDC, testnetMcUSDC } from "../constants/tokens"
-import {
-  DEFAULT_MEE_NODE_URL,
-  type MeeClient,
-  createMeeClient
-} from "./createMeeClient"
+import { type MeeClient, createMeeClient } from "./createMeeClient"
 import type { FeeTokenInfo } from "./decorators/mee/getQuote"
 
 // @ts-ignore
@@ -307,20 +303,17 @@ describe("mee.createMeeClient.delegated", async () => {
   let meeClient: MeeClient
 
   const eoaAccount = privateKeyToAccount(`0x${process.env.PRIVATE_KEY}`)
-  const rpc = `https://sepolia.infura.io/v3/${process.env.INFURA_KEY}`
 
   beforeAll(async () => {
     mcNexus = await toMultichainNexusAccount({
-      chains: [sepolia],
+      chains: [baseSepolia],
       signer: eoaAccount,
-      transports: [http(rpc)],
+      transports: [http()],
       accountAddress: eoaAccount.address
     })
 
-    // The explicit default URL should be removed later.
     meeClient = await createMeeClient({
-      account: mcNexus,
-      url: DEFAULT_MEE_NODE_URL
+      account: mcNexus
     })
   })
 
@@ -333,7 +326,7 @@ describe("mee.createMeeClient.delegated", async () => {
   // Funds are draining quickly on test wallets
   test.skip("should get a quote for a delegated account", async () => {
     const balanceBefore = await getBalance(
-      mcNexus.deploymentOn(sepolia.id, true).publicClient,
+      mcNexus.deploymentOn(baseSepolia.id, true).publicClient,
       zeroAddress
     )
     const quote = await meeClient.getQuote({
@@ -346,12 +339,12 @@ describe("mee.createMeeClient.delegated", async () => {
               value: 1n
             }
           ],
-          chainId: sepolia.id
+          chainId: baseSepolia.id
         }
       ],
       feeToken: {
-        address: testnetMcUSDC.addressOn(sepolia.id), // usdc
-        chainId: sepolia.id
+        address: testnetMcUSDC.addressOn(baseSepolia.id), // usdc
+        chainId: baseSepolia.id
       }
     })
     expect(quote).toBeDefined()
@@ -367,7 +360,7 @@ describe("mee.createMeeClient.delegated", async () => {
     expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
 
     const balanceAfter = await getBalance(
-      mcNexus.deploymentOn(sepolia.id, true).publicClient,
+      mcNexus.deploymentOn(baseSepolia.id, true).publicClient,
       zeroAddress
     )
     expect(balanceAfter).toBeGreaterThan(balanceBefore)
@@ -385,7 +378,7 @@ describe("mee.createMeeClient.delegated", async () => {
 
   test("should override the authorization for delegation", async () => {
     const dummyAuth: SignAuthorizationReturnType = {
-      chainId: sepolia.id,
+      chainId: baseSepolia.id,
       address: zeroAddress,
       nonce: 1,
       r: "0x0000000000000000000000000000000000000000000000000000000000000000",
@@ -405,12 +398,12 @@ describe("mee.createMeeClient.delegated", async () => {
               value: 1n
             }
           ],
-          chainId: sepolia.id
+          chainId: baseSepolia.id
         }
       ],
       feeToken: {
-        address: testnetMcUSDC.addressOn(sepolia.id), // usdc
-        chainId: sepolia.id
+        address: testnetMcUSDC.addressOn(baseSepolia.id), // usdc
+        chainId: baseSepolia.id
       }
     })
 

--- a/src/sdk/clients/createMeeClient.ts
+++ b/src/sdk/clients/createMeeClient.ts
@@ -4,7 +4,6 @@ import { isStaging } from "../account/utils/Helpers"
 import createHttpClient, { type HttpClient, type Url } from "./createHttpClient"
 import { type GetInfoPayload, getInfo, meeActions } from "./decorators/mee"
 
-export const DEFAULT_MEE_NODE_URL = "https://mee-node.biconomy.io/v3"
 /**
   const STAKEPOOL_MEE_NODE_URL = "https://mainnet.mee.stakepool.dev.br/v3"
 */

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -20,7 +20,7 @@ import {
   DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID,
   DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
   DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
-  DEFAULT_STAGING_PATHFINDER_URL,
+  DEFAULT_PATHFINDER_URL,
   type MeeClient,
   createMeeClient
 } from "../../createMeeClient"
@@ -255,17 +255,15 @@ describe("mee.getQuote", () => {
       transports: [http()]
     })
 
-    // TODO: Remove the url and API key once everything is moved into production
     const meeClient = await createMeeClient({
       account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-      url: DEFAULT_STAGING_PATHFINDER_URL
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
     })
 
     const quote = await meeClient.getQuote({
       sponsorship: true,
       sponsorshipOptions: {
-        url: DEFAULT_STAGING_PATHFINDER_URL,
+        url: DEFAULT_PATHFINDER_URL,
         gasTank: {
           address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
           token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
@@ -316,11 +314,9 @@ describe("mee.getQuote", () => {
         transports: [http()]
       })
 
-      // TODO: Remove the url and API key once everything is moved into production
       const meeClient = await createMeeClient({
         account: mcNexus,
-        apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-        url: DEFAULT_STAGING_PATHFINDER_URL
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
       })
 
       await meeClient.getQuote({
@@ -359,11 +355,9 @@ describe("mee.getQuote", () => {
       transports: [http()]
     })
 
-    // TODO: Remove the url and API key once everything is moved into production
     const meeClient = await createMeeClient({
       account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-      url: DEFAULT_STAGING_PATHFINDER_URL
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
     })
 
     const quote = await meeClient.getQuote({
@@ -412,11 +406,9 @@ describe("mee.getQuote", () => {
       index: BigInt(getRandomAccountIndex(1000, 10000000000000))
     })
 
-    // TODO: Remove the url and API key once everything is moved into production
     const meeClient = await createMeeClient({
       account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-      url: DEFAULT_STAGING_PATHFINDER_URL
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
     })
 
     const quote = await meeClient.getQuote({
@@ -472,11 +464,9 @@ describe("mee.getQuote", () => {
       index: BigInt(getRandomAccountIndex(1000, 10000000000000))
     })
 
-    // TODO: Remove the url and API key once everything is moved into production
     const meeClient = await createMeeClient({
       account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-      url: DEFAULT_STAGING_PATHFINDER_URL
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
     })
 
     const quote = await meeClient.getQuote({
@@ -544,11 +534,9 @@ describe("mee.getQuote", () => {
       index: BigInt(getRandomAccountIndex(1000, 10000000000000))
     })
 
-    // TODO: Remove the url and API key once everything is moved into production
     const meeClient = await createMeeClient({
       account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-      url: DEFAULT_STAGING_PATHFINDER_URL
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
     })
 
     const amountToTrigger = 1n
@@ -616,17 +604,15 @@ describe("mee.getQuote", () => {
         transports: [http()]
       })
 
-      // TODO: Remove the url and API key once everything is moved into production
       const meeClient = await createMeeClient({
         account: mcNexus,
-        apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-        url: DEFAULT_STAGING_PATHFINDER_URL
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
       })
 
       const quote = await meeClient.getQuote({
         sponsorship: true,
         sponsorshipOptions: {
-          url: DEFAULT_STAGING_PATHFINDER_URL,
+          url: DEFAULT_PATHFINDER_URL,
           gasTank: {
             address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
             token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
@@ -668,11 +654,9 @@ describe("mee.getQuote", () => {
         transports: [http()]
       })
 
-      // TODO: Remove the url and API key once everything is moved into production
       const meeClient = await createMeeClient({
         account: mcNexus,
-        apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-        url: DEFAULT_STAGING_PATHFINDER_URL
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
       })
 
       const quote = await meeClient.getQuote({
@@ -718,17 +702,15 @@ describe("mee.getQuote", () => {
 
       await expect(await nexusAccount.isDeployed()).to.eq(false)
 
-      // TODO: Remove the url and API key once everything is moved into production
       const meeClient = await createMeeClient({
         account: mcNexus,
-        apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-        url: DEFAULT_STAGING_PATHFINDER_URL
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
       })
 
       const quote = await meeClient.getQuote({
         sponsorship: true,
         sponsorshipOptions: {
-          url: DEFAULT_STAGING_PATHFINDER_URL,
+          url: DEFAULT_PATHFINDER_URL,
           gasTank: {
             address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
             token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
@@ -790,17 +772,15 @@ describe("mee.getQuote", () => {
 
       await expect(isDelegated).to.eq(false)
 
-      // TODO: Remove the url and API key once everything is moved into production
       const meeClient = await createMeeClient({
         account: mcNexus,
-        apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-        url: DEFAULT_STAGING_PATHFINDER_URL
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
       })
 
       const quote = await meeClient.getQuote({
         sponsorship: true,
         sponsorshipOptions: {
-          url: DEFAULT_STAGING_PATHFINDER_URL,
+          url: DEFAULT_PATHFINDER_URL,
           gasTank: {
             address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
             token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
@@ -869,17 +849,15 @@ describe("mee.getQuote", () => {
         testnetMcUSDC.addressOn(baseSepolia.id)
       )
 
-      // TODO: Remove the url and API key once everything is moved into production
       const meeClient = await createMeeClient({
         account: mcNexus,
-        apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-        url: DEFAULT_STAGING_PATHFINDER_URL
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
       })
 
       const quote = await meeClient.getFusionQuote({
         sponsorship: true,
         sponsorshipOptions: {
-          url: DEFAULT_STAGING_PATHFINDER_URL,
+          url: DEFAULT_PATHFINDER_URL,
           gasTank: {
             address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
             token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
@@ -949,11 +927,9 @@ describe("mee.getQuote", () => {
         testnetMcUSDC.addressOn(baseSepolia.id)
       )
 
-      // TODO: Remove the url and API key once everything is moved into production
       const meeClient = await createMeeClient({
         account: mcNexus,
-        apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf",
-        url: DEFAULT_STAGING_PATHFINDER_URL
+        apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
       })
 
       const transferInx = await mcNexus.build({
@@ -969,7 +945,7 @@ describe("mee.getQuote", () => {
       const quote = await meeClient.getFusionQuote({
         sponsorship: true,
         sponsorshipOptions: {
-          url: DEFAULT_STAGING_PATHFINDER_URL,
+          url: DEFAULT_PATHFINDER_URL,
           gasTank: {
             address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
             token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -10,7 +10,6 @@ import {
   toMultichainNexusAccount
 } from "../../../account/toMultiChainNexusAccount"
 import {
-  DEFAULT_MEE_NODE_URL,
   type MeeClient,
   createMeeClient
 } from "../../../clients/createMeeClient"
@@ -227,8 +226,7 @@ describe("mee.multichainSmartSessions", () => {
       })
 
       const dappMeeClient = await createMeeClient({
-        account: dappNexusAccount,
-        url: DEFAULT_MEE_NODE_URL
+        account: dappNexusAccount
       })
       const dappSessionClient = dappMeeClient.extend(meeSessionActions)
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on refactoring the `createMeeClient` functionality by removing the use of `DEFAULT_MEE_NODE_URL` and replacing it with direct account parameters. It also updates the test cases to align with these changes and modifies API keys and URLs for consistency.

### Detailed summary
- Removed `DEFAULT_MEE_NODE_URL` from `createMeeClient`.
- Updated `createMeeClient` calls in tests to use only `account` parameter.
- Changed instances of `sepolia` to `baseSepolia` in tests.
- Updated API keys from `mee_3Zmc7H6Pbd5wUfUGu27aGzdf` to `mee_3ZLvzYAmZa89WLGa3gmMH8JJ`.
- Replaced `DEFAULT_STAGING_PATHFINDER_URL` with `DEFAULT_PATHFINDER_URL`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->