### PR TITLE
fix: remove bridge in test

### DIFF
--- a/src/sdk/templates/mee/createOneClickDepositTemplate.test.ts
+++ b/src/sdk/templates/mee/createOneClickDepositTemplate.test.ts
@@ -80,14 +80,7 @@ describe("createOneClickDepositTemplate", () => {
       },
       bridgeInstructions: async ({ sourceChain, destChain, amount }) => {
         // dummy brige call
-        return mcNexus.build({
-          type: "intent",
-          data: {
-            amount, // amount here,
-            mcToken: testnetMcUSDC,
-            toChain: destChain
-          }
-        })
+        return []
       },
       destChainInstructions: async ({ sourceChain, destChain }) => {
         // dummy instructions
@@ -129,11 +122,10 @@ describe("createOneClickDepositTemplate", () => {
       destChain: destinationChain,
       amount: parseUnits("1", 6)
     })
-    expect(instructions.length).toBe(4)
+    expect(instructions.length).toBe(3)
     expect(instructions[0].chainId).toBe(sourceChain.id)
-    expect(instructions[1].chainId).toBe(sourceChain.id)
+    expect(instructions[1].chainId).toBe(destinationChain.id)
     expect(instructions[2].chainId).toBe(destinationChain.id)
-    expect(instructions[3].chainId).toBe(destinationChain.id)
   })
   it("should call the source/bridge/destination instructions", async () => {
     // mock the source/bridge/destination instructions

--- a/src/sdk/templates/mee/createOneClickDepositTemplate.test.ts
+++ b/src/sdk/templates/mee/createOneClickDepositTemplate.test.ts
@@ -79,7 +79,6 @@ describe("createOneClickDepositTemplate", () => {
         })
       },
       bridgeInstructions: async ({ sourceChain, destChain, amount }) => {
-        // dummy brige call
         return []
       },
       destChainInstructions: async ({ sourceChain, destChain }) => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR refactors the `bridgeInstructions` function and updates the associated test cases in the `createOneClickDepositTemplate` to reflect the changes in expected behavior.

### Detailed summary
- Changed `bridgeInstructions` to return an empty array instead of a `mcNexus.build` call.
- Updated the expected length of `instructions` from 4 to 3.
- Adjusted the expected `chainId` assertions in the test to match the new logic.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->