### PR TITLE
feat: improved tests and unskipped all the tests which affects parallel exec

### DIFF
--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -824,8 +824,7 @@ describe.runIf(runPaidTests)("mee.buildComposable", () => {
     }
   })
 
-  // Skipping this just because this file takes a long time to run.
-  it.skip("should execute composable transaction for uniswap args", async () => {
+  it("should execute composable transaction for uniswap args", async () => {
     const fusionToken = getMultichainContract<typeof erc20Abi>({
       abi: erc20Abi,
       deployments: [
@@ -1428,9 +1427,7 @@ describe.runIf(runPaidTests)("mee.buildComposable", () => {
     console.log({ explorerLinks, hash })
   })
 
-  // Skipping this test. It is working well when running alone. Has some conflicts while running globally.
-  // This is safe to skip
-  it.skip("should composable cleanup execute based on dependency config", async () => {
+  it("should composable cleanup execute based on dependency config", async () => {
     const amountToSupply = parseUnits("0.1", 6)
     const amountToTransfer = parseUnits("0.01", 6)
 

--- a/src/sdk/clients/decorators/mee/executeFusionQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/executeFusionQuote.test.ts
@@ -27,8 +27,7 @@ import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 // @ts-ignore
 const { runPaidTests } = inject("settings")
 
-// Tests below are skipped because they conflict with permit flows when the same nonce for the eoa is used
-describe.runIf(runPaidTests).skip("mee.executeFusionQuote", () => {
+describe.runIf(runPaidTests)("mee.executeFusionQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
 

--- a/src/sdk/clients/decorators/mee/signFusionQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.test.ts
@@ -100,8 +100,7 @@ describe("mee.signFusionQuote", () => {
     expect(signedFusionQuote).toBeDefined()
   })
 
-  // Tests below are skipped because they conflict with permit flows when the same nonce for the eoa is used
-  test.skip("should execute a signed fusion quote using signFusionQuote", async () => {
+  test("should execute a signed fusion quote using signFusionQuote", async () => {
     console.time("signFusionQuote:getQuote")
     console.time("signFusionQuote:getHash")
     console.time("signFusionQuote:receipt")

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -92,8 +92,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
     tokenAddress = mcUSDC.addressOn(optimism.id)
   })
 
-  // Skip this test as it will conflict with the other tests as it uses the same eoa account, and the nonce will be the same
-  test.skip("should execute a quote using signOnChainQuote", async () => {
+  test("should execute a quote using signOnChainQuote", async () => {
     console.time("signOnChainQuote:getQuote")
     console.time("signOnChainQuote:getHash")
     console.time("signOnChainQuote:receipt")
@@ -311,7 +310,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
       expect(signedQuote.signature.startsWith(ON_CHAIN_PREFIX)).toBe(true)
     })
   })
-  describe.skip("custom approvalAmount", () => {
+  describe("custom approvalAmount", () => {
     test("should fail if approvalAmount is smaller than the trigger amount", async () => {
       const amount = parseUnits("0.01", 6)
       const approvalAmount = parseUnits("0.005", 6)
@@ -351,7 +350,8 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
       ).rejects.toThrow()
     })
 
-    test("changes the allowance based on approvalAmount", async () => {
+    // This test is skipped because it uses USDT token which doesn't have fund setup.
+    test.skip("changes the allowance based on approvalAmount", async () => {
       // Define the amount to transfer and the custom approval amount (allowance)
       const amount = parseUnits("0.01", 6)
       const approvalAmount = parseUnits("0.03", 6)

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -134,9 +134,9 @@ describe("mee.signPermitQuote", () => {
     expect(signedPermitQuote).toBeDefined()
   })
 
-  test
-    .runIf(runPaidTests)
-    .skip("should execute a signed fusion quote using signPermitQuote", async () => {
+  test.runIf(runPaidTests)(
+    "should execute a signed fusion quote using signPermitQuote",
+    async () => {
       console.time("signPermitQuote:getQuote")
       console.time("signPermitQuote:getHash")
       console.time("signPermitQuote:receipt")
@@ -196,7 +196,8 @@ describe("mee.signPermitQuote", () => {
         tokenAddress
       )
       expect(balanceOfRecipient).toBe(trigger.amount)
-    })
+    }
+  )
 })
 
 describe.runIf(runPaidTests)("mee.signPermitQuote - testnet", () => {

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
     globalSetup: join(__dirname, "globalSetup.ts"),
     environment: "node",
     testTimeout: 500_000,
-    hookTimeout: 100_000
+    hookTimeout: 250_000,
+    fileParallelism: false,
+    retry: 2
   }
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR primarily focuses on enabling previously skipped tests in various files and adjusting configuration settings for test execution.

### Detailed summary
- Increased `hookTimeout` from `100_000` to `250_000`.
- Added `fileParallelism: false` and `retry: 2` in `vitest.config.ts`.
- Enabled tests in `executeFusionQuote.test.ts`, `signFusionQuote.test.ts`, `signPermitQuote.test.ts`, `signOnChainQuote.test.ts`, and `buildComposable.test.ts`.
- Updated descriptions for skipped tests to active status.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->