### PR TITLE
fix: omit transferFrom on native token trigger

### DIFF
--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -824,8 +824,7 @@ describe.runIf(runPaidTests)("mee.buildComposable", () => {
     }
   })
 
-  // Skipping this just because this file takes a long time to run.
-  it.skip("should execute composable transaction for uniswap args", async () => {
+  it("should execute composable transaction for uniswap args", async () => {
     const fusionToken = getMultichainContract<typeof erc20Abi>({
       abi: erc20Abi,
       deployments: [
@@ -1428,9 +1427,7 @@ describe.runIf(runPaidTests)("mee.buildComposable", () => {
     console.log({ explorerLinks, hash })
   })
 
-  // Skipping this test. It is working well when running alone. Has some conflicts while running globally.
-  // This is safe to skip
-  it.skip("should composable cleanup execute based on dependency config", async () => {
+  it("should composable cleanup execute based on dependency config", async () => {
     const amountToSupply = parseUnits("0.1", 6)
     const amountToTransfer = parseUnits("0.01", 6)
 

--- a/src/sdk/account/decorators/instructions/buildTransferFrom.ts
+++ b/src/sdk/account/decorators/instructions/buildTransferFrom.ts
@@ -99,7 +99,6 @@ export const buildTransferFrom = async (
   ]
 
   const functionContext = getFunctionContextFromAbi(functionSig, abi)
-
   // Check for the runtime arguments and detect the need for composable call
   const isComposableCall = forceComposableEncoding
     ? true

--- a/src/sdk/clients/decorators/mee/executeFusionQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/executeFusionQuote.test.ts
@@ -27,8 +27,7 @@ import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 // @ts-ignore
 const { runPaidTests } = inject("settings")
 
-// Tests below are skipped because they conflict with permit flows when the same nonce for the eoa is used
-describe.runIf(runPaidTests).skip("mee.executeFusionQuote", () => {
+describe.runIf(runPaidTests)("mee.executeFusionQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
 

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -1,5 +1,5 @@
 import type { MetaMaskSmartAccount } from "@metamask/delegation-toolkit"
-import { type Address, erc20Abi } from "viem"
+import { type Address, erc20Abi, zeroAddress } from "viem"
 import type { BuildInstructionTypes } from "../../../account/decorators/build"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { batchInstructions } from "../../../account/utils/batchInstructions"
@@ -204,6 +204,15 @@ export const prepareInstructions = async (
     ? trigger.gasLimit
     : DEFAULT_GAS_LIMIT
 
+  // If token address is zero address, we don't need to add transferFrom instruction
+  if (trigger.tokenAddress === zeroAddress) {
+    const batchedInstructions = await batchInstructions({
+      account,
+      instructions: resolvedInstructions
+    })
+    return { triggerGasLimit, triggerAmount, batchedInstructions }
+  }
+
   const params: BuildInstructionTypes = {
     type: "transferFrom",
     data: {
@@ -215,16 +224,14 @@ export const prepareInstructions = async (
       gasLimit: triggerGasLimit
     }
   }
-
   const triggerTransfer = await (isComposable
     ? account.buildComposable(params)
     : account.build(params))
 
   const batchedInstructions = await batchInstructions({
-    account: account,
+    account,
     instructions: [...triggerTransfer, ...resolvedInstructions]
   })
-
   return { triggerGasLimit, triggerAmount, batchedInstructions }
 }
 

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -162,10 +162,27 @@ export const prepareInstructions = async (
   if (trigger.useMaxAvailableFunds) {
     const { publicClient } = client.account.deploymentOn(trigger.chainId, true)
     if (trigger.tokenAddress === zeroAddress) {
+      const [balance, gasPrice, gasLimit] = await Promise.all([
+        publicClient.getBalance({ address: sender }),
+        publicClient.getGasPrice(),
+        publicClient.estimateGas({ account: sender, to: sender, value: 1n }) // Dummy values
+      ])
+
+      // 50% gas limit buffer to avoid failures
+      const gasLimitWithBuffer = (gasLimit * 150n) / 100n
+
+      // 50% buffer for gas price fluctuations
+      const gasBuffer = 1.5
+
+      const baseCost = gasLimitWithBuffer * gasPrice
+      const gasReserve = BigInt(Math.ceil(Number(baseCost) * gasBuffer))
+
+      if (balance <= gasReserve) {
+        throw new Error("Not enough native token to transfer")
+      }
+
       // native token balance maximum available balance fetch
-      triggerAmount = await publicClient.getBalance({
-        address: sender
-      })
+      triggerAmount = balance - gasReserve
     } else {
       // EOA balance maximum available balance fetch
       triggerAmount = await publicClient.readContract({
@@ -216,6 +233,7 @@ export const prepareInstructions = async (
     })
     return { triggerGasLimit, triggerAmount, batchedInstructions }
   }
+
   const params: BuildInstructionTypes = {
     type: "transferFrom",
     data: {
@@ -235,6 +253,7 @@ export const prepareInstructions = async (
     account,
     instructions: [...triggerTransfer, ...resolvedInstructions]
   })
+
   return { triggerGasLimit, triggerAmount, batchedInstructions }
 }
 

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -161,16 +161,20 @@ export const prepareInstructions = async (
 
   if (trigger.useMaxAvailableFunds) {
     const { publicClient } = client.account.deploymentOn(trigger.chainId, true)
-
-    // EOA balance maximum available balance fetch
-    const maxAvailableBalance = await publicClient.readContract({
-      address: trigger.tokenAddress,
-      abi: erc20Abi,
-      functionName: "balanceOf",
-      args: [sender]
-    })
-
-    triggerAmount = maxAvailableBalance
+    if (trigger.tokenAddress === zeroAddress) {
+      // native token balance maximum available balance fetch
+      triggerAmount = await publicClient.getBalance({
+        address: sender
+      })
+    } else {
+      // EOA balance maximum available balance fetch
+      triggerAmount = await publicClient.readContract({
+        address: trigger.tokenAddress,
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [sender]
+      })
+    }
   } else {
     if (!trigger.amount) throw new Error("Trigger amount field is required")
 
@@ -187,6 +191,11 @@ export const prepareInstructions = async (
   // So we don't know a specific amount to be defined here before getting the quote. So we take runtimeBalance which will take
   // the remaining funds after the fee deduction.
   if (trigger.useMaxAvailableFunds) {
+    if (trigger.tokenAddress === zeroAddress) {
+      throw new Error(
+        "Native token trigger is not supported with useMaxAvailableFunds"
+      )
+    }
     transferFromAmount = runtimeERC20AllowanceOf({
       owner: sender,
       spender: scaAddress,

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -190,12 +190,7 @@ export const prepareInstructions = async (
   // If max available funds ? the entire balance from EOA is added as transfer amount. But the fees will be taken from this
   // So we don't know a specific amount to be defined here before getting the quote. So we take runtimeBalance which will take
   // the remaining funds after the fee deduction.
-  if (trigger.useMaxAvailableFunds) {
-    if (trigger.tokenAddress === zeroAddress) {
-      throw new Error(
-        "Native token trigger is not supported with useMaxAvailableFunds"
-      )
-    }
+  if (trigger.useMaxAvailableFunds && trigger.tokenAddress !== zeroAddress) {
     transferFromAmount = runtimeERC20AllowanceOf({
       owner: sender,
       spender: scaAddress,
@@ -221,7 +216,6 @@ export const prepareInstructions = async (
     })
     return { triggerGasLimit, triggerAmount, batchedInstructions }
   }
-
   const params: BuildInstructionTypes = {
     type: "transferFrom",
     data: {

--- a/src/sdk/clients/decorators/mee/signFusionQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.test.ts
@@ -100,8 +100,7 @@ describe("mee.signFusionQuote", () => {
     expect(signedFusionQuote).toBeDefined()
   })
 
-  // Tests below are skipped because they conflict with permit flows when the same nonce for the eoa is used
-  test.skip("should execute a signed fusion quote using signFusionQuote", async () => {
+  test("should execute a signed fusion quote using signFusionQuote", async () => {
     console.time("signFusionQuote:getQuote")
     console.time("signFusionQuote:getHash")
     console.time("signFusionQuote:receipt")

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -592,13 +592,13 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
     const ethTrigger = {
       chainId: network.chain.id,
       tokenAddress: zeroAddress,
-      amount: 1n
+      // amount: 1n,
+      useMaxAvailableFunds: true
     }
     const feeToken = {
       address: zeroAddress,
       chainId: network.chain.id
     }
-    const sender = mcNexus.signer.address
     const { address: recipient } = mcNexus.deploymentOn(network.chain.id, true)
     const quote = await getOnChainQuote(meeClient, {
       trigger: ethTrigger,

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -93,8 +93,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
     tokenAddress = mcUSDC.addressOn(optimism.id)
   })
 
-  // Skip this test as it will conflict with the other tests as it uses the same eoa account, and the nonce will be the same
-  test.skip("should execute a quote using signOnChainQuote", async () => {
+  test("should execute a quote using signOnChainQuote", async () => {
     console.time("signOnChainQuote:getQuote")
     console.time("signOnChainQuote:getHash")
     console.time("signOnChainQuote:receipt")
@@ -312,7 +311,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
       expect(signedQuote.signature.startsWith(ON_CHAIN_PREFIX)).toBe(true)
     })
   })
-  describe.skip("custom approvalAmount", () => {
+  describe("custom approvalAmount", () => {
     test("should fail if approvalAmount is smaller than the trigger amount", async () => {
       const amount = parseUnits("0.01", 6)
       const approvalAmount = parseUnits("0.005", 6)
@@ -352,7 +351,8 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
       ).rejects.toThrow()
     })
 
-    test("changes the allowance based on approvalAmount", async () => {
+    // This test is skipped because it uses USDT token which doesn't have fund setup.
+    test.skip("changes the allowance based on approvalAmount", async () => {
       // Define the amount to transfer and the custom approval amount (allowance)
       const amount = parseUnits("0.01", 6)
       const approvalAmount = parseUnits("0.03", 6)
@@ -631,6 +631,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
       expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
     })
+
     test("should work with useMaxAvailableFunds", async () => {
       const ethTrigger: Trigger = {
         chainId: network.chain.id,
@@ -669,6 +670,54 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
         mcNexus.signer.address
       )
       expect(balance).toBe(quote.trigger.amount)
+
+      // TODO: add execution as well once the runtimeNativeTokenBalanceOf is added
+    })
+
+    test("should work with useMaxAvailableFunds for custom recipient", async () => {
+      const ethTrigger: Trigger = {
+        chainId: network.chain.id,
+        tokenAddress: zeroAddress,
+        useMaxAvailableFunds: true,
+        recipientAddress: eoaAccount.address
+      }
+
+      const feeToken = {
+        address: zeroAddress,
+        chainId: network.chain.id
+      }
+
+      const { address: recipient } = mcNexus.deploymentOn(
+        network.chain.id,
+        true
+      )
+
+      const zeroTransfer = await mcNexus.build({
+        type: "default",
+        data: {
+          chainId: network.chain.id,
+          calls: [
+            {
+              // dummy transfer to an address, this can be any transaction
+              to: recipient,
+              value: 1n
+            }
+          ]
+        }
+      })
+
+      const quote = await getOnChainQuote(meeClient, {
+        trigger: ethTrigger,
+        instructions: [zeroTransfer],
+        feeToken
+      })
+
+      const { hash } = await meeClient.executeFusionQuote({
+        fusionQuote: quote
+      })
+
+      const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
+      expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
     })
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -592,8 +592,7 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
     const ethTrigger = {
       chainId: network.chain.id,
       tokenAddress: zeroAddress,
-      // amount: 1n,
-      useMaxAvailableFunds: true
+      amount: 1n
     }
     const feeToken = {
       address: zeroAddress,

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -49,6 +49,7 @@ import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 
 // @ts-ignore
 const { runPaidTests } = inject("settings")
+
 describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
@@ -588,41 +589,86 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
     })
   })
-  test("should handle ETH forwarder trigger call", async () => {
-    const ethTrigger = {
-      chainId: network.chain.id,
-      tokenAddress: zeroAddress,
-      amount: 1n
-    }
-    const feeToken = {
-      address: zeroAddress,
-      chainId: network.chain.id
-    }
-    const { address: recipient } = mcNexus.deploymentOn(network.chain.id, true)
-    const quote = await getOnChainQuote(meeClient, {
-      trigger: ethTrigger,
-      instructions: [
-        mcNexus.build({
-          type: "default",
-          data: {
-            chainId: network.chain.id,
-            calls: [
-              {
-                // dummy transfer to an address, this can be any transaction
-                to: recipient,
-                value: 1n
-              }
-            ]
-          }
-        })
-      ],
-      feeToken
+  describe("should handle ETH forwarder trigger call", () => {
+    test("should handle ETH forwarder trigger call", async () => {
+      const ethTrigger = {
+        chainId: network.chain.id,
+        tokenAddress: zeroAddress,
+        amount: 1n
+      }
+      const feeToken = {
+        address: zeroAddress,
+        chainId: network.chain.id
+      }
+      const { address: recipient } = mcNexus.deploymentOn(
+        network.chain.id,
+        true
+      )
+      const quote = await getOnChainQuote(meeClient, {
+        trigger: ethTrigger,
+        instructions: [
+          mcNexus.build({
+            type: "default",
+            data: {
+              chainId: network.chain.id,
+              calls: [
+                {
+                  // dummy transfer to an address, this can be any transaction
+                  to: recipient,
+                  value: 1n
+                }
+              ]
+            }
+          })
+        ],
+        feeToken
+      })
+      // return
+      const { hash } = await meeClient.executeFusionQuote({
+        fusionQuote: quote
+      })
+      // Wait for the transaction to complete
+      const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
+      expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
     })
-    const { hash } = await meeClient.executeFusionQuote({
-      fusionQuote: quote
+    test("should work with useMaxAvailableFunds", async () => {
+      const ethTrigger: Trigger = {
+        chainId: network.chain.id,
+        tokenAddress: zeroAddress,
+        useMaxAvailableFunds: true
+      }
+      const feeToken = {
+        address: zeroAddress,
+        chainId: network.chain.id
+      }
+      const { address: recipient } = mcNexus.deploymentOn(
+        network.chain.id,
+        true
+      )
+      const quote = await getOnChainQuote(meeClient, {
+        trigger: ethTrigger,
+        instructions: [
+          mcNexus.build({
+            type: "default",
+            data: {
+              chainId: network.chain.id,
+              calls: [
+                {
+                  // dummy transfer to an address, this can be any transaction
+                  to: recipient,
+                  value: 1n
+                }
+              ]
+            }
+          })
+        ],
+        feeToken
+      })
+      const balance = await getBalance(
+        mcNexus.deploymentOn(network.chain.id, true).publicClient,
+        mcNexus.signer.address
+      )
+      expect(balance).toBe(quote.trigger.amount)
     })
-    // Wait for the transaction to complete
-    const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
-    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -41,6 +41,7 @@ import {
   createMeeClient
 } from "../../createMeeClient"
 import executeSignedQuote from "./executeSignedQuote"
+import getOnChainQuote from "./getOnChainQuote"
 import { type FeeTokenInfo, getQuote } from "./getQuote"
 import { ON_CHAIN_PREFIX, signOnChainQuote } from "./signOnChainQuote"
 import type { Trigger } from "./signPermitQuote"
@@ -48,7 +49,6 @@ import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
 
 // @ts-ignore
 const { runPaidTests } = inject("settings")
-
 describe.runIf(runPaidTests)("mee.signOnChainQuote", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
@@ -587,5 +587,43 @@ describe.runIf(runPaidTests)("mee.signOnChainQuote - testnet", () => {
       const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
       expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
     })
+  })
+  test("should handle ETH forwarder trigger call", async () => {
+    const ethTrigger = {
+      chainId: network.chain.id,
+      tokenAddress: zeroAddress,
+      amount: 1n
+    }
+    const feeToken = {
+      address: zeroAddress,
+      chainId: network.chain.id
+    }
+    const sender = mcNexus.signer.address
+    const { address: recipient } = mcNexus.deploymentOn(network.chain.id, true)
+    const quote = await getOnChainQuote(meeClient, {
+      trigger: ethTrigger,
+      instructions: [
+        mcNexus.build({
+          type: "default",
+          data: {
+            chainId: network.chain.id,
+            calls: [
+              {
+                // dummy transfer to an address, this can be any transaction
+                to: recipient,
+                value: 1n
+              }
+            ]
+          }
+        })
+      ],
+      feeToken
+    })
+    const { hash } = await meeClient.executeFusionQuote({
+      fusionQuote: quote
+    })
+    // Wait for the transaction to complete
+    const receipt = await meeClient.waitForSupertransactionReceipt({ hash })
+    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
   })
 })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.ts
@@ -41,11 +41,13 @@ export const ON_CHAIN_PREFIX = "0x177eee01"
  */
 const generateTriggerCallFromTrigger = async ({
   account,
-  spender,
-  trigger
+  trigger,
+  recipient,
+  scaAddress
 }: {
   account: MultichainSmartAccount
-  spender: Address
+  recipient: Address
+  scaAddress: Address
   trigger: Trigger
 }) => {
   let triggerCall: AbstractCall | ComposableCall
@@ -57,7 +59,7 @@ const generateTriggerCallFromTrigger = async ({
     const forwardCalldata = encodeFunctionData({
       abi: ForwarderAbi,
       functionName: "forward",
-      args: [spender]
+      args: [recipient]
     })
     const [
       {
@@ -100,7 +102,7 @@ const generateTriggerCallFromTrigger = async ({
     ] = await account.build({
       type: "approve",
       data: {
-        spender,
+        spender: scaAddress,
         tokenAddress: trigger.tokenAddress,
         chainId: trigger.chainId,
         amount
@@ -138,13 +140,18 @@ export const signOnChainQuote = async (
   const {
     chain,
     walletClient,
-    address: spender
+    address: scaAddress
   } = account_.deploymentOn(chainId, true)
+
+  // By default the trigger amount will be deposited to sca account.
+  // if a custom recipient is defined ? It will deposit to the recipient address
+  const recipient = trigger.recipientAddress || scaAddress
 
   const triggerCall = await generateTriggerCallFromTrigger({
     account: account_,
     trigger,
-    spender
+    recipient,
+    scaAddress
   })
   // This will be always a non composable transaction, so don't worry about the composability
   const dataOrPrefix =
@@ -153,6 +160,7 @@ export const signOnChainQuote = async (
 
   // @ts-ignore
   const hash = await walletClient.sendTransaction(call)
+
   // @ts-ignore
   await walletClient.waitForTransactionReceipt({ hash, confirmations })
 

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.ts
@@ -146,7 +146,6 @@ export const signOnChainQuote = async (
     trigger,
     spender
   })
-
   // This will be always a non composable transaction, so don't worry about the composability
   const dataOrPrefix =
     (triggerCall as AbstractCall)?.data ?? FUSION_NATIVE_TRANSFER_PREFIX

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -134,9 +134,9 @@ describe("mee.signPermitQuote", () => {
     expect(signedPermitQuote).toBeDefined()
   })
 
-  test
-    .runIf(runPaidTests)
-    .skip("should execute a signed fusion quote using signPermitQuote", async () => {
+  test.runIf(runPaidTests)(
+    "should execute a signed fusion quote using signPermitQuote",
+    async () => {
       console.time("signPermitQuote:getQuote")
       console.time("signPermitQuote:getHash")
       console.time("signPermitQuote:receipt")
@@ -196,7 +196,8 @@ describe("mee.signPermitQuote", () => {
         tokenAddress
       )
       expect(balanceOfRecipient).toBe(trigger.amount)
-    })
+    }
+  )
 })
 
 describe.runIf(runPaidTests)("mee.signPermitQuote - testnet", () => {

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -27,6 +27,8 @@ export default defineConfig({
     globalSetup: join(__dirname, "globalSetup.ts"),
     environment: "node",
     testTimeout: 500_000,
-    hookTimeout: 100_000
+    hookTimeout: 250_000,
+    fileParallelism: false,
+    retry: 2
   }
 })


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing test configurations and improving the handling of on-chain quotes in the `mee` module. It includes adjustments to timeouts, test execution conditions, and the logic for managing funds in various scenarios.

### Detailed summary
- Increased `hookTimeout` to `250,000`.
- Added `fileParallelism: false` and `retry: 2` in `vitest.config.ts`.
- Modified test executions to no longer skip certain tests in `executeFusionQuote`, `signFusionQuote`, and `signPermitQuote`.
- Improved handling of `trigger` parameters in `signOnChainQuote` and related functions.
- Added checks for `zeroAddress` to manage native token balances.
- Introduced new tests for handling ETH forwarder trigger calls and `useMaxAvailableFunds` scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->