### PR TITLE
fix: feePayer test

### DIFF
--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -1,15 +1,15 @@
 import {
+  http,
   type Chain,
   type LocalAccount,
   type Transport,
   createWalletClient,
   erc20Abi,
-  http,
   publicActions
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { baseSepolia } from "viem/chains"
-import { beforeAll, describe, expect, test } from "vitest"
+import { beforeAll, describe, expect, inject, test } from "vitest"
 import {
   TESTNET_RPC_URLS,
   TEST_BLOCK_CONFIRMATIONS,

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -1,16 +1,15 @@
 import {
-  http,
   type Chain,
   type LocalAccount,
   type Transport,
   createWalletClient,
   erc20Abi,
+  http,
   publicActions
 } from "viem"
-import { privateKeyToAccount } from "viem/accounts"
-import { generatePrivateKey } from "viem/accounts"
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { baseSepolia } from "viem/chains"
-import { beforeAll, describe, expect, inject, test } from "vitest"
+import { beforeAll, describe, expect, test } from "vitest"
 import {
   TESTNET_RPC_URLS,
   TEST_BLOCK_CONFIRMATIONS,
@@ -40,10 +39,11 @@ import {
 } from "../../createMeeClient"
 import {
   CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION,
-  DEFAULT_GAS_LIMIT
+  DEFAULT_GAS_LIMIT,
+  type FeeTokenInfo,
+  type Instruction,
+  getQuote
 } from "./getQuote"
-import { type FeeTokenInfo, type Instruction, getQuote } from "./getQuote"
-import { Trigger } from "./signPermitQuote"
 
 const getRandomAccountIndex = (min: number, max: number) => {
   const minValue = Math.ceil(min) // Round up to ensure inclusive min
@@ -1071,8 +1071,7 @@ describe("mee.getQuote", () => {
     expect(transactionStatus).to.to.eq("MINED_SUCCESS")
   })
 
-  // TODO: Fix this test, this is failing due to gas issues
-  test.skip("should use feePayer if provided", async () => {
+  test("should use feePayer if provided", async () => {
     const chain = baseSepolia
     const mcNexus = await toMultichainNexusAccount({
       chains: [chain],
@@ -1118,17 +1117,18 @@ describe("mee.getQuote", () => {
         address: tokenAddress
       }
     })
-    // Estimate gas for approve
-    const approveGas = await publicClient.estimateContractGas({
-      address: feeAccount.address,
+    const request = await publicClient.simulateContract({
+      account: feeAccount.address,
+      address: tokenAddress,
       abi: erc20Abi,
       functionName: "approve",
       args: [
         mcNexus.addressOn(chain.id, true),
         BigInt(quote.paymentInfo.tokenWeiAmount) + 1n
-      ],
-      account: feeAccount.address // explicitly simulate from their address
+      ]
     })
+    // Estimate gas for approve
+    const approveGas = await publicClient.estimateGas(request)
 
     // Estimate current gas fees
     const gasFees = await publicClient.estimateFeesPerGas()
@@ -1154,6 +1154,7 @@ describe("mee.getQuote", () => {
       recipient: feeAccount.address,
       amount: BigInt(quote.paymentInfo.tokenWeiAmount) + 1n
     })
+
     // set allowance to the fee account on the mcNexus account
     await setAllowance({
       publicClient,

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -214,7 +214,7 @@ describe.runIf(runPaidTests)("mee.signPermitQuote - testnet", () => {
     chain = network.chain
     mcNexus = await toMultichainNexusAccount({
       chains: [chain],
-      transports: [http()],
+      transports: [http(network.rpcUrl)],
       signer: eoaAccount,
       index: 1n
     })

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -357,14 +357,14 @@ export const setAllowance = async ({
   spender: Address
   amount: bigint
 }) => {
-  const resetApprovalHash = await walletClient.writeContract({
+  const allowanceTxHash = await walletClient.writeContract({
     address: tokenAddress,
     abi: erc20Abi,
     functionName: "approve",
     args: [spender, amount]
   })
   return await publicClient.waitForTransactionReceipt({
-    hash: resetApprovalHash,
+    hash: allowanceTxHash,
     confirmations: TEST_BLOCK_CONFIRMATIONS
   })
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the functionality and testing of the `mee` module by refining contract interactions and improving test coverage.

### Detailed summary
- Updated `signPermitQuote.test.ts` to use `http(network.rpcUrl)` instead of `http()`.
- Renamed `resetApprovalHash` to `allowanceTxHash` in `testUtils.ts`.
- Modified transaction receipt handling to use `allowanceTxHash`.
- Consolidated imports in `getQuote.test.ts`.
- Changed a test from skipped to active for fee payer functionality.
- Updated gas estimation logic in `getQuote.test.ts` using `simulateContract`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->