### PR TITLE
feat: custom approval amount

### DIFF
--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -198,9 +198,9 @@ export const getOnChainQuote = async (
   return {
     quote,
     trigger: {
+      ...trigger,
       amount,
-      gasLimit: triggerGasLimit,
-      ...trigger
+      gasLimit: triggerGasLimit
     }
   }
 }

--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -198,10 +198,9 @@ export const getOnChainQuote = async (
   return {
     quote,
     trigger: {
-      tokenAddress: trigger.tokenAddress,
-      chainId: trigger.chainId,
       amount,
-      gasLimit: triggerGasLimit
+      gasLimit: triggerGasLimit,
+      ...trigger
     }
   }
 }

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -64,8 +64,7 @@ describe("mee.getPermitQuote", () => {
     })
 
     meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
+      account: mcNexus
     })
     tokenAddress = mcUSDC.addressOn(paymentChain.id)
   })

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -63,7 +63,10 @@ describe("mee.getPermitQuote", () => {
       signer: eoaAccount
     })
 
-    meeClient = await createMeeClient({ account: mcNexus })
+    meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3ZLvzYAmZa89WLGa3gmMH8JJ"
+    })
     tokenAddress = mcUSDC.addressOn(paymentChain.id)
   })
 
@@ -347,11 +350,6 @@ describe("mee.getPermitQuote", () => {
   })
 
   test("should add gas fees to amount when not using max available amount", async () => {
-    const client = createPublicClient({
-      chain: paymentChain,
-      transport: transports[0]
-    })
-
     const amount = parseUnits("1", 6) // 1 unit of token
     const trigger: Trigger = {
       chainId: paymentChain.id,

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -179,8 +179,7 @@ export const getPermitQuote = async (
   return {
     quote,
     trigger: {
-      tokenAddress: trigger.tokenAddress,
-      chainId: trigger.chainId,
+      ...trigger,
       amount,
       gasLimit: triggerGasLimit
     }

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -753,12 +753,12 @@ const preparePaymentInfo = async (
     const initData: InitDataOrUndefined = isAccountDeployed
       ? undefined
       : delegate
-      ? {
-          eip7702Auth: await validPaymentAccount.toDelegation({
-            authorization
-          })
-        }
-      : { initCode }
+        ? {
+            eip7702Auth: await validPaymentAccount.toDelegation({
+              authorization
+            })
+          }
+        : { initCode }
 
     paymentInfo = {
       sponsored: false,

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -43,8 +43,8 @@ import type { Trigger } from "./signPermitQuote"
 import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 
 // @ts-ignore
-const { runPaidTests } = inject("settings")
-
+// const { runPaidTests } = inject("settings")
+const runPaidTests = true
 describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
@@ -453,11 +453,12 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
   })
   describe("custom approvalAmount", () => {
     test("changes the allowance based on approvalAmount", async () => {
-      const amount = parseUnits("0.01", 6) // 1 unit of token
+      // Define the amount to transfer and the custom approval amount (allowance)
+      const amount = parseUnits("0.01", 6)
       const approvalAmount = parseUnits("0.03", 6)
-      console.log("approvalAmount", approvalAmount, amount)
       const token = testnetMcUSDC.addressOn(chain.id)
 
+      // Create a wallet client for sending transactions and a public client for reading blockchain state
       const walletClient = createWalletClient({
         account: eoaAccount,
         chain: network.chain,
@@ -467,7 +468,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         chain: network.chain,
         transport: http(network.rpcUrl)
       })
-      // Set allowance to 0 before the test to ensure a known state
+      // Set the allowance to 0 before the test to ensure a known state (reset approval)
       const resetApprovalHash = await walletClient.writeContract({
         address: token,
         abi: erc20Abi,
@@ -477,6 +478,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       await publicClient.waitForTransactionReceipt({
         hash: resetApprovalHash
       })
+      // Read the starting allowance (should be 0)
       const allowanceStart = await publicClient.readContract({
         address: token,
         abi: erc20Abi,
@@ -485,11 +487,12 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       })
       expect(allowanceStart).toBe(0n)
 
+      // Prepare the trigger with the custom approvalAmount
       const trigger: Trigger = {
         chainId: chain.id,
         tokenAddress: token,
-        amount,
-        approvalAmount
+        amount, // The amount to transfer
+        approvalAmount // The custom allowance to set
       }
 
       const fusionQuote = await meeClient.getOnChainQuote({
@@ -523,14 +526,15 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         hash
       })
       expect(executeReceipt.transactionStatus).toBe("MINED_SUCCESS")
+      // Read the ending allowance (should match approvalAmount - the amount that was spent on fees and the amount that was transferred)
       const allowanceEnd = await publicClient.readContract({
         address: token,
         abi: erc20Abi,
         functionName: "allowance",
         args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
       })
-      console.log("allowance start", allowanceStart)
-      console.log("allowance end", allowanceEnd)
+      const fees = BigInt(executeReceipt.paymentInfo?.tokenWeiAmount ?? 0n)
+      expect(allowanceEnd).toBe(approvalAmount - amount - fees)
       console.log({
         eoa: mcNexus.signer.address,
         eoaAccount: eoaAccount.address,

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -25,14 +25,12 @@ import {
   toMultichainNexusAccount
 } from "../../../account/toMultiChainNexusAccount"
 import { FORWARDER_ADDRESS } from "../../../constants"
-import { mcUSDC, testnetMcUSDC } from "../../../constants/tokens"
-import { runtimeERC20BalanceOf } from "../../../modules/utils/composabilityCalls"
+import { mcUSDC, mcUSDT } from "../../../constants/tokens"
 import {
   DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID,
   DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
   DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
   DEFAULT_PATHFINDER_URL,
-  DEFAULT_STAGING_PATHFINDER_URL,
   type MeeClient,
   createMeeClient
 } from "../../createMeeClient"
@@ -149,7 +147,6 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
     )
     expect(balanceOfRecipient).toBe(trigger.amount)
   })
-
   describe("trigger calls", () => {
     test("should handle ETH forwarder trigger call", async () => {
       const ethTrigger = {
@@ -451,12 +448,50 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
     })
   })
   describe("custom approvalAmount", () => {
+    test("should fail if approvalAmount is smaller than the trigger amount", async () => {
+      const amount = parseUnits("0.01", 6)
+      const approvalAmount = parseUnits("0.005", 6)
+      const token = mcUSDT.addressOn(network.chain.id)
+      const trigger: Trigger = {
+        chainId: network.chain.id,
+        tokenAddress: token,
+        amount,
+        approvalAmount
+      }
+      const fusionQuote = await meeClient.getOnChainQuote({
+        trigger,
+        instructions: [
+          await mcNexus.build({
+            type: "transfer",
+            data: {
+              // transfer back to the eoa account
+              recipient: mcNexus.signer.address,
+              tokenAddress: token,
+              amount: 1n,
+              chainId: network.chain.id
+            }
+          })
+        ],
+        feeToken: {
+          chainId: network.chain.id,
+          address: token
+        }
+      })
+      expect(fusionQuote).toBeDefined()
+      expect(fusionQuote.trigger).toBeDefined()
+      // Execute the quote
+      await expect(
+        meeClient.executeFusionQuote({
+          fusionQuote
+        })
+      ).rejects.toThrow()
+    })
+
     test("changes the allowance based on approvalAmount", async () => {
       // Define the amount to transfer and the custom approval amount (allowance)
       const amount = parseUnits("0.01", 6)
       const approvalAmount = parseUnits("0.03", 6)
-      const token = testnetMcUSDC.addressOn(chain.id)
-
+      const token = mcUSDT.addressOn(network.chain.id)
       // Create a wallet client for sending transactions and a public client for reading blockchain state
       const walletClient = createWalletClient({
         account: eoaAccount,
@@ -472,7 +507,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         address: token,
         abi: erc20Abi,
         functionName: "approve",
-        args: [mcNexus.addressOn(chain.id, true), 0n]
+        args: [mcNexus.addressOn(network.chain.id, true), 0n]
       })
       await publicClient.waitForTransactionReceipt({
         hash: resetApprovalHash
@@ -482,13 +517,16 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         address: token,
         abi: erc20Abi,
         functionName: "allowance",
-        args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
+        args: [
+          mcNexus.signer.address,
+          mcNexus.addressOn(network.chain.id, true)
+        ]
       })
       expect(allowanceStart).toBe(0n)
 
       // Prepare the trigger with the custom approvalAmount
       const trigger: Trigger = {
-        chainId: chain.id,
+        chainId: network.chain.id,
         tokenAddress: token,
         amount, // The amount to transfer
         approvalAmount // The custom allowance to set
@@ -504,12 +542,12 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
               recipient: mcNexus.signer.address,
               tokenAddress: token,
               amount: 1n,
-              chainId: chain.id
+              chainId: network.chain.id
             }
           })
         ],
         feeToken: {
-          chainId: chain.id,
+          chainId: network.chain.id,
           address: token
         }
       })
@@ -530,7 +568,10 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         address: token,
         abi: erc20Abi,
         functionName: "allowance",
-        args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
+        args: [
+          mcNexus.signer.address,
+          mcNexus.addressOn(network.chain.id, true)
+        ]
       })
       const fees = BigInt(executeReceipt.paymentInfo?.tokenWeiAmount ?? 0n)
       expect(allowanceEnd).toBe(approvalAmount - amount - fees)

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -457,9 +457,9 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       const approvalAmount = parseUnits("0.03", 6)
       console.log("approvalAmount", approvalAmount, amount)
       const token = testnetMcUSDC.addressOn(chain.id)
-      const account = privateKeyToAccount(pKey as Hex)
+
       const walletClient = createWalletClient({
-        account,
+        account: eoaAccount,
         chain: network.chain,
         transport: http(network.rpcUrl)
       })
@@ -472,14 +472,11 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         address: token,
         abi: erc20Abi,
         functionName: "approve",
-        args: [mcNexus.addressOn(chain.id, true), 0n],
-        account: mcNexus.signer
+        args: [mcNexus.addressOn(chain.id, true), 0n]
       })
-
       await publicClient.waitForTransactionReceipt({
         hash: resetApprovalHash
       })
-
       const allowanceStart = await publicClient.readContract({
         address: token,
         abi: erc20Abi,
@@ -534,6 +531,13 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       })
       console.log("allowance start", allowanceStart)
       console.log("allowance end", allowanceEnd)
+      console.log({
+        eoa: mcNexus.signer.address,
+        eoaAccount: eoaAccount.address,
+        mcNexus: mcNexus.addressOn(chain.id, true),
+        chainId: chain.id,
+        executeReceipt
+      })
     })
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -43,8 +43,7 @@ import type { Trigger } from "./signPermitQuote"
 import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 
 // @ts-ignore
-// const { runPaidTests } = inject("settings")
-const runPaidTests = true
+const { runPaidTests } = inject("settings")
 describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -297,6 +297,136 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
       expect(signedQuote.signature.startsWith(ON_CHAIN_PREFIX)).toBe(true)
     })
   })
+  describe.skip("custom approvalAmount", () => {
+    test("should fail if approvalAmount is smaller than the trigger amount", async () => {
+      const amount = parseUnits("0.01", 6)
+      const approvalAmount = parseUnits("0.005", 6)
+      const token = mcUSDT.addressOn(network.chain.id)
+      const trigger: Trigger = {
+        chainId: network.chain.id,
+        tokenAddress: token,
+        amount,
+        approvalAmount
+      }
+      const fusionQuote = await meeClient.getOnChainQuote({
+        trigger,
+        instructions: [
+          await mcNexus.build({
+            type: "transfer",
+            data: {
+              // transfer back to the eoa account
+              recipient: mcNexus.signer.address,
+              tokenAddress: token,
+              amount: 1n,
+              chainId: network.chain.id
+            }
+          })
+        ],
+        feeToken: {
+          chainId: network.chain.id,
+          address: token
+        }
+      })
+      expect(fusionQuote).toBeDefined()
+      expect(fusionQuote.trigger).toBeDefined()
+      // Execute the quote
+      await expect(
+        meeClient.executeFusionQuote({
+          fusionQuote
+        })
+      ).rejects.toThrow()
+    })
+
+    test("changes the allowance based on approvalAmount", async () => {
+      // Define the amount to transfer and the custom approval amount (allowance)
+      const amount = parseUnits("0.01", 6)
+      const approvalAmount = parseUnits("0.03", 6)
+      const token = mcUSDT.addressOn(network.chain.id)
+      // Create a wallet client for sending transactions and a public client for reading blockchain state
+      const walletClient = createWalletClient({
+        account: eoaAccount,
+        chain: network.chain,
+        transport: http(network.rpcUrl)
+      })
+      const publicClient = createPublicClient({
+        chain: network.chain,
+        transport: http(network.rpcUrl)
+      })
+      // Set the allowance to 0 before the test to ensure a known state (reset approval)
+      const resetApprovalHash = await walletClient.writeContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [mcNexus.addressOn(network.chain.id, true), 0n]
+      })
+      await publicClient.waitForTransactionReceipt({
+        hash: resetApprovalHash
+      })
+      // Read the starting allowance (should be 0)
+      const allowanceStart = await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [
+          mcNexus.signer.address,
+          mcNexus.addressOn(network.chain.id, true)
+        ]
+      })
+      expect(allowanceStart).toBe(0n)
+
+      // Prepare the trigger with the custom approvalAmount
+      const trigger: Trigger = {
+        chainId: network.chain.id,
+        tokenAddress: token,
+        amount, // The amount to transfer
+        approvalAmount // The custom allowance to set
+      }
+
+      const fusionQuote = await meeClient.getOnChainQuote({
+        trigger,
+        instructions: [
+          await mcNexus.build({
+            type: "transfer",
+            data: {
+              // transfer back to the eoa account
+              recipient: mcNexus.signer.address,
+              tokenAddress: token,
+              amount: 1n,
+              chainId: network.chain.id
+            }
+          })
+        ],
+        feeToken: {
+          chainId: network.chain.id,
+          address: token
+        }
+      })
+      expect(fusionQuote).toBeDefined()
+      expect(fusionQuote.trigger).toBeDefined()
+      // // Execute the quote
+      const { hash } = await meeClient.executeFusionQuote({
+        fusionQuote
+      })
+
+      // Wait for the transaction to complete
+      const executeReceipt = await meeClient.waitForSupertransactionReceipt({
+        hash
+      })
+      expect(executeReceipt.transactionStatus).toBe("MINED_SUCCESS")
+      // Read the ending allowance (should match approvalAmount - the amount that was spent on fees and the amount that was transferred)
+      const allowanceEnd = await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [
+          mcNexus.signer.address,
+          mcNexus.addressOn(network.chain.id, true)
+        ]
+      })
+      const fees = BigInt(executeReceipt.paymentInfo?.tokenWeiAmount ?? 0n)
+      expect(allowanceEnd).toBe(approvalAmount - amount - fees)
+    })
+  })
 })
 
 describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
@@ -445,136 +575,6 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       // Wait for the transaction to complete
       const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
       expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
-    })
-  })
-  describe("custom approvalAmount", () => {
-    test("should fail if approvalAmount is smaller than the trigger amount", async () => {
-      const amount = parseUnits("0.01", 6)
-      const approvalAmount = parseUnits("0.005", 6)
-      const token = mcUSDT.addressOn(network.chain.id)
-      const trigger: Trigger = {
-        chainId: network.chain.id,
-        tokenAddress: token,
-        amount,
-        approvalAmount
-      }
-      const fusionQuote = await meeClient.getOnChainQuote({
-        trigger,
-        instructions: [
-          await mcNexus.build({
-            type: "transfer",
-            data: {
-              // transfer back to the eoa account
-              recipient: mcNexus.signer.address,
-              tokenAddress: token,
-              amount: 1n,
-              chainId: network.chain.id
-            }
-          })
-        ],
-        feeToken: {
-          chainId: network.chain.id,
-          address: token
-        }
-      })
-      expect(fusionQuote).toBeDefined()
-      expect(fusionQuote.trigger).toBeDefined()
-      // Execute the quote
-      await expect(
-        meeClient.executeFusionQuote({
-          fusionQuote
-        })
-      ).rejects.toThrow()
-    })
-
-    test("changes the allowance based on approvalAmount", async () => {
-      // Define the amount to transfer and the custom approval amount (allowance)
-      const amount = parseUnits("0.01", 6)
-      const approvalAmount = parseUnits("0.03", 6)
-      const token = mcUSDT.addressOn(network.chain.id)
-      // Create a wallet client for sending transactions and a public client for reading blockchain state
-      const walletClient = createWalletClient({
-        account: eoaAccount,
-        chain: network.chain,
-        transport: http(network.rpcUrl)
-      })
-      const publicClient = createPublicClient({
-        chain: network.chain,
-        transport: http(network.rpcUrl)
-      })
-      // Set the allowance to 0 before the test to ensure a known state (reset approval)
-      const resetApprovalHash = await walletClient.writeContract({
-        address: token,
-        abi: erc20Abi,
-        functionName: "approve",
-        args: [mcNexus.addressOn(network.chain.id, true), 0n]
-      })
-      await publicClient.waitForTransactionReceipt({
-        hash: resetApprovalHash
-      })
-      // Read the starting allowance (should be 0)
-      const allowanceStart = await publicClient.readContract({
-        address: token,
-        abi: erc20Abi,
-        functionName: "allowance",
-        args: [
-          mcNexus.signer.address,
-          mcNexus.addressOn(network.chain.id, true)
-        ]
-      })
-      expect(allowanceStart).toBe(0n)
-
-      // Prepare the trigger with the custom approvalAmount
-      const trigger: Trigger = {
-        chainId: network.chain.id,
-        tokenAddress: token,
-        amount, // The amount to transfer
-        approvalAmount // The custom allowance to set
-      }
-
-      const fusionQuote = await meeClient.getOnChainQuote({
-        trigger,
-        instructions: [
-          await mcNexus.build({
-            type: "transfer",
-            data: {
-              // transfer back to the eoa account
-              recipient: mcNexus.signer.address,
-              tokenAddress: token,
-              amount: 1n,
-              chainId: network.chain.id
-            }
-          })
-        ],
-        feeToken: {
-          chainId: network.chain.id,
-          address: token
-        }
-      })
-      expect(fusionQuote).toBeDefined()
-      expect(fusionQuote.trigger).toBeDefined()
-      // // Execute the quote
-      const { hash } = await meeClient.executeFusionQuote({
-        fusionQuote
-      })
-
-      // Wait for the transaction to complete
-      const executeReceipt = await meeClient.waitForSupertransactionReceipt({
-        hash
-      })
-      expect(executeReceipt.transactionStatus).toBe("MINED_SUCCESS")
-      // Read the ending allowance (should match approvalAmount - the amount that was spent on fees and the amount that was transferred)
-      const allowanceEnd = await publicClient.readContract({
-        address: token,
-        abi: erc20Abi,
-        functionName: "allowance",
-        args: [
-          mcNexus.signer.address,
-          mcNexus.addressOn(network.chain.id, true)
-        ]
-      })
-      const fees = BigInt(executeReceipt.paymentInfo?.tokenWeiAmount ?? 0n)
-      expect(allowanceEnd).toBe(approvalAmount - amount - fees)
     })
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -4,20 +4,29 @@ import {
   type Hex,
   type LocalAccount,
   type Transport,
+  createPublicClient,
+  createWalletClient,
+  erc20Abi,
   isHex,
+  parseUnits,
   zeroAddress
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { optimism } from "viem/chains"
 import { beforeAll, describe, expect, inject, test, vi } from "vitest"
 import { getTestChainConfig, toNetwork } from "../../../../test/testSetup"
-import { type NetworkConfig, getBalance } from "../../../../test/testUtils"
+import {
+  type NetworkConfig,
+  getBalance,
+  pKey
+} from "../../../../test/testUtils"
 import {
   type MultichainSmartAccount,
   toMultichainNexusAccount
 } from "../../../account/toMultiChainNexusAccount"
 import { FORWARDER_ADDRESS } from "../../../constants"
 import { mcUSDC, testnetMcUSDC } from "../../../constants/tokens"
+import { runtimeERC20BalanceOf } from "../../../modules/utils/composabilityCalls"
 import {
   DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID,
   DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
@@ -30,10 +39,12 @@ import {
 import executeSignedQuote from "./executeSignedQuote"
 import { type FeeTokenInfo, getQuote } from "./getQuote"
 import { ON_CHAIN_PREFIX, signOnChainQuote } from "./signOnChainQuote"
+import type { Trigger } from "./signPermitQuote"
 import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 
 // @ts-ignore
 const { runPaidTests } = inject("settings")
+
 describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
@@ -438,6 +449,99 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       // Wait for the transaction to complete
       const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
       expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+    })
+  })
+  describe("custom approvalAmount", () => {
+    test("changes the allowance based on approvalAmount", async () => {
+      const amount = parseUnits("0.01", 6) // 1 unit of token
+      const approvalAmount = parseUnits("0.03", 6)
+      console.log("approvalAmount", approvalAmount, amount)
+      const token = testnetMcUSDC.addressOn(chain.id)
+      const account = privateKeyToAccount(pKey as Hex)
+      const walletClient = createWalletClient({
+        account,
+        chain: network.chain,
+        transport: http(network.rpcUrl)
+      })
+      const publicClient = createPublicClient({
+        chain: network.chain,
+        transport: http(network.rpcUrl)
+      })
+      // Set allowance to 0 before the test to ensure a known state
+      const resetApprovalHash = await walletClient.writeContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [mcNexus.addressOn(chain.id, true), 0n],
+        account: mcNexus.signer
+      })
+
+      const resetApprovalReceipt = await publicClient.waitForTransactionReceipt(
+        {
+          hash: resetApprovalHash
+        }
+      )
+      console.log("resetApprovalReceipt", resetApprovalReceipt)
+
+      const allowanceStart = await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
+      })
+      expect(allowanceStart).toBe(0n)
+      console.log("allowance start", allowanceStart)
+
+      const trigger: Trigger = {
+        chainId: chain.id,
+        tokenAddress: token,
+        amount,
+        approvalAmount
+      }
+
+      const fusionQuote = await meeClient.getOnChainQuote({
+        trigger,
+        instructions: [
+          await mcNexus.build({
+            type: "transfer",
+            data: {
+              recipient: mcNexus.signer.address,
+              tokenAddress: token,
+              amount: runtimeERC20BalanceOf({
+                targetAddress: mcNexus.signer.address,
+                tokenAddress: token
+              }),
+              chainId: chain.id
+            }
+          })
+        ],
+        feeToken: {
+          chainId: chain.id,
+          address: token
+        }
+      })
+
+      expect(fusionQuote).toBeDefined()
+      expect(fusionQuote.trigger).toBeDefined()
+      console.log("fusionQuote", fusionQuote)
+      // // Execute the quote
+      const { hash } = await meeClient.executeFusionQuote({
+        fusionQuote
+      })
+
+      // Wait for the transaction to complete
+      const executeReceipt = await meeClient.waitForSupertransactionReceipt({
+        hash
+      })
+      expect(executeReceipt.transactionStatus).toBe("MINED_SUCCESS")
+      const allowanceEnd = await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
+      })
+      console.log("allowance end", allowanceEnd)
+      console.log("fusionQuote", fusionQuote)
     })
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -476,12 +476,9 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         account: mcNexus.signer
       })
 
-      const resetApprovalReceipt = await publicClient.waitForTransactionReceipt(
-        {
-          hash: resetApprovalHash
-        }
-      )
-      console.log("resetApprovalReceipt", resetApprovalReceipt)
+      await publicClient.waitForTransactionReceipt({
+        hash: resetApprovalHash
+      })
 
       const allowanceStart = await publicClient.readContract({
         address: token,
@@ -490,7 +487,6 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
       })
       expect(allowanceStart).toBe(0n)
-      console.log("allowance start", allowanceStart)
 
       const trigger: Trigger = {
         chainId: chain.id,
@@ -505,12 +501,10 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
           await mcNexus.build({
             type: "transfer",
             data: {
+              // transfer back to the eoa account
               recipient: mcNexus.signer.address,
               tokenAddress: token,
-              amount: runtimeERC20BalanceOf({
-                targetAddress: mcNexus.signer.address,
-                tokenAddress: token
-              }),
+              amount: 1n,
               chainId: chain.id
             }
           })
@@ -520,10 +514,8 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
           address: token
         }
       })
-
       expect(fusionQuote).toBeDefined()
       expect(fusionQuote.trigger).toBeDefined()
-      console.log("fusionQuote", fusionQuote)
       // // Execute the quote
       const { hash } = await meeClient.executeFusionQuote({
         fusionQuote
@@ -540,8 +532,8 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         functionName: "allowance",
         args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
       })
+      console.log("allowance start", allowanceStart)
       console.log("allowance end", allowanceEnd)
-      console.log("fusionQuote", fusionQuote)
     })
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -534,13 +534,6 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       })
       const fees = BigInt(executeReceipt.paymentInfo?.tokenWeiAmount ?? 0n)
       expect(allowanceEnd).toBe(approvalAmount - amount - fees)
-      console.log({
-        eoa: mcNexus.signer.address,
-        eoaAccount: eoaAccount.address,
-        mcNexus: mcNexus.addressOn(chain.id, true),
-        chainId: chain.id,
-        executeReceipt
-      })
     })
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.ts
@@ -96,6 +96,20 @@ const generateTriggerCallFromTrigger = async ({
     triggerCall = ethForwardCall
   } else {
     // erc20 trigger
+
+    // check if we have an explicit `approvalAmount` set and error if it's smaller than the trigger amount
+    if (
+      trigger.approvalAmount &&
+      trigger.amount !== undefined &&
+      trigger.approvalAmount < trigger.amount
+    ) {
+      throw new Error(
+        `Approval amount must be bigger or equal with the amount to approve from the trigger (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
+      )
+    }
+
+    const amount = trigger.approvalAmount ?? trigger.amount
+
     const [
       {
         calls: [approveCall]
@@ -106,7 +120,7 @@ const generateTriggerCallFromTrigger = async ({
         spender,
         tokenAddress: trigger.tokenAddress,
         chainId: trigger.chainId,
-        amount: trigger.amount
+        amount
       } as BuildApproveParameters
     })
     triggerCall = approveCall

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.ts
@@ -104,7 +104,7 @@ const generateTriggerCallFromTrigger = async ({
       trigger.approvalAmount < trigger.amount
     ) {
       throw new Error(
-        `Approval amount must be bigger or equal with the amount to approve from the trigger (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
+        `Approval amount must be bigger or equal with the amount from the trigger (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
       )
     }
 

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -1,10 +1,15 @@
 import {
+  http,
   type Address,
   type Chain,
   type LocalAccount,
   type Transport,
+  createPublicClient,
+  createWalletClient,
+  erc20Abi,
   getContract,
   keccak256,
+  parseUnits,
   toBytes,
   zeroAddress
 } from "viem"
@@ -17,17 +22,16 @@ import {
   toMultichainNexusAccount
 } from "../../../account/toMultiChainNexusAccount"
 import { PERMIT_TYPEHASH, TokenWithPermitAbi } from "../../../constants"
-import { mcUSDC } from "../../../constants/tokens"
+import { mcUSDC, testnetMcUSDC } from "../../../constants/tokens"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import { executeSignedQuote } from "./executeSignedQuote"
 import getFusionQuote from "./getFusionQuote"
 import { type FeeTokenInfo, getQuote } from "./getQuote"
-import { signPermitQuote } from "./signPermitQuote"
+import { type Trigger, signPermitQuote } from "./signPermitQuote"
 import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 
 // @ts-ignore
 const { runPaidTests } = inject("settings")
-
 describe("mee.signPermitQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
@@ -168,7 +172,9 @@ describe("mee.signPermitQuote", () => {
       const signedQuote = await signPermitQuote(meeClient, { fusionQuote })
       const { hash } = await executeSignedQuote(meeClient, { signedQuote })
       console.timeEnd("signPermitQuote:getHash")
-      const receipt = await waitForSupertransactionReceipt(meeClient, { hash })
+      const receipt = await waitForSupertransactionReceipt(meeClient, {
+        hash
+      })
       console.timeEnd("signPermitQuote:receipt")
 
       expect(receipt).toBeDefined()
@@ -180,4 +186,153 @@ describe("mee.signPermitQuote", () => {
       )
       expect(balanceOfRecipient).toBe(trigger.amount)
     })
+})
+
+describe.runIf(runPaidTests)("mee.signPermitQuote - testnet", () => {
+  let network: NetworkConfig
+  let eoaAccount: LocalAccount
+
+  let mcNexus: MultichainSmartAccount
+  let meeClient: MeeClient
+
+  let chain: Chain
+
+  beforeAll(async () => {
+    network = await toNetwork("TESTNET_FROM_ENV_VARS")
+    eoaAccount = network.account!
+    chain = network.chain
+    mcNexus = await toMultichainNexusAccount({
+      chains: [chain],
+      transports: [http()],
+      signer: eoaAccount,
+      index: 1n
+    })
+    meeClient = await createMeeClient({
+      account: mcNexus
+    })
+  })
+
+  describe("custom approvalAmount", () => {
+    test("should fail if approvalAmount is smaller than the trigger amount", async () => {
+      const amount = parseUnits("0.01", 6)
+      const approvalAmount = parseUnits("0.005", 6)
+      const token = testnetMcUSDC.addressOn(network.chain.id)
+      const trigger: Trigger = {
+        chainId: network.chain.id,
+        tokenAddress: token,
+        amount,
+        approvalAmount
+      }
+      const fusionQuote = await meeClient.getOnChainQuote({
+        trigger,
+        instructions: [
+          await mcNexus.build({
+            type: "transfer",
+            data: {
+              // transfer back to the eoa account
+              recipient: mcNexus.signer.address,
+              tokenAddress: token,
+              amount: 1n,
+              chainId: network.chain.id
+            }
+          })
+        ],
+        feeToken: {
+          chainId: network.chain.id,
+          address: token
+        }
+      })
+      expect(fusionQuote).toBeDefined()
+      expect(fusionQuote.trigger).toBeDefined()
+      await expect(
+        meeClient.executeFusionQuote({
+          fusionQuote
+        })
+      ).rejects.toThrow()
+    })
+    test("changes the allowance based on approvalAmount", async () => {
+      // Define the amount to transfer and the custom approval amount (allowance)
+      const amount = parseUnits("0.01", 6)
+      const approvalAmount = parseUnits("0.03", 6)
+      const token = testnetMcUSDC.addressOn(chain.id)
+
+      // Create a wallet client for sending transactions and a public client for reading blockchain state
+      const walletClient = createWalletClient({
+        account: eoaAccount,
+        chain: network.chain,
+        transport: http(network.rpcUrl)
+      })
+      const publicClient = createPublicClient({
+        chain: network.chain,
+        transport: http(network.rpcUrl)
+      })
+      // Set the allowance to 0 before the test to ensure a known state (reset approval)
+      const resetApprovalHash = await walletClient.writeContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "approve",
+        args: [mcNexus.addressOn(chain.id, true), 0n]
+      })
+      await publicClient.waitForTransactionReceipt({
+        hash: resetApprovalHash
+      })
+      // Read the starting allowance (should be 0)
+      const allowanceStart = await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
+      })
+      expect(allowanceStart).toBe(0n)
+
+      // Prepare the trigger with the custom approvalAmount
+      const trigger: Trigger = {
+        chainId: chain.id,
+        tokenAddress: token,
+        amount, // The amount to transfer
+        approvalAmount // The custom allowance to set
+      }
+
+      const fusionQuote = await meeClient.getOnChainQuote({
+        trigger,
+        instructions: [
+          await mcNexus.build({
+            type: "transfer",
+            data: {
+              // transfer back to the eoa account
+              recipient: mcNexus.signer.address,
+              tokenAddress: token,
+              amount: 1n,
+              chainId: chain.id
+            }
+          })
+        ],
+        feeToken: {
+          chainId: chain.id,
+          address: token
+        }
+      })
+      expect(fusionQuote).toBeDefined()
+      expect(fusionQuote.trigger).toBeDefined()
+      // // Execute the quote
+      const { hash } = await meeClient.executeFusionQuote({
+        fusionQuote
+      })
+
+      // Wait for the transaction to complete
+      const executeReceipt = await meeClient.waitForSupertransactionReceipt({
+        hash
+      })
+      expect(executeReceipt.transactionStatus).toBe("MINED_SUCCESS")
+      // Read the ending allowance (should match approvalAmount - the amount that was spent on fees and the amount that was transferred)
+      const allowanceEnd = await publicClient.readContract({
+        address: token,
+        abi: erc20Abi,
+        functionName: "allowance",
+        args: [mcNexus.signer.address, mcNexus.addressOn(chain.id, true)]
+      })
+      const fees = BigInt(executeReceipt.paymentInfo?.tokenWeiAmount ?? 0n)
+      expect(allowanceEnd).toBe(approvalAmount - amount - fees)
+    })
+  })
 })

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -153,12 +153,6 @@ export const signPermitQuote = async (
 
   const amount = trigger.approvalAmount ?? trigger.amount
 
-  console.log("before approve trigger", trigger, {
-    tokenAddress: trigger.tokenAddress,
-    chainId: trigger.chainId,
-    amount
-  })
-
   const { walletClient, address: spender } = account_.deploymentOn(
     trigger.chainId,
     true

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -147,7 +147,7 @@ export const signPermitQuote = async (
     trigger.approvalAmount < trigger.amount
   ) {
     throw new Error(
-      `Approval amount must be bigger or equal with the amount to approve from the trigger (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
+      `Approval amount must be bigger or equal with the amount from the trigger (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
     )
   }
 

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -140,14 +140,14 @@ export const signPermitQuote = async (
   if (!trigger.amount)
     throw new Error("Amount is required to sign a permit quote")
 
-  // check if we have an explicit `approvalAmount` set and error if it's smaller than the default amount
+  // check if we have an explicit `approvalAmount` set and error if it's smaller than the trigger amount
   if (
     trigger.approvalAmount &&
     trigger.amount !== undefined &&
     trigger.approvalAmount < trigger.amount
   ) {
     throw new Error(
-      `Approval amount must be at bigger or equal with the default amount to approve (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
+      `Approval amount must be bigger or equal with the amount to approve from the trigger (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
     )
   }
 

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -49,6 +49,11 @@ export type TokenTrigger = {
    */
   amount?: bigint
   /**
+   * A custom amount to approve as the trigger
+   * @example 1000000n // 1 USDC (6 decimals)
+   */
+  approvalAmount?: bigint
+  /**
    * custom gas limit can be added to override the default 50_000 gas limit
    */
   gasLimit?: bigint
@@ -135,6 +140,25 @@ export const signPermitQuote = async (
   if (!trigger.amount)
     throw new Error("Amount is required to sign a permit quote")
 
+  // check if we have an explicit `approvalAmount` set and error if it's smaller than the default amount
+  if (
+    trigger.approvalAmount &&
+    trigger.amount !== undefined &&
+    trigger.approvalAmount < trigger.amount
+  ) {
+    throw new Error(
+      `Approval amount must be at bigger or equal with the default amount to approve (triggerAmount: ${trigger.amount} amount: ${trigger.approvalAmount})`
+    )
+  }
+
+  const amount = trigger.approvalAmount ?? trigger.amount
+
+  console.log("before approve trigger", trigger, {
+    tokenAddress: trigger.tokenAddress,
+    chainId: trigger.chainId,
+    amount
+  })
+
   const { walletClient, address: spender } = account_.deploymentOn(
     trigger.chainId,
     true
@@ -185,7 +209,7 @@ export const signPermitQuote = async (
     message: {
       owner,
       spender: spender,
-      value: trigger.amount,
+      value: amount,
       nonce,
       deadline: BigInt(quote.hash)
     },
@@ -212,7 +236,7 @@ export const signPermitQuote = async (
       spender,
       domainSeparator,
       PERMIT_TYPEHASH,
-      trigger.amount,
+      amount,
       BigInt(trigger.chainId),
       nonce,
       sigComponents.v!,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the handling of `approvalAmount` in the `trigger` object across several functions, ensuring that it is validated against the `amount`. It also includes updates to tests related to these changes.

### Detailed summary
- Updated `trigger` object to spread properties using `...trigger` in `getPermitQuote.ts` and `getOnChainQuote.ts`.
- Added validation for `approvalAmount` in `signOnChainQuote.ts` and `signPermitQuote.ts`.
- Adjusted tests to ensure `approvalAmount` is greater than or equal to `amount`.
- Refactored `createMeeClient` calls for better readability.
- Added tests for scenarios involving `approvalAmount` in `signPermitQuote.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->