### PR TITLE
feat: multichain session enable object for smart sessions

### DIFF
--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -14,7 +14,7 @@ import {
   runtimeERC20BalanceOf,
   runtimeNonceOf
 } from "../../../modules/utils/composabilityCalls"
-import type { GrantPermissionResponse } from "../../../modules/validators/smartSessions/decorators/grantPermission"
+import type { GrantPermissionResponseEntry } from "../../../modules/validators/smartSessions/decorators/grantPermission"
 import createHttpClient, { type Url } from "../../createHttpClient"
 import {
   type BaseMeeClient,
@@ -414,7 +414,7 @@ export interface MeeFilledUserOpDetails {
   /** Cleanup userop flag - Special user op */
   isCleanUpUserOp?: boolean
   /** Optional Session details for redeeming a permission */
-  sessionDetails?: GrantPermissionResponse
+  sessionDetails?: GrantPermissionResponseEntry
   /** Short encoding flag @see QuoteRequest.shortEncoding
    *  It is expected to be set here because it is returned by the node
    *  and the node always knows if the given superTxn entry's hash

--- a/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
@@ -74,8 +74,8 @@ export type GrantPermissionParameters<
 export type GrantPermissionResponse = Prettify<
   Omit<
     Awaited<ReturnType<typeof getEnableSessionDetails>>,
-    "permissionEnableHash" 
-  > 
+    "permissionEnableHash"
+  >
 >[]
 
 export async function grantPermissionPersonalSign<
@@ -86,7 +86,6 @@ export async function grantPermissionPersonalSign<
 ): Promise<GrantPermissionResponse> {
   const { sessions, accountsAndChainIds, clients, signer } =
     await prepareForGrantingPermission(nexusClient, parameters)
-  
 
   // re-implement getEnableSessionDetails so it takes an array nexusAccountsForRhinestone
   // and uses one account for every chain coz it can have different address for every chain
@@ -98,7 +97,7 @@ export async function grantPermissionPersonalSign<
   const sessionDetailsWithPermissionEnableHash = await getEnableSessionDetails({
     enableMode: SmartSessionMode.UNSAFE_ENABLE,
     sessions,
-    accountsAndChainIds[0],
+    account: accountsAndChainIds[0].account,
     clients,
     enableValidatorAddress: zeroAddress, // default validator
     ignoreSecurityAttestations: true
@@ -119,9 +118,9 @@ export async function grantPermissionPersonalSign<
 
 /**
  * Grants the permission signed with typed data signature
- * @param nexusClient 
- * @param parameters 
- * @returns 
+ * @param nexusClient
+ * @param parameters
+ * @returns
  */
 
 export async function grantPermissionTypedDataSign<
@@ -200,75 +199,75 @@ export async function grantPermissionTypedDataSign<
     })
   }
 
-  const permissionEnableSig =
-    await signer.signTypedData({
-      domain: {
-        name: "SmartSession",
-        version: "1"
-      },
-      types: {
-        PolicyData: [
-          { name: "policy", type: "address" },
-          { name: "initData", type: "bytes" }
-        ],
-        ActionData: [
-          { name: "actionTargetSelector", type: "bytes4" },
-          { name: "actionTarget", type: "address" },
-          { name: "actionPolicies", type: "PolicyData[]" }
-        ],
-        ERC7739Context: [
-          { name: "appDomainSeparator", type: "bytes32" },
-          { name: "contentName", type: "string[]" }
-        ],
-        ERC7739Data: [
-          { name: "allowedERC7739Content", type: "ERC7739Context[]" },
-          { name: "erc1271Policies", type: "PolicyData[]" }
-        ],
-        SignedPermissions: [
-          { name: "permitGenericPolicy", type: "bool" },
-          { name: "permitAdminAccess", type: "bool" },
-          { name: "ignoreSecurityAttestations", type: "bool" },
-          { name: "permitERC4337Paymaster", type: "bool" },
-          { name: "userOpPolicies", type: "PolicyData[]" },
-          { name: "erc7739Policies", type: "ERC7739Data" },
-          { name: "actions", type: "ActionData[]" }
-        ],
-        SignedSession: [
-          { name: "account", type: "address" },
-          { name: "permissions", type: "SignedPermissions" },
-          { name: "sessionValidator", type: "address" },
-          { name: "sessionValidatorInitData", type: "bytes" },
-          { name: "salt", type: "bytes32" },
-          { name: "smartSession", type: "address" },
-          { name: "nonce", type: "uint256" }
-        ],
-        ChainSession: [
-          { name: "chainId", type: "uint64" },
-          { name: "session", type: "SignedSession" }
-        ],
-        MultiChainSession: [
-          { name: "sessionsAndChainIds", type: "ChainSession[]" }
-        ]
-      },
-      primaryType: "MultiChainSession",
-      message: {
-        sessionsAndChainIds: chainSessions
-      }
-    })
+  const permissionEnableSig = await signer.signTypedData({
+    domain: {
+      name: "SmartSession",
+      version: "1"
+    },
+    types: {
+      PolicyData: [
+        { name: "policy", type: "address" },
+        { name: "initData", type: "bytes" }
+      ],
+      ActionData: [
+        { name: "actionTargetSelector", type: "bytes4" },
+        { name: "actionTarget", type: "address" },
+        { name: "actionPolicies", type: "PolicyData[]" }
+      ],
+      ERC7739Context: [
+        { name: "appDomainSeparator", type: "bytes32" },
+        { name: "contentName", type: "string[]" }
+      ],
+      ERC7739Data: [
+        { name: "allowedERC7739Content", type: "ERC7739Context[]" },
+        { name: "erc1271Policies", type: "PolicyData[]" }
+      ],
+      SignedPermissions: [
+        { name: "permitGenericPolicy", type: "bool" },
+        { name: "permitAdminAccess", type: "bool" },
+        { name: "ignoreSecurityAttestations", type: "bool" },
+        { name: "permitERC4337Paymaster", type: "bool" },
+        { name: "userOpPolicies", type: "PolicyData[]" },
+        { name: "erc7739Policies", type: "ERC7739Data" },
+        { name: "actions", type: "ActionData[]" }
+      ],
+      SignedSession: [
+        { name: "account", type: "address" },
+        { name: "permissions", type: "SignedPermissions" },
+        { name: "sessionValidator", type: "address" },
+        { name: "sessionValidatorInitData", type: "bytes" },
+        { name: "salt", type: "bytes32" },
+        { name: "smartSession", type: "address" },
+        { name: "nonce", type: "uint256" }
+      ],
+      ChainSession: [
+        { name: "chainId", type: "uint64" },
+        { name: "session", type: "SignedSession" }
+      ],
+      MultiChainSession: [
+        { name: "sessionsAndChainIds", type: "ChainSession[]" }
+      ]
+    },
+    primaryType: "MultiChainSession",
+    message: {
+      sessionsAndChainIds: chainSessions
+    }
+  })
 
-  const sessionDetailsSignature = getOwnableValidatorMockSignature({ threshold: 1 })
+  const sessionDetailsSignature = getOwnableValidatorMockSignature({
+    threshold: 1
+  })
 
   const sessionDetailsArray = sessions.map((session) => {
-    
     const permissionId = getPermissionId({
       session: session
     })
 
     const sessionIndex = sessions.indexOf(session)
 
-    const accountType = accountsAndChainIds.find(
-      (a) => a.chainId === session.chainId
-    )?.account.type ?? "nexus"
+    const accountType =
+      accountsAndChainIds.find((a) => a.chainId === session.chainId)?.account
+        .type ?? "nexus"
 
     return {
       mode: SmartSessionMode.UNSAFE_ENABLE,
@@ -286,7 +285,7 @@ export async function grantPermissionTypedDataSign<
       }
     }
   })
-  
+
   return sessionDetailsArray
 }
 

--- a/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
@@ -74,9 +74,9 @@ export type GrantPermissionParameters<
 export type GrantPermissionResponse = Prettify<
   Omit<
     Awaited<ReturnType<typeof getEnableSessionDetails>>,
-    "permissionEnableHash"
-  >
->
+    "permissionEnableHash" 
+  > 
+>[]
 
 export async function grantPermissionPersonalSign<
   TModularSmartAccount extends ModularSmartAccount | undefined
@@ -84,25 +84,22 @@ export async function grantPermissionPersonalSign<
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>
 ): Promise<GrantPermissionResponse> {
-  const { sessions, nexusAccountsForRhinestone, publicClients, signer } =
+  const { sessions, accountsAndChainIds, clients, signer } =
     await prepareForGrantingPermission(nexusClient, parameters)
-  for (const [index, nexusAccountForRhinestone] of nexusAccountsForRhinestone.entries()) {
-  }
-
+  
 
   // re-implement getEnableSessionDetails so it takes an array nexusAccountsForRhinestone
   // and uses one account for every chain coz it can have different address for every chain
-  // but we sign only once 
-  // so the sessionDetails object is just modified for all the chains: to have different: 
-  // - session to enable 
+  // but we sign only once
+  // so the sessionDetails object is just modified for all the chains: to have different:
+  // - session to enable
   // - chain digest index
 
-  
   const sessionDetailsWithPermissionEnableHash = await getEnableSessionDetails({
     enableMode: SmartSessionMode.UNSAFE_ENABLE,
-    sessions: [session],
-    account: nexusAccountForRhinestone,
-    clients: [publicClient],
+    sessions,
+    accountsAndChainIds[0],
+    clients,
     enableValidatorAddress: zeroAddress, // default validator
     ignoreSecurityAttestations: true
   })
@@ -120,19 +117,26 @@ export async function grantPermissionPersonalSign<
   return sessionDetails
 }
 
+/**
+ * Grants the permission signed with typed data signature
+ * @param nexusClient 
+ * @param parameters 
+ * @returns 
+ */
+
 export async function grantPermissionTypedDataSign<
   TModularSmartAccount extends ModularSmartAccount | undefined
 >(
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>
 ): Promise<GrantPermissionResponse> {
-  const { session, nexusAccountForRhinestone, publicClient, signer } =
+  const { sessions, accountsAndChainIds, clients, signer } =
     await prepareForGrantingPermission(nexusClient, parameters)
 
   // keeping this algorithm with `for` loop
   // because we are going to use multiple sessions in the future
-  const sessions = [session]
-  const clients = [publicClient]
+  //const sessions = [session]
+  //const clients = [publicClient]
 
   const chainDigests: { chainId: bigint; sessionDigest: any }[] = []
   const chainSessions: ChainSession[] = []
@@ -149,15 +153,23 @@ export async function grantPermissionTypedDataSign<
       throw new Error(`Client not found for chainId ${session.chainId}`)
     }
 
+    const account = accountsAndChainIds.find(
+      (a) => a.chainId === session.chainId
+    )?.account
+
+    if (!account) {
+      throw new Error(`Account not found for chainId ${session.chainId}`)
+    }
+
     const sessionNonce = await getSessionNonce({
       client,
-      account: nexusAccountForRhinestone,
+      account,
       permissionId
     })
 
     const sessionDigest = await getSessionDigest({
       client,
-      account: nexusAccountForRhinestone,
+      account,
       session,
       mode: SmartSessionMode.UNSAFE_ENABLE,
       permissionId
@@ -181,36 +193,14 @@ export async function grantPermissionTypedDataSign<
           erc7739Policies: session.erc7739Policies,
           actions: session.actions
         },
-        account: nexusAccountForRhinestone.address,
+        account: account.address,
         smartSession: GLOBAL_CONSTANTS.SMART_SESSIONS_ADDRESS,
         nonce: sessionNonce
       }
     })
   }
 
-  // const sessionToEnable = sessions[sessionIndex || 0]
-  const sessionToEnable = sessions[0] // for now it is always 0
-  const permissionId = getPermissionId({
-    session: sessionToEnable
-  })
-
-  const sessionDetails = {
-    mode: SmartSessionMode.UNSAFE_ENABLE,
-    permissionId,
-    signature: "0x" as Hex,
-    enableSessionData: {
-      enableSession: {
-        chainDigestIndex: 0, // TODO: sessionIndex || 0,
-        hashesAndChainIds: chainDigests,
-        sessionToEnable,
-        permissionEnableSig: "0x" as Hex
-      },
-      validator: zeroAddress, // default validator
-      accountType: nexusAccountForRhinestone.type
-    }
-  }
-
-  sessionDetails.enableSessionData.enableSession.permissionEnableSig =
+  const permissionEnableSig =
     await signer.signTypedData({
       domain: {
         name: "SmartSession",
@@ -266,15 +256,44 @@ export async function grantPermissionTypedDataSign<
       }
     })
 
-  sessionDetails.signature = getOwnableValidatorMockSignature({ threshold: 1 })
+  const sessionDetailsSignature = getOwnableValidatorMockSignature({ threshold: 1 })
 
-  return sessionDetails
+  const sessionDetailsArray = sessions.map((session) => {
+    
+    const permissionId = getPermissionId({
+      session: session
+    })
+
+    const sessionIndex = sessions.indexOf(session)
+
+    const accountType = accountsAndChainIds.find(
+      (a) => a.chainId === session.chainId
+    )?.account.type ?? "nexus"
+
+    return {
+      mode: SmartSessionMode.UNSAFE_ENABLE,
+      permissionId,
+      signature: sessionDetailsSignature,
+      enableSessionData: {
+        enableSession: {
+          chainDigestIndex: sessionIndex,
+          hashesAndChainIds: chainDigests,
+          sessionToEnable: session,
+          permissionEnableSig: permissionEnableSig
+        },
+        validator: zeroAddress, // default validator
+        accountType
+      }
+    }
+  })
+  
+  return sessionDetailsArray
 }
 
 export type PrepareForGrantingPermissionResponse = {
   sessions: Session[]
   accountsAndChainIds: AccountAndChainId[]
-  publicClients: PublicClient[]
+  clients: PublicClient[]
   signer: any
 }
 
@@ -289,10 +308,9 @@ const prepareForGrantingPermission = async <
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>
 ): Promise<PrepareForGrantingPermissionResponse> => {
-
-  let sessions: Session[] = []
-  let accountsAndChainIds: AccountAndChainId[] = []
-  let publicClients: PublicClient[] = []
+  const sessions: Session[] = []
+  const accountsAndChainIds: AccountAndChainId[] = []
+  const publicClients: PublicClient[] = []
   const signer = nexusClient.account?.signer || parameters[0].account?.signer
   if (!signer) {
     throw new Error("Signer is not set")
@@ -319,7 +337,7 @@ const prepareForGrantingPermission = async <
     if (!publicClient) {
       throw new Error("Public client is not set")
     }
-    
+
     const session: Session = {
       sessionValidator: OWNABLE_VALIDATOR_ADDRESS,
       permitERC4337Paymaster: false,
@@ -333,26 +351,24 @@ const prepareForGrantingPermission = async <
       chainId: bigChainId ?? BigInt(chainIdFromAccount),
       ...session_
     }
-  
-    const accountAndChainId: AccountAndChainId = 
-    { 
+
+    const accountAndChainId: AccountAndChainId = {
       account: getAccount({
         address: await nexusAccount.getAddress(),
-        type: "nexus",
+        type: "nexus"
       }),
       chainId: bigChainId ?? BigInt(chainIdFromAccount)
     }
-    
+
     sessions.push(session)
     accountsAndChainIds.push(accountAndChainId)
     publicClients.push(publicClient)
   }
-  
-    return {
-      sessions,
-      accountsAndChainIds,
-      publicClients,
-      signer
-    }
-  
+
+  return {
+    sessions,
+    accountsAndChainIds,
+    clients: publicClients,
+    signer
+  }
 }

--- a/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
@@ -71,13 +71,16 @@ export type GrantPermissionParameters<
   TModularSmartAccount extends ModularSmartAccount | undefined
 > = GrantPermissionParameterEntry<TModularSmartAccount>[]
 
-// The session details in stringified format.
-export type GrantPermissionResponse = Prettify<
+// session details for a single chain that can be used to enable and use the permission
+export type GrantPermissionResponseEntry = Prettify<
   Omit<
     Awaited<ReturnType<typeof getEnableSessionDetails>>,
     "permissionEnableHash"
   >
->[]
+>
+
+// The array of session details that can be used to enable and use the permission
+export type GrantPermissionResponse = GrantPermissionResponseEntry[]
 
 /**
  * Grants the permission signed with personal signature
@@ -290,7 +293,6 @@ async function getTypedDataEnableSessionSignature(
 /**
  * Prepare for granting permission
  */
-
 export type PrepareForGrantingPermissionResponse = {
   sessions: Session[]
   accountsAndChainIds: AccountAndChainId[]
@@ -312,7 +314,7 @@ const prepareForGrantingPermission = async <
   const sessions: Session[] = []
   const accountsAndChainIds: AccountAndChainId[] = []
   const publicClients: PublicClient[] = []
-  const signer = nexusClient.account?.signer || parameters[0].account?.signer
+  const signer = nexusClient?.account?.signer || parameters[0].account?.signer
   if (!signer) {
     throw new Error("Signer is not set")
   }

--- a/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
@@ -10,7 +10,7 @@ import {
   SmartSessionMode,
   encodeValidationData,
   getAccount,
-  getEnableSessionDetails,
+  type getEnableSessionDetails,
   getOwnableValidatorMockSignature,
   getPermissionId,
   getSessionDigest,
@@ -104,7 +104,7 @@ export async function grantPermissionTypedDataSign<
 }
 
 async function grantPermission<
-TModularSmartAccount extends ModularSmartAccount | undefined
+  TModularSmartAccount extends ModularSmartAccount | undefined
 >(
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>,
@@ -175,9 +175,10 @@ TModularSmartAccount extends ModularSmartAccount | undefined
     })
   }
 
-  const permissionEnableSig = mode === "PERSONAL_SIGN" ? 
-    await getPersonalEnableSessionSignature(chainSessions, signer) : 
-    await getTypedDataEnableSessionSignature(chainSessions, signer)
+  const permissionEnableSig =
+    mode === "PERSONAL_SIGN"
+      ? await getPersonalEnableSessionSignature(chainSessions, signer)
+      : await getTypedDataEnableSessionSignature(chainSessions, signer)
 
   const sessionDetailsSignature = getOwnableValidatorMockSignature({
     threshold: 1
@@ -218,12 +219,18 @@ TModularSmartAccount extends ModularSmartAccount | undefined
  * Handle enable session signatures
  */
 
-async function getPersonalEnableSessionSignature(chainSessions: ChainSession[], signer: any): Promise<Hex> {
+async function getPersonalEnableSessionSignature(
+  chainSessions: ChainSession[],
+  signer: any
+): Promise<Hex> {
   const permissionEnableHash = hashChainSessions(chainSessions)
   return await signer.signMessage({ message: { raw: permissionEnableHash } })
 }
 
-async function getTypedDataEnableSessionSignature(chainSessions: ChainSession[], signer: any): Promise<Hex> {
+async function getTypedDataEnableSessionSignature(
+  chainSessions: ChainSession[],
+  signer: any
+): Promise<Hex> {
   return await signer.signTypedData({
     domain: {
       name: "SmartSession",

--- a/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
@@ -15,7 +15,8 @@ import {
   getPermissionId,
   getSessionDigest,
   getSessionNonce,
-  getSudoPolicy
+  getSudoPolicy,
+  hashChainSessions
 } from "@rhinestone/module-sdk"
 import {
   type Address,
@@ -78,64 +79,39 @@ export type GrantPermissionResponse = Prettify<
   >
 >[]
 
+/**
+ * Grants the permission signed with personal signature
+ */
 export async function grantPermissionPersonalSign<
   TModularSmartAccount extends ModularSmartAccount | undefined
 >(
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>
 ): Promise<GrantPermissionResponse> {
-  const { sessions, accountsAndChainIds, clients, signer } =
-    await prepareForGrantingPermission(nexusClient, parameters)
-
-  // re-implement getEnableSessionDetails so it takes an array nexusAccountsForRhinestone
-  // and uses one account for every chain coz it can have different address for every chain
-  // but we sign only once
-  // so the sessionDetails object is just modified for all the chains: to have different:
-  // - session to enable
-  // - chain digest index
-
-  const sessionDetailsWithPermissionEnableHash = await getEnableSessionDetails({
-    enableMode: SmartSessionMode.UNSAFE_ENABLE,
-    sessions,
-    account: accountsAndChainIds[0].account,
-    clients,
-    enableValidatorAddress: zeroAddress, // default validator
-    ignoreSecurityAttestations: true
-  })
-
-  const { permissionEnableHash, ...sessionDetails } =
-    sessionDetailsWithPermissionEnableHash
-
-  if (!sessionDetails.enableSessionData?.enableSession.permissionEnableSig) {
-    throw new Error("enableSessionData is undefined")
-  }
-  sessionDetails.enableSessionData.enableSession.permissionEnableSig =
-    await signer.signMessage({ message: { raw: permissionEnableHash } })
-
-  sessionDetails.signature = getOwnableValidatorMockSignature({ threshold: 1 })
-  return sessionDetails
+  return await grantPermission(nexusClient, parameters, "PERSONAL_SIGN")
 }
 
 /**
  * Grants the permission signed with typed data signature
- * @param nexusClient
- * @param parameters
- * @returns
  */
-
 export async function grantPermissionTypedDataSign<
   TModularSmartAccount extends ModularSmartAccount | undefined
 >(
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>
 ): Promise<GrantPermissionResponse> {
+  return await grantPermission(nexusClient, parameters, "TYPED_DATA_SIGN")
+}
+
+async function grantPermission<
+TModularSmartAccount extends ModularSmartAccount | undefined
+>(
+  nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
+  parameters: GrantPermissionParameters<TModularSmartAccount>,
+  mode: "PERSONAL_SIGN" | "TYPED_DATA_SIGN"
+): Promise<GrantPermissionResponse> {
   const { sessions, accountsAndChainIds, clients, signer } =
     await prepareForGrantingPermission(nexusClient, parameters)
-
-  // keeping this algorithm with `for` loop
-  // because we are going to use multiple sessions in the future
-  //const sessions = [session]
-  //const clients = [publicClient]
 
   const chainDigests: { chainId: bigint; sessionDigest: any }[] = []
   const chainSessions: ChainSession[] = []
@@ -199,7 +175,56 @@ export async function grantPermissionTypedDataSign<
     })
   }
 
-  const permissionEnableSig = await signer.signTypedData({
+  const permissionEnableSig = mode === "PERSONAL_SIGN" ? 
+    await getPersonalEnableSessionSignature(chainSessions, signer) : 
+    await getTypedDataEnableSessionSignature(chainSessions, signer)
+
+  const sessionDetailsSignature = getOwnableValidatorMockSignature({
+    threshold: 1
+  })
+
+  const sessionDetailsArray = sessions.map((session) => {
+    const permissionId = getPermissionId({
+      session: session
+    })
+
+    const sessionIndex = sessions.indexOf(session)
+
+    const accountType =
+      accountsAndChainIds.find((a) => a.chainId === session.chainId)?.account
+        .type ?? "nexus"
+
+    return {
+      mode: SmartSessionMode.UNSAFE_ENABLE,
+      permissionId,
+      signature: sessionDetailsSignature,
+      enableSessionData: {
+        enableSession: {
+          chainDigestIndex: sessionIndex,
+          hashesAndChainIds: chainDigests,
+          sessionToEnable: session,
+          permissionEnableSig: permissionEnableSig
+        },
+        validator: zeroAddress, // default validator
+        accountType
+      }
+    }
+  })
+
+  return sessionDetailsArray
+}
+
+/**
+ * Handle enable session signatures
+ */
+
+async function getPersonalEnableSessionSignature(chainSessions: ChainSession[], signer: any): Promise<Hex> {
+  const permissionEnableHash = hashChainSessions(chainSessions)
+  return await signer.signMessage({ message: { raw: permissionEnableHash } })
+}
+
+async function getTypedDataEnableSessionSignature(chainSessions: ChainSession[], signer: any): Promise<Hex> {
+  return await signer.signTypedData({
     domain: {
       name: "SmartSession",
       version: "1"
@@ -253,41 +278,11 @@ export async function grantPermissionTypedDataSign<
       sessionsAndChainIds: chainSessions
     }
   })
-
-  const sessionDetailsSignature = getOwnableValidatorMockSignature({
-    threshold: 1
-  })
-
-  const sessionDetailsArray = sessions.map((session) => {
-    const permissionId = getPermissionId({
-      session: session
-    })
-
-    const sessionIndex = sessions.indexOf(session)
-
-    const accountType =
-      accountsAndChainIds.find((a) => a.chainId === session.chainId)?.account
-        .type ?? "nexus"
-
-    return {
-      mode: SmartSessionMode.UNSAFE_ENABLE,
-      permissionId,
-      signature: sessionDetailsSignature,
-      enableSessionData: {
-        enableSession: {
-          chainDigestIndex: sessionIndex,
-          hashesAndChainIds: chainDigests,
-          sessionToEnable: session,
-          permissionEnableSig: permissionEnableSig
-        },
-        validator: zeroAddress, // default validator
-        accountType
-      }
-    }
-  })
-
-  return sessionDetailsArray
 }
+
+/**
+ * Prepare for granting permission
+ */
 
 export type PrepareForGrantingPermissionResponse = {
   sessions: Session[]

--- a/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/grantPermission.ts
@@ -56,7 +56,7 @@ export type RequiredSessionParams = RequiredBy<
   "actions"
 >
 
-export type GrantPermissionParameters<
+export type GrantPermissionParameterEntry<
   TModularSmartAccount extends ModularSmartAccount | undefined
 > = Prettify<
   Partial<PrettifiedSession> &
@@ -65,6 +65,10 @@ export type GrantPermissionParameters<
       redeemer: Address
     } & { account?: TModularSmartAccount }
 >
+
+export type GrantPermissionParameters<
+  TModularSmartAccount extends ModularSmartAccount | undefined
+> = GrantPermissionParameterEntry<TModularSmartAccount>[]
 
 // The session details in stringified format.
 export type GrantPermissionResponse = Prettify<
@@ -80,9 +84,20 @@ export async function grantPermissionPersonalSign<
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>
 ): Promise<GrantPermissionResponse> {
-  const { session, nexusAccountForRhinestone, publicClient, signer } =
+  const { sessions, nexusAccountsForRhinestone, publicClients, signer } =
     await prepareForGrantingPermission(nexusClient, parameters)
+  for (const [index, nexusAccountForRhinestone] of nexusAccountsForRhinestone.entries()) {
+  }
 
+
+  // re-implement getEnableSessionDetails so it takes an array nexusAccountsForRhinestone
+  // and uses one account for every chain coz it can have different address for every chain
+  // but we sign only once 
+  // so the sessionDetails object is just modified for all the chains: to have different: 
+  // - session to enable 
+  // - chain digest index
+
+  
   const sessionDetailsWithPermissionEnableHash = await getEnableSessionDetails({
     enableMode: SmartSessionMode.UNSAFE_ENABLE,
     sessions: [session],
@@ -114,7 +129,7 @@ export async function grantPermissionTypedDataSign<
   const { session, nexusAccountForRhinestone, publicClient, signer } =
     await prepareForGrantingPermission(nexusClient, parameters)
 
-  // keeping this ago with `for` loop
+  // keeping this algorithm with `for` loop
   // because we are going to use multiple sessions in the future
   const sessions = [session]
   const clients = [publicClient]
@@ -195,28 +210,6 @@ export async function grantPermissionTypedDataSign<
     }
   }
 
-  /* 
-  const sessionDetailsWithPermissionEnableHash = await getEnableSessionDetails({
-    enableMode: SmartSessionMode.UNSAFE_ENABLE,
-    sessions: [session],
-    account: nexusAccountForRhinestone,
-    clients: [publicClient],
-    enableValidatorAddress: zeroAddress, // default validator
-    ignoreSecurityAttestations: true
-  })
-
-   const { permissionEnableHash, ...sessionDetails2 } =
-    sessionDetailsWithPermissionEnableHash  */
-
-  // console.log("sessionDetails comparison ", sessionDetails == sessionDetails2)
-  /* console.log("sessionDetails hashesAndChainIds ", sessionDetails.enableSessionData.enableSession.hashesAndChainIds.map(h => h.chainId), sessionDetails.enableSessionData.enableSession.hashesAndChainIds.map(h => h.sessionDigest))
-  console.log("sessionDetails2 hashesAndChainIds ", sessionDetails2.enableSessionData.enableSession.hashesAndChainIds.map(h => h.chainId), sessionDetails2.enableSessionData.enableSession.hashesAndChainIds.map(h => h.sessionDigest))
-
-  console.log("sessionDetails sessionToEnable ", sessionDetails.enableSessionData.enableSession.sessionToEnable)
-  console.log("sessionDetails2 sessionToEnable ", sessionDetails2.enableSessionData.enableSession.sessionToEnable) */
-
-  // const typedHash = hashChainSessions(chainSessions)
-
   sessionDetails.enableSessionData.enableSession.permissionEnableSig =
     await signer.signTypedData({
       domain: {
@@ -279,10 +272,15 @@ export async function grantPermissionTypedDataSign<
 }
 
 export type PrepareForGrantingPermissionResponse = {
-  session: Session
-  nexusAccountForRhinestone: Account
-  publicClient: PublicClient
+  sessions: Session[]
+  accountsAndChainIds: AccountAndChainId[]
+  publicClients: PublicClient[]
   signer: any
+}
+
+export type AccountAndChainId = {
+  account: Account
+  chainId: bigint
 }
 
 const prepareForGrantingPermission = async <
@@ -291,53 +289,70 @@ const prepareForGrantingPermission = async <
   nexusClient: Client<Transport, Chain | undefined, TModularSmartAccount>,
   parameters: GrantPermissionParameters<TModularSmartAccount>
 ): Promise<PrepareForGrantingPermissionResponse> => {
-  const {
-    account: nexusAccount = nexusClient.account,
-    redeemer,
-    chainId: bigChainId,
-    ...session_
-  } = parameters
-  const publicClient = nexusAccount?.client as PublicClient
-  const signer = nexusAccount?.signer
-  const chainIdFromAccount = nexusAccount?.client?.chain?.id
-  if (!chainIdFromAccount) {
-    throw new Error("Chain ID is not set")
-  }
-  if (!nexusAccount) {
-    throw new AccountNotFoundError({
-      docsPath: "/nexus-client/methods#sendtransaction"
-    })
-  }
-  if (!publicClient) {
-    throw new Error("Public client is not set")
-  }
+
+  let sessions: Session[] = []
+  let accountsAndChainIds: AccountAndChainId[] = []
+  let publicClients: PublicClient[] = []
+  const signer = nexusClient.account?.signer || parameters[0].account?.signer
   if (!signer) {
     throw new Error("Signer is not set")
   }
 
-  const session: Session = {
-    sessionValidator: OWNABLE_VALIDATOR_ADDRESS,
-    permitERC4337Paymaster: false,
-    sessionValidatorInitData: encodeValidationData({
-      threshold: 1,
-      owners: [redeemer]
-    }),
-    salt: generateSalt(),
-    userOpPolicies: session_?.permitERC4337Paymaster ? [getSudoPolicy()] : [],
-    erc7739Policies: { allowedERC7739Content: [], erc1271Policies: [] },
-    chainId: bigChainId ?? BigInt(chainIdFromAccount),
-    ...session_
-  }
+  for (const parameterEntry of parameters) {
+    const {
+      account: nexusAccount = nexusClient.account,
+      redeemer,
+      chainId: bigChainId,
+      ...session_
+    } = parameterEntry
+    const publicClient = nexusAccount?.client as PublicClient
+    const chainIdFromAccount = nexusAccount?.client?.chain?.id
 
-  const nexusAccountForRhinestone = getAccount({
-    address: await nexusAccount.getAddress(),
-    type: "nexus"
-  })
-
-  return {
-    session,
-    nexusAccountForRhinestone,
-    publicClient,
-    signer
+    if (!chainIdFromAccount) {
+      throw new Error("Chain ID is not set")
+    }
+    if (!nexusAccount) {
+      throw new AccountNotFoundError({
+        docsPath: "/nexus-client/methods#sendtransaction"
+      })
+    }
+    if (!publicClient) {
+      throw new Error("Public client is not set")
+    }
+    
+    const session: Session = {
+      sessionValidator: OWNABLE_VALIDATOR_ADDRESS,
+      permitERC4337Paymaster: false,
+      sessionValidatorInitData: encodeValidationData({
+        threshold: 1,
+        owners: [redeemer]
+      }),
+      salt: generateSalt(),
+      userOpPolicies: session_?.permitERC4337Paymaster ? [getSudoPolicy()] : [],
+      erc7739Policies: { allowedERC7739Content: [], erc1271Policies: [] },
+      chainId: bigChainId ?? BigInt(chainIdFromAccount),
+      ...session_
+    }
+  
+    const accountAndChainId: AccountAndChainId = 
+    { 
+      account: getAccount({
+        address: await nexusAccount.getAddress(),
+        type: "nexus",
+      }),
+      chainId: bigChainId ?? BigInt(chainIdFromAccount)
+    }
+    
+    sessions.push(session)
+    accountsAndChainIds.push(accountAndChainId)
+    publicClients.push(publicClient)
   }
+  
+    return {
+      sessions,
+      accountsAndChainIds,
+      publicClients,
+      signer
+    }
+  
 }

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -120,28 +120,32 @@ export const grantMeePermission = async <
           : undefined
 
       return mode === "PERSONAL_SIGN"
-        ? grantPermissionPersonalSign(undefined as AnyData, [{
-            account: deployment,
-            redeemer,
-            actions: [
-              ...actions.map((action) => ({ ...action, actionTarget })),
-              ...(paymentActionPolicy ? [paymentActionPolicy] : [])
-            ],
-            sessionValidator: MEE_VALIDATOR_ADDRESS,
-            sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
-            permitERC4337Paymaster: true
-          }])
-        : grantPermissionTypedDataSign(undefined as AnyData, [{
-            account: deployment,
-            redeemer,
-            actions: [
-              ...actions.map((action) => ({ ...action, actionTarget })),
-              ...(paymentActionPolicy ? [paymentActionPolicy] : [])
-            ],
-            sessionValidator: MEE_VALIDATOR_ADDRESS,
-            sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
-            permitERC4337Paymaster: true
-          }])
+        ? grantPermissionPersonalSign(undefined as AnyData, [
+            {
+              account: deployment,
+              redeemer,
+              actions: [
+                ...actions.map((action) => ({ ...action, actionTarget })),
+                ...(paymentActionPolicy ? [paymentActionPolicy] : [])
+              ],
+              sessionValidator: MEE_VALIDATOR_ADDRESS,
+              sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
+              permitERC4337Paymaster: true
+            }
+          ])
+        : grantPermissionTypedDataSign(undefined as AnyData, [
+            {
+              account: deployment,
+              redeemer,
+              actions: [
+                ...actions.map((action) => ({ ...action, actionTarget })),
+                ...(paymentActionPolicy ? [paymentActionPolicy] : [])
+              ],
+              sessionValidator: MEE_VALIDATOR_ADDRESS,
+              sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
+              permitERC4337Paymaster: true
+            }
+          ])
     })
   )
   return sessionDetails

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -102,7 +102,7 @@ export const grantMeePermission = async <
     maxPaymentAmount = parseUnits("5", decimals)
   }
 
-  const grantPermissionParameters = actions.map( (action) => {
+  const grantPermissionParameters = actions.map((action) => {
     const chainId = action.chainId
     const actionTarget = action.actionTarget // TODO: do we even need it?
     const deployment = account.deployments.find(
@@ -110,15 +110,15 @@ export const grantMeePermission = async <
     )
 
     const paymentActionPolicy =
-        feeToken && feeToken.chainId === chainId
-          ? {
-              actionTarget: feeToken.address,
-              actionTargetSelector: "0xa9059cbb" as Address, // transfer
-              actionPolicies: [
-                getPolicyForPayment(maxPaymentAmount!, feeToken.address)
-              ]
-            }
-          : undefined
+      feeToken && feeToken.chainId === chainId
+        ? {
+            actionTarget: feeToken.address,
+            actionTargetSelector: "0xa9059cbb" as Address, // transfer
+            actionPolicies: [
+              getPolicyForPayment(maxPaymentAmount!, feeToken.address)
+            ]
+          }
+        : undefined
 
     return {
       account: deployment,
@@ -132,11 +132,16 @@ export const grantMeePermission = async <
       permitERC4337Paymaster: true
     }
   })
-//)
 
   return mode === "PERSONAL_SIGN"
-  ? grantPermissionPersonalSign(undefined as AnyData, grantPermissionParameters)
-  : grantPermissionTypedDataSign(undefined as AnyData, grantPermissionParameters)
+    ? grantPermissionPersonalSign(
+        undefined as AnyData,
+        grantPermissionParameters
+      )
+    : grantPermissionTypedDataSign(
+        undefined as AnyData,
+        grantPermissionParameters
+      )
 }
 
 const getPolicyForPayment = (maxPaymentAmount: bigint, token: Address) => {

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -120,7 +120,7 @@ export const grantMeePermission = async <
           : undefined
 
       return mode === "PERSONAL_SIGN"
-        ? grantPermissionPersonalSign(undefined as AnyData, {
+        ? grantPermissionPersonalSign(undefined as AnyData, [{
             account: deployment,
             redeemer,
             actions: [
@@ -130,8 +130,8 @@ export const grantMeePermission = async <
             sessionValidator: MEE_VALIDATOR_ADDRESS,
             sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
             permitERC4337Paymaster: true
-          })
-        : grantPermissionTypedDataSign(undefined as AnyData, {
+          }])
+        : grantPermissionTypedDataSign(undefined as AnyData, [{
             account: deployment,
             redeemer,
             actions: [
@@ -141,7 +141,7 @@ export const grantMeePermission = async <
             sessionValidator: MEE_VALIDATOR_ADDRESS,
             sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
             permitERC4337Paymaster: true
-          })
+          }])
     })
   )
   return sessionDetails

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -32,7 +32,7 @@ export type GrantMeePermissionParams<
     maxPaymentAmount?: bigint
   }
 >
-export type GrantMeePermissionPayload = GrantPermissionResponse[]
+export type GrantMeePermissionPayload = GrantPermissionResponse
 
 export const grantMeePermissionPersonalSign = async <
   TModularSmartAccount extends ModularSmartAccount | undefined
@@ -59,8 +59,12 @@ export const grantMeePermissionTypedDataSign = async <
  * as it is not needed for the sponsored mode
  * If the superTxn is not sponsored, the payment action policy is added
  *
- * Attention: actions for the cleanup userOps are not added automatically
+ * @alert Attention: actions for the cleanup userOps are not added automatically
  * and should be provided explicitly in the actions array
+ *
+ * @alert Despite the fact smart sessions module supports it, please,
+ * avoid granting several permissions for the same chain within single `grantMeePermission` usage.
+ * Because later you will only be able to enable and use one permission per chain.
  *
  * @param baseMeeClient - The base MeeClient
  * @param params - The parameters for the grantMeePermission function
@@ -98,17 +102,14 @@ export const grantMeePermission = async <
     maxPaymentAmount = parseUnits("5", decimals)
   }
 
-  const sessionDetails = await Promise.all(
-    actions.map((action) => {
-      const chainId = action.chainId
-      const actionTarget = action.actionTarget
-      const deployment = account.deployments.find(
-        (deployment) => deployment?.client?.chain?.id === chainId
-      )
+  const grantPermissionParameters = actions.map( (action) => {
+    const chainId = action.chainId
+    const actionTarget = action.actionTarget // TODO: do we even need it?
+    const deployment = account.deployments.find(
+      (deployment) => deployment?.client?.chain?.id === chainId
+    )
 
-      // if no fee token is provided, the payment action policy is not added
-      // as it is not needed for the sponsored mode
-      const paymentActionPolicy =
+    const paymentActionPolicy =
         feeToken && feeToken.chainId === chainId
           ? {
               actionTarget: feeToken.address,
@@ -119,36 +120,23 @@ export const grantMeePermission = async <
             }
           : undefined
 
-      return mode === "PERSONAL_SIGN"
-        ? grantPermissionPersonalSign(undefined as AnyData, [
-            {
-              account: deployment,
-              redeemer,
-              actions: [
-                ...actions.map((action) => ({ ...action, actionTarget })),
-                ...(paymentActionPolicy ? [paymentActionPolicy] : [])
-              ],
-              sessionValidator: MEE_VALIDATOR_ADDRESS,
-              sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
-              permitERC4337Paymaster: true
-            }
-          ])
-        : grantPermissionTypedDataSign(undefined as AnyData, [
-            {
-              account: deployment,
-              redeemer,
-              actions: [
-                ...actions.map((action) => ({ ...action, actionTarget })),
-                ...(paymentActionPolicy ? [paymentActionPolicy] : [])
-              ],
-              sessionValidator: MEE_VALIDATOR_ADDRESS,
-              sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
-              permitERC4337Paymaster: true
-            }
-          ])
-    })
-  )
-  return sessionDetails
+    return {
+      account: deployment,
+      redeemer,
+      actions: [
+        ...actions.map((action) => ({ ...action, actionTarget })),
+        ...(paymentActionPolicy ? [paymentActionPolicy] : [])
+      ],
+      sessionValidator: MEE_VALIDATOR_ADDRESS,
+      sessionValidatorInitData: redeemer, // initdata for the k1Mee validator is just the signer address
+      permitERC4337Paymaster: true
+    }
+  })
+//)
+
+  return mode === "PERSONAL_SIGN"
+  ? grantPermissionPersonalSign(undefined as AnyData, grantPermissionParameters)
+  : grantPermissionTypedDataSign(undefined as AnyData, grantPermissionParameters)
 }
 
 const getPolicyForPayment = (maxPaymentAmount: bigint, token: Address) => {

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
@@ -30,6 +30,9 @@ export type UseMeePermissionParams = {
 
 export type UseMeePermissionPayload = { hash: Hash }
 
+/**
+ * Use a MEE Permission
+ */
 export const useMeePermission = async (
   meeClient_: BaseMeeClient,
   parameters: UseMeePermissionParams

--- a/src/sdk/modules/validators/smartSessions/decorators/usePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/usePermission.ts
@@ -71,7 +71,9 @@ export async function usePermission<
 
   // find the all session details when chainId matches
   const sessionDetails_ = sessionDetailsArray.filter(
-    (sessionDetails__) => sessionDetails__.enableSessionData.enableSession.sessionToEnable.chainId === BigInt(chainId)
+    (sessionDetails__) =>
+      sessionDetails__.enableSessionData.enableSession.sessionToEnable
+        .chainId === BigInt(chainId)
   )
 
   //sanity check

--- a/src/sdk/modules/validators/smartSessions/decorators/usePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/usePermission.ts
@@ -19,7 +19,9 @@ export type UsePermissionParameters<
   /** Additional calls to be included in the user operation. */
   calls: Call[]
   /** Data string returned from grantPermission. Could be stored in local storage or a database. */
-  sessionDetails: GrantPermissionResponse
+  sessionDetailsArray: GrantPermissionResponse
+  /** Index within chain: specifies which session to use if some chain has multiple sessions. */
+  indexWithinChain?: number
   /** Mode. ENABLE the first time, or USE when > 1 time. */
   mode: "ENABLE_AND_USE" | "USE"
   /** Verification gas limit. */
@@ -48,7 +50,8 @@ export async function usePermission<
 ): Promise<Hash> {
   const {
     account: nexusAccount = nexusClient.account,
-    sessionDetails: sessionDetails_,
+    sessionDetailsArray,
+    indexWithinChain: indexWithinChain_ = 0,
     nonce: nonce_,
     mode: mode_,
     ...rest
@@ -62,14 +65,25 @@ export async function usePermission<
       ? SmartSessionMode.UNSAFE_ENABLE
       : SmartSessionMode.USE
 
-  const sessionDetails = {
-    ...sessionDetails_,
-    mode
-  }
-
   if (!chainId) {
     throw new Error("Chain ID is not set")
   }
+
+  // find the all session details when chainId matches
+  const sessionDetails_ = sessionDetailsArray.filter(
+    (sessionDetails__) => sessionDetails__.enableSessionData.enableSession.sessionToEnable.chainId === BigInt(chainId)
+  )
+
+  //sanity check
+  if (sessionDetails_.length < indexWithinChain_ + 1) {
+    throw new Error("Not enough sessions for the given index within chain")
+  }
+
+  const sessionDetails = {
+    ...sessionDetails_[indexWithinChain_],
+    mode
+  }
+
   if (!nexusAccount) {
     throw new AccountNotFoundError({
       docsPath: "/nexus-client/methods#sendtransaction"

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -274,8 +274,7 @@ describe("mee.multichainSmartSessions", () => {
     }
   )
 
-  //test.runIf(runPaidTests)(
-  test.skip(  
+  test.runIf(runPaidTests)(
     "should grant and use multichain permissions with sponsorship",
     async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -61,9 +61,6 @@ describe("mee.multichainSmartSessions", () => {
       index: BigInt(Date.now())
     })
 
-    console.log("paymentChain ", paymentChain.id)
-    console.log("targetChain ", targetChain.id)
-
     feeToken = {
       address: mcUSDC.addressOn(paymentChain.id),
       chainId: paymentChain.id
@@ -84,7 +81,7 @@ describe("mee.multichainSmartSessions", () => {
 
       const transferToNexusTrigger = {
         tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Optimism chain
-        amount: parseUnits("0.15", 6), // so Nexus is able to pay for the next SuperTxns
+        amount: parseUnits("0.1", 6), // so Nexus is able to pay for the next SuperTxns
         chainId: paymentChain.id // Which chain this trigger executes on
       }
 
@@ -277,7 +274,8 @@ describe("mee.multichainSmartSessions", () => {
     }
   )
 
-  test.runIf(runPaidTests)(
+  //test.runIf(runPaidTests)(
+  test.skip(  
     "should grant and use multichain permissions with sponsorship",
     async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
@@ -337,7 +335,6 @@ describe("mee.multichainSmartSessions", () => {
             chainId: paymentChain.id
           }
         ]
-        //feeToken
       })
 
       const receipt = await meeClient.waitForSupertransactionReceipt({

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -23,6 +23,10 @@ import { toSmartSessionsModule } from "./toSmartSessionsModule"
 
 // @ts-ignore
 const { runPaidTests } = inject("settings")
+const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
+const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
+const COUNTER_ON_BASE_SEPOLIA = "0xcaf661eeD95DE905Fcf5234040A7d6A70c6F5C85"
+const COUNTER_ON_OPTIMISM_SEPOLIA = "0x111EB1afF13be64d81485E7d45E70A6A0283dedE"
 
 describe("mee.multichainSmartSessions", () => {
   let network: NetworkConfig
@@ -57,6 +61,9 @@ describe("mee.multichainSmartSessions", () => {
       index: BigInt(Date.now())
     })
 
+    console.log("paymentChain ", paymentChain.id)
+    console.log("targetChain ", targetChain.id)
+
     feeToken = {
       address: mcUSDC.addressOn(paymentChain.id),
       chainId: paymentChain.id
@@ -77,7 +84,7 @@ describe("mee.multichainSmartSessions", () => {
 
       const transferToNexusTrigger = {
         tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Optimism chain
-        amount: parseUnits("0.15", 6), // 0.07 usdc => so Nexus is able to pay for the next SuperTxns
+        amount: parseUnits("0.15", 6), // so Nexus is able to pay for the next SuperTxns
         chainId: paymentChain.id // Which chain this trigger executes on
       }
 
@@ -194,9 +201,6 @@ describe("mee.multichainSmartSessions", () => {
         })
       expect(prepareForPermissionsPayload).toBeUndefined()
 
-      const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
-      const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
-
       const sessionDetails =
         await sessionMeeClient.grantPermissionTypedDataSign({
           redeemer: redeemerAddress,
@@ -284,9 +288,6 @@ describe("mee.multichainSmartSessions", () => {
           feeToken
         })
       expect(prepareForPermissionsPayload).toBeUndefined()
-
-      const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
-      const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
 
       const sessionDetails = await sessionMeeClient.grantPermissionPersonalSign(
         {

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -2,6 +2,7 @@ import {
   COUNTER_ADDRESS,
   type Ecosystem,
   type Infra,
+  getRandomNumber,
   toClients,
   toEcosystem
 } from "@biconomy/ecosystem"
@@ -12,6 +13,7 @@ import {
   type LocalAccount,
   type PublicClient,
   createPublicClient,
+  parseAbi,
   parseEther
 } from "viem"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
@@ -30,23 +32,33 @@ describe("modules.toSmartSessionsModule", () => {
   let ecosystem: Ecosystem
   let infra: Infra
   let chain: Chain
+  let secondInfra: Infra
+  let secondChain: Chain
   let bundlerUrl: string
-
+  let secondBundlerUrl: string
   let eoaAccount: LocalAccount
   let redeemerAccount: LocalAccount
   let redeemerAddress: Address
+  let nexusAccount: NexusAccount
   let nexusClient: NexusClient
   let nexusAccountAddress: Address
-  let nexusAccount: NexusAccount
+  let secondChainNexusAccount: NexusAccount
+  let secondChainNexusClient: NexusClient
   let sessionDetails: GrantPermissionResponse
   let sessionDetailsTypedDataSign: GrantPermissionResponse
   let publicClient: PublicClient
+  let secondChainPublicClient: PublicClient
 
   beforeAll(async () => {
-    ecosystem = await toEcosystem()
+    ecosystem = await toEcosystem({
+      chainLength: 2
+    })
     infra = ecosystem.infras[0]
+    secondInfra = ecosystem.infras[1]
     chain = infra.network.chain
+    secondChain = secondInfra.network.chain
     bundlerUrl = infra.bundler.url
+    secondBundlerUrl = secondInfra.bundler.url
     eoaAccount = getTestAccount(0)
     redeemerAccount = getTestAccount(1)
     redeemerAddress = redeemerAccount.address
@@ -56,6 +68,11 @@ describe("modules.toSmartSessionsModule", () => {
       transport: http(infra.network.rpcUrl)
     })
 
+    secondChainPublicClient = createPublicClient({
+      chain: secondChain,
+      transport: http(secondInfra.network.rpcUrl)
+    })
+
     nexusAccount = await toNexusAccount({
       signer: eoaAccount,
       chain,
@@ -63,15 +80,36 @@ describe("modules.toSmartSessionsModule", () => {
     })
 
     const { testClient } = await toClients(infra.network)
+    const { testClient: secondTestClient } = await toClients(
+      secondInfra.network
+    )
 
     nexusClient = createSmartAccountClient({
       bundlerUrl,
       account: nexusAccount,
       mock: true
     })
+
+    // prepare Nexus account for a second chain
+    secondChainNexusAccount = await toNexusAccount({
+      ...nexusAccount,
+      chain: secondChain,
+      transport: http(secondInfra.network.rpcUrl)
+    })
+
+    secondChainNexusClient = createSmartAccountClient({
+      bundlerUrl: secondBundlerUrl,
+      account: secondChainNexusAccount,
+      mock: true
+    })
+
     nexusAccountAddress = await nexusAccount.getAddress()
     await testClient.setBalance({
       address: nexusAccountAddress,
+      value: parseEther("100")
+    })
+    await secondTestClient.setBalance({
+      address: secondChainNexusAccount.address,
       value: parseEther("100")
     })
   })
@@ -79,7 +117,7 @@ describe("modules.toSmartSessionsModule", () => {
     await killNetwork([infra.network.rpcPort, infra.bundler.port])
   })
 
-  test("grant a permission with typed data sign", async () => {
+  test("install the smart sessions module for both chains", async () => {
     const smartSessionsModule = toSmartSessionsModule({ signer: eoaAccount })
 
     // Install the smart sessions module on the Nexus client's smart contract account
@@ -93,6 +131,18 @@ describe("modules.toSmartSessionsModule", () => {
 
     expect(installSuccess).toBe(true)
 
+    const secondChainHash = await secondChainNexusClient.installModule({
+      module: smartSessionsModule
+    })
+
+    const { success: secondChainInstallSuccess } =
+      await secondChainNexusClient.waitForUserOperationReceipt({
+        hash: secondChainHash
+      })
+    expect(secondChainInstallSuccess).toBe(true)
+  })
+
+  test("grant a permission with typed data sign", async () => {
     // extend the Nexus client with the smart sessions actions
     const smartSessionsClient = nexusClient.extend(smartSessionActions())
 
@@ -106,12 +156,32 @@ describe("modules.toSmartSessionsModule", () => {
               actionTargetSelector: "0x273ea3e3",
               actionPolicies: [getSudoPolicy()]
             }
-          ]
+          ],
+          chainId: BigInt(chain.id)
+        },
+        {
+          redeemer: redeemerAddress,
+          actions: [
+            {
+              actionTarget: COUNTER_ADDRESS,
+              actionTargetSelector: "0x273ea3e3",
+              actionPolicies: [getSudoPolicy()]
+            }
+          ],
+          // for the chains different from the smart sessions client chain,
+          // it is required to pass the account instance for this chain id
+          account: secondChainNexusAccount
         }
       ])
   })
 
   test("use a permission with typed data sign", async () => {
+    const counterBefore = await publicClient.readContract({
+      address: COUNTER_ADDRESS,
+      abi: parseAbi(["function getNumber() view returns (uint256)"]),
+      functionName: "getNumber"
+    })
+
     const emulatedAccount = await toNexusAccount({
       accountAddress: nexusAccount.address,
       signer: redeemerAccount,
@@ -139,6 +209,56 @@ describe("modules.toSmartSessionsModule", () => {
     if (!receiptTypedDataSignOne.success) {
       throw new Error("Smart sessions module validation failed")
     }
+
+    const counterAfter = await publicClient.readContract({
+      address: COUNTER_ADDRESS,
+      abi: parseAbi(["function getNumber() view returns (uint256)"]),
+      functionName: "getNumber"
+    })
+    expect(counterAfter).toBe(counterBefore + 1n)
+  })
+
+  test("use a permission with typed data sign for a second chain", async () => {
+    const counterBefore = await secondChainPublicClient.readContract({
+      address: COUNTER_ADDRESS,
+      abi: parseAbi(["function getNumber() view returns (uint256)"]),
+      functionName: "getNumber"
+    })
+
+    const emulatedAccount = await toNexusAccount({
+      accountAddress: secondChainNexusAccount.address,
+      signer: redeemerAccount,
+      chain: secondChain,
+      transport: http(secondInfra.network.rpcUrl)
+    })
+
+    const emulatedClient = createSmartAccountClient({
+      account: emulatedAccount,
+      transport: http(secondBundlerUrl),
+      mock: true
+    })
+
+    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
+
+    const userOpHashTypedDataSignSecondChain =
+      await smartSessionsClient.usePermission({
+        sessionDetailsArray: sessionDetailsTypedDataSign,
+        calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
+        mode: "ENABLE_AND_USE"
+      })
+
+    const receiptTypedDataSignSecondChain =
+      await secondChainNexusClient.waitForUserOperationReceipt({
+        hash: userOpHashTypedDataSignSecondChain
+      })
+    expect(receiptTypedDataSignSecondChain.success).toBe(true)
+
+    const counterAfter = await secondChainPublicClient.readContract({
+      address: COUNTER_ADDRESS,
+      abi: parseAbi(["function getNumber() view returns (uint256)"]),
+      functionName: "getNumber"
+    })
+    expect(counterAfter).toBe(counterBefore + 1n)
   })
 
   test("use a permission with typed data sign a second time", async () => {
@@ -172,16 +292,18 @@ describe("modules.toSmartSessionsModule", () => {
 
   test("grant a permission", async () => {
     const smartSessionsClient = nexusClient.extend(smartSessionActions())
-    sessionDetails = await smartSessionsClient.grantPermissionPersonalSign([{
-      redeemer: redeemerAddress,
-      actions: [
-        {
-          actionTarget: COUNTER_ADDRESS,
-          actionTargetSelector: "0x273ea3e3",
-          actionPolicies: [getSudoPolicy()]
-        }
-      ]
-    }])
+    sessionDetails = await smartSessionsClient.grantPermissionPersonalSign([
+      {
+        redeemer: redeemerAddress,
+        actions: [
+          {
+            actionTarget: COUNTER_ADDRESS,
+            actionTargetSelector: "0x273ea3e3",
+            actionPolicies: [getSudoPolicy()]
+          }
+        ]
+      }
+    ])
   })
 
   test("use a permission", async () => {
@@ -213,7 +335,7 @@ describe("modules.toSmartSessionsModule", () => {
     }
   })
 
-  test.skip("use a permission a second time", async () => {
+  test("use a permission a second time", async () => {
     const emulatedAccount = await toNexusAccount({
       accountAddress: nexusAccount.address,
       signer: redeemerAccount,
@@ -230,7 +352,7 @@ describe("modules.toSmartSessionsModule", () => {
     const smartSessionsClient = emulatedClient.extend(smartSessionActions())
 
     const userOpHashTwo = await smartSessionsClient.usePermission({
-      sessionDetails,
+      sessionDetailsArray: sessionDetails,
       calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
       mode: "USE"
     })

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -302,11 +302,18 @@ describe("modules.toSmartSessionsModule", () => {
             actionPolicies: [getSudoPolicy()]
           }
         ]
+      },
+      // decrement the counter as a separate permission
+      {
+        redeemer: redeemerAddress,
+        actions: [
+          {
+            actionTarget: COUNTER_ADDRESS,
+            actionTargetSelector: "0x871cc9d4",
+            actionPolicies: [getSudoPolicy()]
+          }
+        ]
       }
-      //{
-      // TODO: add a second permission for the same chain
-      // then test using it by prividing the index;
-      //}
     ])
   })
 
@@ -337,6 +344,36 @@ describe("modules.toSmartSessionsModule", () => {
     if (!receiptOne.success) {
       throw new Error("Smart sessions module validation failed")
     }
+  })
+
+  test("use a second permission on the same chain should work with index", async () => {
+    const emulatedAccount = await toNexusAccount({
+      accountAddress: nexusAccount.address,
+      signer: redeemerAccount,
+      chain,
+      transport: http(infra.network.rpcUrl)
+    })
+
+    const emulatedClient = createSmartAccountClient({
+      account: emulatedAccount,
+      transport: http(bundlerUrl),
+      mock: true
+    })
+
+    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
+
+    // with index, it would use the second permission
+    // which allows 0x871cc9d4
+    const userOpHashWithIndex = await smartSessionsClient.usePermission({
+      sessionDetailsArray: sessionDetails,
+      calls: [{ to: COUNTER_ADDRESS, data: "0x871cc9d4" }],
+      mode: "ENABLE_AND_USE",
+      indexWithinChain: 1 // starts from 0
+    })
+    const receiptWithIndex = await nexusClient.waitForUserOperationReceipt({
+      hash: userOpHashWithIndex
+    })
+    expect(receiptWithIndex.success).toBe(true)
   })
 
   test("use a permission a second time", async () => {

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -111,7 +111,7 @@ describe("modules.toSmartSessionsModule", () => {
     const smartSessionsClient = nexusClient.extend(smartSessionActions())
 
     sessionDetailsTypedDataSign =
-      await smartSessionsClient.grantPermissionTypedDataSign({
+      await smartSessionsClient.grantPermissionTypedDataSign([{
         redeemer: redeemerAddress,
         actions: [
           {
@@ -120,7 +120,7 @@ describe("modules.toSmartSessionsModule", () => {
             actionPolicies: [getSudoPolicy()]
           }
         ]
-      })
+      }])
   })
 
   test("use a permission", async () => {

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -79,91 +79,6 @@ describe("modules.toSmartSessionsModule", () => {
     await killNetwork([infra.network.rpcPort, infra.bundler.port])
   })
 
-  test.skip("grant a permission", async () => {
-    const smartSessionsModule = toSmartSessionsModule({ signer: eoaAccount })
-
-    // Install the smart sessions module on the Nexus client's smart contract account
-    const hash = await nexusClient.installModule({
-      module: smartSessionsModule
-    })
-
-    // Wait for the module installation transaction to be mined and check its success
-    const { success: installSuccess } =
-      await nexusClient.waitForUserOperationReceipt({ hash })
-
-    expect(installSuccess).toBe(true)
-
-    const smartSessionsClient = nexusClient.extend(smartSessionActions())
-
-    sessionDetails = await smartSessionsClient.grantPermissionPersonalSign({
-      redeemer: redeemerAddress,
-      actions: [
-        {
-          actionTarget: COUNTER_ADDRESS,
-          actionTargetSelector: "0x273ea3e3",
-          actionPolicies: [getSudoPolicy()]
-        }
-      ]
-    })
-  })
-
-  test.skip("use a permission", async () => {
-    const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
-      signer: redeemerAccount,
-      chain,
-      transport: http(infra.network.rpcUrl)
-    })
-
-    const emulatedClient = createSmartAccountClient({
-      account: emulatedAccount,
-      transport: http(bundlerUrl),
-      mock: true
-    })
-
-    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
-
-    const userOpHashOne = await smartSessionsClient.usePermission({
-      sessionDetails,
-      calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
-      mode: "ENABLE_AND_USE"
-    })
-    const receiptOne = await nexusClient.waitForUserOperationReceipt({
-      hash: userOpHashOne
-    })
-    if (!receiptOne.success) {
-      throw new Error("Smart sessions module validation failed")
-    }
-  })
-
-  test.skip("use a permission a second time", async () => {
-    const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
-      signer: redeemerAccount,
-      chain,
-      transport: http(infra.network.rpcUrl)
-    })
-
-    const emulatedClient = createSmartAccountClient({
-      account: emulatedAccount,
-      transport: http(bundlerUrl),
-      mock: true
-    })
-
-    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
-
-    const userOpHashTwo = await smartSessionsClient.usePermission({
-      sessionDetails,
-      calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
-      mode: "USE"
-    })
-
-    const receiptTwo = await nexusClient.waitForUserOperationReceipt({
-      hash: userOpHashTwo
-    })
-    expect(receiptTwo.success).toBe(true)
-  })
-
   test("grant a permission with typed data sign", async () => {
     const smartSessionsModule = toSmartSessionsModule({ signer: eoaAccount })
 
@@ -253,5 +168,76 @@ describe("modules.toSmartSessionsModule", () => {
         hash: userOpHashTwoTypedDataSign
       })
     expect(receiptTwoTypedDataSign.success).toBe(true)
+  })
+
+  test("grant a permission", async () => {
+    const smartSessionsClient = nexusClient.extend(smartSessionActions())
+    sessionDetails = await smartSessionsClient.grantPermissionPersonalSign([{
+      redeemer: redeemerAddress,
+      actions: [
+        {
+          actionTarget: COUNTER_ADDRESS,
+          actionTargetSelector: "0x273ea3e3",
+          actionPolicies: [getSudoPolicy()]
+        }
+      ]
+    }])
+  })
+
+  test("use a permission", async () => {
+    const emulatedAccount = await toNexusAccount({
+      accountAddress: nexusAccount.address,
+      signer: redeemerAccount,
+      chain,
+      transport: http(infra.network.rpcUrl)
+    })
+
+    const emulatedClient = createSmartAccountClient({
+      account: emulatedAccount,
+      transport: http(bundlerUrl),
+      mock: true
+    })
+
+    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
+
+    const userOpHashOne = await smartSessionsClient.usePermission({
+      sessionDetailsArray: sessionDetails,
+      calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
+      mode: "ENABLE_AND_USE"
+    })
+    const receiptOne = await nexusClient.waitForUserOperationReceipt({
+      hash: userOpHashOne
+    })
+    if (!receiptOne.success) {
+      throw new Error("Smart sessions module validation failed")
+    }
+  })
+
+  test.skip("use a permission a second time", async () => {
+    const emulatedAccount = await toNexusAccount({
+      accountAddress: nexusAccount.address,
+      signer: redeemerAccount,
+      chain,
+      transport: http(infra.network.rpcUrl)
+    })
+
+    const emulatedClient = createSmartAccountClient({
+      account: emulatedAccount,
+      transport: http(bundlerUrl),
+      mock: true
+    })
+
+    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
+
+    const userOpHashTwo = await smartSessionsClient.usePermission({
+      sessionDetails,
+      calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
+      mode: "USE"
+    })
+
+    const receiptTwo = await nexusClient.waitForUserOperationReceipt({
+      hash: userOpHashTwo
+    })
+    expect(receiptTwo.success).toBe(true)
   })
 })

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -302,10 +302,10 @@ describe("modules.toSmartSessionsModule", () => {
             actionPolicies: [getSudoPolicy()]
           }
         ]
-      },
+      }
       //{
-        // TODO: add a second permission for the same chain
-        // then test using it by prividing the index;
+      // TODO: add a second permission for the same chain
+      // then test using it by prividing the index;
       //}
     ])
   })

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -79,7 +79,7 @@ describe("modules.toSmartSessionsModule", () => {
     await killNetwork([infra.network.rpcPort, infra.bundler.port])
   })
 
-  test("grant a permission", async () => {
+  test.skip("grant a permission", async () => {
     const smartSessionsModule = toSmartSessionsModule({ signer: eoaAccount })
 
     // Install the smart sessions module on the Nexus client's smart contract account
@@ -107,25 +107,7 @@ describe("modules.toSmartSessionsModule", () => {
     })
   })
 
-  test("grant a permission with typed data sign", async () => {
-    const smartSessionsClient = nexusClient.extend(smartSessionActions())
-
-    sessionDetailsTypedDataSign =
-      await smartSessionsClient.grantPermissionTypedDataSign([
-        {
-          redeemer: redeemerAddress,
-          actions: [
-            {
-              actionTarget: COUNTER_ADDRESS,
-              actionTargetSelector: "0x273ea3e3",
-              actionPolicies: [getSudoPolicy()]
-            }
-          ]
-        }
-      ])
-  })
-
-  test("use a permission", async () => {
+  test.skip("use a permission", async () => {
     const emulatedAccount = await toNexusAccount({
       accountAddress: nexusAccount.address,
       signer: redeemerAccount,
@@ -154,37 +136,7 @@ describe("modules.toSmartSessionsModule", () => {
     }
   })
 
-  test("use a permission with typed data sign", async () => {
-    const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
-      signer: redeemerAccount,
-      chain,
-      transport: http(infra.network.rpcUrl)
-    })
-
-    const emulatedClient = createSmartAccountClient({
-      account: emulatedAccount,
-      transport: http(bundlerUrl),
-      mock: true
-    })
-
-    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
-
-    const userOpHashTypedDataSignOne = await smartSessionsClient.usePermission({
-      sessionDetails: sessionDetailsTypedDataSign,
-      calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
-      mode: "ENABLE_AND_USE"
-    })
-    const receiptTypedDataSignOne =
-      await nexusClient.waitForUserOperationReceipt({
-        hash: userOpHashTypedDataSignOne
-      })
-    if (!receiptTypedDataSignOne.success) {
-      throw new Error("Smart sessions module validation failed")
-    }
-  })
-
-  test("use a permission a second time", async () => {
+  test.skip("use a permission a second time", async () => {
     const emulatedAccount = await toNexusAccount({
       accountAddress: nexusAccount.address,
       signer: redeemerAccount,
@@ -212,7 +164,69 @@ describe("modules.toSmartSessionsModule", () => {
     expect(receiptTwo.success).toBe(true)
   })
 
-  test("use a permission a second time with typed data sign", async () => {
+  test("grant a permission with typed data sign", async () => {
+    const smartSessionsModule = toSmartSessionsModule({ signer: eoaAccount })
+
+    // Install the smart sessions module on the Nexus client's smart contract account
+    const hash = await nexusClient.installModule({
+      module: smartSessionsModule
+    })
+
+    // Wait for the module installation transaction to be mined and check its success
+    const { success: installSuccess } =
+      await nexusClient.waitForUserOperationReceipt({ hash })
+
+    expect(installSuccess).toBe(true)
+
+    // extend the Nexus client with the smart sessions actions
+    const smartSessionsClient = nexusClient.extend(smartSessionActions())
+
+    sessionDetailsTypedDataSign =
+      await smartSessionsClient.grantPermissionTypedDataSign([
+        {
+          redeemer: redeemerAddress,
+          actions: [
+            {
+              actionTarget: COUNTER_ADDRESS,
+              actionTargetSelector: "0x273ea3e3",
+              actionPolicies: [getSudoPolicy()]
+            }
+          ]
+        }
+      ])
+  })
+
+  test("use a permission with typed data sign", async () => {
+    const emulatedAccount = await toNexusAccount({
+      accountAddress: nexusAccount.address,
+      signer: redeemerAccount,
+      chain,
+      transport: http(infra.network.rpcUrl)
+    })
+
+    const emulatedClient = createSmartAccountClient({
+      account: emulatedAccount,
+      transport: http(bundlerUrl),
+      mock: true
+    })
+
+    const smartSessionsClient = emulatedClient.extend(smartSessionActions())
+
+    const userOpHashTypedDataSignOne = await smartSessionsClient.usePermission({
+      sessionDetailsArray: sessionDetailsTypedDataSign,
+      calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
+      mode: "ENABLE_AND_USE"
+    })
+    const receiptTypedDataSignOne =
+      await nexusClient.waitForUserOperationReceipt({
+        hash: userOpHashTypedDataSignOne
+      })
+    if (!receiptTypedDataSignOne.success) {
+      throw new Error("Smart sessions module validation failed")
+    }
+  })
+
+  test("use a permission with typed data sign a second time", async () => {
     const emulatedAccount = await toNexusAccount({
       accountAddress: nexusAccount.address,
       signer: redeemerAccount,
@@ -229,7 +243,7 @@ describe("modules.toSmartSessionsModule", () => {
     const smartSessionsClient = emulatedClient.extend(smartSessionActions())
 
     const userOpHashTwoTypedDataSign = await smartSessionsClient.usePermission({
-      sessionDetails: sessionDetailsTypedDataSign,
+      sessionDetailsArray: sessionDetailsTypedDataSign,
       calls: [{ to: COUNTER_ADDRESS, data: "0x273ea3e3" }],
       mode: "USE"
     })

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -290,7 +290,7 @@ describe("modules.toSmartSessionsModule", () => {
     expect(receiptTwoTypedDataSign.success).toBe(true)
   })
 
-  test("grant a permission", async () => {
+  test("grant a permission with personal sign", async () => {
     const smartSessionsClient = nexusClient.extend(smartSessionActions())
     sessionDetails = await smartSessionsClient.grantPermissionPersonalSign([
       {
@@ -302,7 +302,11 @@ describe("modules.toSmartSessionsModule", () => {
             actionPolicies: [getSudoPolicy()]
           }
         ]
-      }
+      },
+      //{
+        // TODO: add a second permission for the same chain
+        // then test using it by prividing the index;
+      //}
     ])
   })
 

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -111,16 +111,18 @@ describe("modules.toSmartSessionsModule", () => {
     const smartSessionsClient = nexusClient.extend(smartSessionActions())
 
     sessionDetailsTypedDataSign =
-      await smartSessionsClient.grantPermissionTypedDataSign([{
-        redeemer: redeemerAddress,
-        actions: [
-          {
-            actionTarget: COUNTER_ADDRESS,
-            actionTargetSelector: "0x273ea3e3",
-            actionPolicies: [getSudoPolicy()]
-          }
-        ]
-      }])
+      await smartSessionsClient.grantPermissionTypedDataSign([
+        {
+          redeemer: redeemerAddress,
+          actions: [
+            {
+              actionTarget: COUNTER_ADDRESS,
+              actionTargetSelector: "0x273ea3e3",
+              actionPolicies: [getSudoPolicy()]
+            }
+          ]
+        }
+      ])
   })
 
   test("use a permission", async () => {


### PR DESCRIPTION
use the feature of multichain session enable object implemented by Smart Sessions contracts

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily enhances the `smartSessions` functionality by modifying permission handling, introducing array-based session details, and improving error handling. It also updates tests to accommodate these changes, ensuring better multichain support and session management.

### Detailed summary
- Added `useMeePermission` type for MEE permissions.
- Changed `sessionDetails` to `sessionDetailsArray` for handling multiple sessions.
- Introduced `indexWithinChain` to select sessions.
- Updated `grantMeePermission` to handle new session structures.
- Enhanced error handling for chain ID checks.
- Modified tests to support multichain session permissions.
- Updated permission granting functions to support both personal and typed data signatures.
- Refactored session handling logic for clarity and efficiency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->