### PR TITLE
chore: refactor fusion modes

### DIFF
--- a/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
+++ b/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
@@ -1,14 +1,8 @@
 import type { MetaMaskSmartAccount } from "@metamask/delegation-toolkit"
-import { erc20Abi } from "viem"
-import type { BuildInstructionTypes } from "../../../account"
-import { batchInstructions } from "../../../account/utils/batchInstructions"
 import { resolveInstructions } from "../../../account/utils/resolveInstructions"
-import {
-  greaterThanOrEqualTo,
-  runtimeERC20AllowanceOf
-} from "../../../modules/utils/composabilityCalls"
 import type { BaseMeeClient } from "../../createMeeClient"
-import { DEFAULT_GAS_LIMIT, type GetQuotePayload, getQuote } from "./getQuote"
+import { prepareInstructions } from "./getFusionQuote"
+import { type GetQuotePayload, getQuote } from "./getQuote"
 import type { GetQuoteParams } from "./getQuote"
 import type { Trigger } from "./signPermitQuote"
 
@@ -89,71 +83,23 @@ export const getMmDtkQuote = async (
     ...rest
   } = parameters
 
-  const sender = delegatorSmartAccount.address
-  const recipient = account_.addressOn(trigger.chainId, true)
-
-  let triggerAmount = 0n
-
-  if (trigger.useMaxAvailableFunds) {
-    const { publicClient } = client.account.deploymentOn(trigger.chainId, true)
-
-    // EOA balance maximum available balance fetch
-    const maxAvailableBalance = await publicClient.readContract({
-      address: trigger.tokenAddress,
-      abi: erc20Abi,
-      functionName: "balanceOf",
-      args: [sender]
-    })
-
-    triggerAmount = maxAvailableBalance
-  } else {
-    if (!trigger.amount) throw new Error("Trigger amount field is required")
-
-    triggerAmount = trigger.amount
+  if (trigger.call) {
+    throw new Error("Custom call trigger is not supported for permit quotes")
   }
 
   const resolvedInstructions = await resolveInstructions(instructions)
 
-  const isComposable = resolvedInstructions.some(
-    ({ isComposable }) => isComposable
-  )
+  const sender = delegatorSmartAccount.address
+  const recipient = account_.addressOn(trigger.chainId, true)
 
-  // If max available funds ? the entire balance from EOA is added as transfer amount. But the fees will be taken from this
-  // So we don't know a specific amount to be defined here before getting the quote. So we take runtimeBalance which will take
-  // the remaining funds after the fee deduction.
-  const transferFromAmount = trigger.useMaxAvailableFunds
-    ? runtimeERC20AllowanceOf({
-        owner: sender,
-        spender: recipient,
-        tokenAddress: trigger.tokenAddress,
-        constraints: [greaterThanOrEqualTo(1n)]
-      })
-    : triggerAmount
-
-  const triggerGasLimit = trigger.gasLimit
-    ? trigger.gasLimit
-    : DEFAULT_GAS_LIMIT
-
-  const params: BuildInstructionTypes = {
-    type: "transferFrom",
-    data: {
-      tokenAddress: trigger.tokenAddress,
-      chainId: trigger.chainId,
-      amount: transferFromAmount,
-      recipient,
+  const { triggerGasLimit, triggerAmount, batchedInstructions } =
+    await prepareInstructions(client, {
+      resolvedInstructions,
+      trigger,
       sender,
-      gasLimit: triggerGasLimit
-    }
-  }
-
-  const triggerTransfer = await (isComposable
-    ? account_.buildComposable(params)
-    : account_.build(params))
-
-  const batchedInstructions = await batchInstructions({
-    account: account_,
-    instructions: [...triggerTransfer, ...resolvedInstructions]
-  })
+      recipient,
+      account: account_
+    })
 
   // using the quote-permit endpoint as the redeemed permission
   // will aprove whatever is required to be approved, so the


### PR DESCRIPTION
reuse the same code instead of having 3 copies of it

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on refactoring the quote retrieval process in the SDK by introducing a new function, `prepareInstructions`, to streamline the handling of trigger amounts and gas limits for on-chain and permit quotes.

### Detailed summary
- Introduced `prepareInstructions` function in `getFusionQuote.ts`.
- Removed redundant code for handling `triggerAmount` and `triggerGasLimit` from `getOnChainQuote.ts`, `getMmDtkQuote.ts`, and `getPermitQuote.ts`.
- Updated recipient address retrieval in `getOnChainQuote.ts`, `getMmDtkQuote.ts`, and `getPermitQuote.ts`.
- Simplified the logic for determining `triggerAmount` and `transferFromAmount`.
- Consolidated instruction batching into the new `prepareInstructions` function.
- Ensured consistent handling of composable instructions across the different quote functions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->