### PR TITLE
feat: across intent wrapper

### DIFF
--- a/src/sdk/account/decorators/build.ts
+++ b/src/sdk/account/decorators/build.ts
@@ -2,6 +2,9 @@ import type { Address } from "viem"
 import type { Instruction } from "../../clients/decorators/mee/getQuote"
 import type { RuntimeValue } from "../../modules"
 import type { BaseMultichainSmartAccount } from "../toMultiChainNexusAccount"
+import buildAcrossIntentComposable, {
+  type BuildAcrossIntentComposableParams
+} from "./instructions/buildAcrossIntentComposable"
 import {
   type BuildApproveParameters,
   buildApprove
@@ -38,9 +41,6 @@ import {
 import buildWithdrawal, {
   type BuildWithdrawalParameters
 } from "./instructions/buildWithdrawal"
-import buildAcrossIntentComposable, {
-  type BuildAcrossIntentComposableParams
-} from "./instructions/buildAcrossIntentComposable"
 
 /**
  * Parameters for a token builders

--- a/src/sdk/account/decorators/build.ts
+++ b/src/sdk/account/decorators/build.ts
@@ -38,6 +38,9 @@ import {
 import buildWithdrawal, {
   type BuildWithdrawalParameters
 } from "./instructions/buildWithdrawal"
+import buildAcrossIntentComposable, {
+  type BuildAcrossIntentComposableParams
+} from "./instructions/buildAcrossIntentComposable"
 
 /**
  * Parameters for a token builders
@@ -170,6 +173,17 @@ export type BuildComposableRawInstruction = {
 }
 
 /**
+ * Build action which is used to build instructions for a across intent composable call
+ * @property type - Literal "acrossIntent" to identify the action type
+ * @property data - {@link BuildAcrossIntentComposableParameters} The parameters for the across intent composable action
+ */
+export type BuildAcrossIntentComposableInstruction = {
+  type: "acrossIntent"
+  data: BuildAcrossIntentComposableParams
+  efficientMode?: false // as raw calldata doesn't have to be compressed
+}
+
+/**
  * Build action which is used to build instructions for uninstalling modules
  * @property type - Literal "buildMultichainInstructions" to identify the action type
  * @property data - {@link BuildMultichainInstructionParameters} The parameters for the uninstall modules action
@@ -203,6 +217,7 @@ export type BuildComposableInstructionTypes =
   | BaseInstructionTypes
   | BuildComposableInstruction
   | BuildComposableRawInstruction
+  | BuildAcrossIntentComposableInstruction
 
 /**
  * Builds transaction instructions based on the provided action type and parameters
@@ -307,6 +322,9 @@ export const buildComposable = async (
     }
     case "batch": {
       return buildBatch(baseParams, data)
+    }
+    case "acrossIntent": {
+      return buildAcrossIntentComposable(baseParams, data)
     }
     default: {
       throw new Error(`Unknown build action type: ${type}`)

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
@@ -114,7 +114,7 @@ describe("mee.buildAcrossIntentComposable", () => {
           recipient: mcNexus.addressOn(base.id)!,
           inputToken: mcUSDC.addressOn(optimism.id),
           outputToken: mcUSDC.addressOn(base.id),
-          runtimeParams: {
+          inputAmountRuntimeParams: {
             targetAddress: mcNexus.addressOn(optimism.id)!,
             tokenAddress: mcUSDC.addressOn(optimism.id),
             constraints: []

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
@@ -26,7 +26,6 @@ import {
 import type { FeeTokenInfo } from "../../../clients/decorators/mee/getQuote"
 import type { Trigger } from "../../../clients/decorators/mee/signPermitQuote"
 import { mcUSDC } from "../../../constants/tokens"
-import { createChainAddressMap } from "../../../modules"
 import type { MultichainSmartAccount } from "../../toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../toMultiChainNexusAccount"
 
@@ -115,6 +114,11 @@ describe("mee.buildAcrossIntentComposable", () => {
           recipient: mcNexus.addressOn(base.id)!,
           inputToken: mcUSDC.addressOn(optimism.id),
           outputToken: mcUSDC.addressOn(base.id),
+          runtimeParams: {
+            targetAddress: mcNexus.addressOn(optimism.id)!,
+            tokenAddress: mcUSDC.addressOn(optimism.id),
+            constraints: []
+          },
           approximateExpectedInputAmount: benchmarkInputAmount,
           originChainId: optimism.id,
           destinationChainId: base.id,
@@ -130,7 +134,6 @@ describe("mee.buildAcrossIntentComposable", () => {
       })
 
       const { hash } = await meeClient.executeFusionQuote({ fusionQuote })
-      console.log(hash)
 
       const receipt = await meeClient.waitForSupertransactionReceipt({
         hash,

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
@@ -1,0 +1,183 @@
+import {
+  http,
+  type Address,
+  type Chain,
+  type LocalAccount,
+  type PublicClient,
+  type Transport,
+  createPublicClient,
+  erc20Abi,
+  parseUnits,
+  zeroAddress,
+  readContract,
+} from "viem"
+import { beforeAll, describe, expect, inject, test } from "vitest"
+import {createChainAddressMap, runtimeERC20BalanceOf, greaterThanOrEqualTo} from "../../../modules"
+import { getTestChainConfig, TEST_BLOCK_CONFIRMATIONS, toNetwork } from "../../../../test/testSetup"
+import type { NetworkConfig } from "../../../../test/testUtils"
+import { type FeeTokenInfo } from "../../../clients/decorators/mee/getQuote"
+import type { MultichainSmartAccount } from "../../toMultiChainNexusAccount"
+import { toMultichainNexusAccount } from "../../toMultiChainNexusAccount"
+import { mcUSDC } from "../../../constants/tokens"
+import {
+  type MeeClient,
+  createMeeClient
+} from "../../../clients/createMeeClient"
+import { base } from "viem/chains"
+import { optimism } from "viem/chains"
+import { Trigger } from "../../../clients/decorators/mee/signPermitQuote"
+import type { ComposableCall } from "../../../modules/utils/composabilityCalls"
+
+// @ts-ignore
+const { runPaidTests } = inject("settings")
+
+describe("mee.buildAcrossIntentComposable", () => {
+  let network: NetworkConfig
+  let eoaAccount: LocalAccount
+
+  let feeToken: FeeTokenInfo
+  let mcNexus: MultichainSmartAccount
+  let meeClient: MeeClient
+
+  let tokenAddress: Address
+
+  let paymentChain: Chain
+  let targetChain: Chain
+  let transports: Transport[]
+  let decimals: number
+  let pubClient: PublicClient
+  let pubClientTarget: PublicClient
+
+  beforeAll(async () => {
+    network = await toNetwork("MAINNET_FROM_ENV_VARS")
+    ;[[paymentChain, targetChain], transports] = getTestChainConfig(network)
+
+    eoaAccount = network.account!
+    feeToken = {
+      address: mcUSDC.addressOn(paymentChain.id),
+      chainId: paymentChain.id
+    }
+
+    pubClient = createPublicClient({
+      chain: paymentChain,
+      transport: transports[0]
+    })
+
+    decimals = await pubClient.readContract({
+      address: feeToken.address,
+      abi: erc20Abi,
+      functionName: "decimals"
+    })
+
+    pubClientTarget = createPublicClient({
+      chain: targetChain,
+      transport: transports[1]
+    })
+
+    mcNexus = await toMultichainNexusAccount({
+      chains: [paymentChain, targetChain],
+      transports,
+      signer: eoaAccount
+    })
+
+    meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: process.env.PERSONAL_MEE_API_KEY
+    })
+    tokenAddress = mcUSDC.addressOn(paymentChain.id)
+
+  })
+
+  test.runIf(runPaidTests)("should build and execute an across intent composable userOp", async () => {
+     
+    // 🏦 AAVE Pool addresses
+    const aavePoolAddresses = createChainAddressMap([
+      [base.id, '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5'],
+      [optimism.id, '0x794a61358D6845594F94dc1DB02A252b5b4814aD']
+    ])
+    
+    // 💎 aUSDC (AAVE interest-bearing USDC)
+    const aUSDCAddresses = createChainAddressMap([
+      [base.id, '0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB'],
+      [optimism.id, '0x625E7708f30cA75bfd92586e17077590C60eb4cD']
+    ])
+    
+    // 🚀 Across SpokePool addresses
+    const acrossSpokePool = createChainAddressMap([
+      [base.id, '0x09aea4b2242abc8bb4bb78d537a67a245a7bec64'],
+      [optimism.id, '0x6f26Bf09B1C792e3228e5467807a900A503c0281']
+    ])
+
+    const orchOnTargetBalanceBefore = await pubClientTarget.readContract({
+      address: mcUSDC.addressOn(base.id),
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      args: [mcNexus.addressOn(base.id)!]
+    })
+
+    const actualInputAmount = parseUnits("1", decimals)
+    const benchmarkInputAmount = parseUnits("2", decimals)
+
+    const trigger: Trigger = {
+      chainId: optimism.id,
+      tokenAddress: mcUSDC.addressOn(optimism.id),
+      amount: actualInputAmount,
+    }
+
+    const callAcrossInstructions = await mcNexus.buildComposable({
+      type: 'acrossIntent',
+      data: {
+        pool: acrossSpokePool[optimism.id],
+        depositor: mcNexus.addressOn(optimism.id)!, // WOULD IT EVEN WORK? FUNDING USEROP/ACTION SHOULD BE THERE => NEED TO CHECK IT IN THE USEROP
+        recipient: mcNexus.addressOn(base.id)!,
+        inputToken: mcUSDC.addressOn(optimism.id),
+        outputToken: mcUSDC.addressOn(base.id),
+        approximateExpectedInputAmount: benchmarkInputAmount,
+        originChainId: optimism.id,
+        destinationChainId: base.id,
+        message: '0x',
+        relayerAddress: zeroAddress,
+      }
+    })
+
+    const fusionQuote = await meeClient.getFusionQuote({
+      trigger,
+      instructions: callAcrossInstructions,
+      feeToken
+    })
+
+    console.log(fusionQuote.quote.userOps[1]);
+     
+    const { hash } = await meeClient.executeFusionQuote({ fusionQuote })
+    console.log(hash)
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+      confirmations: TEST_BLOCK_CONFIRMATIONS
+    })
+
+    expect(receipt).toBeDefined()
+    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+    
+    
+    const orchOnPaymentBalanceAfter = await pubClient.readContract({
+      address: mcUSDC.addressOn(optimism.id),
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      args: [mcNexus.addressOn(optimism.id)!]
+    })
+    
+    expect(orchOnPaymentBalanceAfter).toEqual(0n)
+
+    const orchOnTargetBalanceAfter = await pubClientTarget.readContract({
+      address: mcUSDC.addressOn(base.id),
+      abi: erc20Abi,
+      functionName: "balanceOf",
+      args: [mcNexus.addressOn(base.id)!]
+    })
+
+    // expect the balance to be balance before + actual input amount - fees and fees are not more than 30%
+    expect(orchOnTargetBalanceAfter).toBeGreaterThanOrEqual(orchOnTargetBalanceBefore + (actualInputAmount * 3n) / 10n)
+
+  })
+})

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
@@ -8,7 +8,6 @@ import {
   createPublicClient,
   erc20Abi,
   parseUnits,
-  readContract,
   zeroAddress
 } from "viem"
 import { base } from "viem/chains"
@@ -27,12 +26,7 @@ import {
 import type { FeeTokenInfo } from "../../../clients/decorators/mee/getQuote"
 import type { Trigger } from "../../../clients/decorators/mee/signPermitQuote"
 import { mcUSDC } from "../../../constants/tokens"
-import {
-  createChainAddressMap,
-  greaterThanOrEqualTo,
-  runtimeERC20BalanceOf
-} from "../../../modules"
-import type { ComposableCall } from "../../../modules/utils/composabilityCalls"
+import { createChainAddressMap } from "../../../modules"
 import type { MultichainSmartAccount } from "../../toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../toMultiChainNexusAccount"
 
@@ -98,24 +92,6 @@ describe("mee.buildAcrossIntentComposable", () => {
   test.runIf(runPaidTests)(
     "should build and execute an across intent composable userOp",
     async () => {
-      // 🏦 AAVE Pool addresses
-      const aavePoolAddresses = createChainAddressMap([
-        [base.id, "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5"],
-        [optimism.id, "0x794a61358D6845594F94dc1DB02A252b5b4814aD"]
-      ])
-
-      // 💎 aUSDC (AAVE interest-bearing USDC)
-      const aUSDCAddresses = createChainAddressMap([
-        [base.id, "0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB"],
-        [optimism.id, "0x625E7708f30cA75bfd92586e17077590C60eb4cD"]
-      ])
-
-      // 🚀 Across SpokePool addresses
-      const acrossSpokePool = createChainAddressMap([
-        [base.id, "0x09aea4b2242abc8bb4bb78d537a67a245a7bec64"],
-        [optimism.id, "0x6f26Bf09B1C792e3228e5467807a900A503c0281"]
-      ])
-
       const orchOnTargetBalanceBefore = await pubClientTarget.readContract({
         address: mcUSDC.addressOn(base.id),
         abi: erc20Abi,
@@ -123,7 +99,7 @@ describe("mee.buildAcrossIntentComposable", () => {
         args: [mcNexus.addressOn(base.id)!]
       })
 
-      const actualInputAmount = parseUnits("1", decimals)
+      const actualInputAmount = parseUnits("0.5", decimals)
       const benchmarkInputAmount = parseUnits("2", decimals)
 
       const trigger: Trigger = {
@@ -135,8 +111,7 @@ describe("mee.buildAcrossIntentComposable", () => {
       const callAcrossInstructions = await mcNexus.buildComposable({
         type: "acrossIntent",
         data: {
-          pool: acrossSpokePool[optimism.id],
-          depositor: mcNexus.addressOn(optimism.id)!, // WOULD IT EVEN WORK? FUNDING USEROP/ACTION SHOULD BE THERE => NEED TO CHECK IT IN THE USEROP
+          depositor: mcNexus.addressOn(optimism.id)!,
           recipient: mcNexus.addressOn(base.id)!,
           inputToken: mcUSDC.addressOn(optimism.id),
           outputToken: mcUSDC.addressOn(base.id),

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.test.ts
@@ -8,25 +8,33 @@ import {
   createPublicClient,
   erc20Abi,
   parseUnits,
-  zeroAddress,
   readContract,
+  zeroAddress
 } from "viem"
+import { base } from "viem/chains"
+import { optimism } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
-import {createChainAddressMap, runtimeERC20BalanceOf, greaterThanOrEqualTo} from "../../../modules"
-import { getTestChainConfig, TEST_BLOCK_CONFIRMATIONS, toNetwork } from "../../../../test/testSetup"
+import {
+  TEST_BLOCK_CONFIRMATIONS,
+  getTestChainConfig,
+  toNetwork
+} from "../../../../test/testSetup"
 import type { NetworkConfig } from "../../../../test/testUtils"
-import { type FeeTokenInfo } from "../../../clients/decorators/mee/getQuote"
-import type { MultichainSmartAccount } from "../../toMultiChainNexusAccount"
-import { toMultichainNexusAccount } from "../../toMultiChainNexusAccount"
-import { mcUSDC } from "../../../constants/tokens"
 import {
   type MeeClient,
   createMeeClient
 } from "../../../clients/createMeeClient"
-import { base } from "viem/chains"
-import { optimism } from "viem/chains"
-import { Trigger } from "../../../clients/decorators/mee/signPermitQuote"
+import type { FeeTokenInfo } from "../../../clients/decorators/mee/getQuote"
+import type { Trigger } from "../../../clients/decorators/mee/signPermitQuote"
+import { mcUSDC } from "../../../constants/tokens"
+import {
+  createChainAddressMap,
+  greaterThanOrEqualTo,
+  runtimeERC20BalanceOf
+} from "../../../modules"
 import type { ComposableCall } from "../../../modules/utils/composabilityCalls"
+import type { MultichainSmartAccount } from "../../toMultiChainNexusAccount"
+import { toMultichainNexusAccount } from "../../toMultiChainNexusAccount"
 
 // @ts-ignore
 const { runPaidTests } = inject("settings")
@@ -85,99 +93,98 @@ describe("mee.buildAcrossIntentComposable", () => {
       apiKey: process.env.PERSONAL_MEE_API_KEY
     })
     tokenAddress = mcUSDC.addressOn(paymentChain.id)
-
   })
 
-  test.runIf(runPaidTests)("should build and execute an across intent composable userOp", async () => {
-     
-    // 🏦 AAVE Pool addresses
-    const aavePoolAddresses = createChainAddressMap([
-      [base.id, '0xA238Dd80C259a72e81d7e4664a9801593F98d1c5'],
-      [optimism.id, '0x794a61358D6845594F94dc1DB02A252b5b4814aD']
-    ])
-    
-    // 💎 aUSDC (AAVE interest-bearing USDC)
-    const aUSDCAddresses = createChainAddressMap([
-      [base.id, '0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB'],
-      [optimism.id, '0x625E7708f30cA75bfd92586e17077590C60eb4cD']
-    ])
-    
-    // 🚀 Across SpokePool addresses
-    const acrossSpokePool = createChainAddressMap([
-      [base.id, '0x09aea4b2242abc8bb4bb78d537a67a245a7bec64'],
-      [optimism.id, '0x6f26Bf09B1C792e3228e5467807a900A503c0281']
-    ])
+  test.runIf(runPaidTests)(
+    "should build and execute an across intent composable userOp",
+    async () => {
+      // 🏦 AAVE Pool addresses
+      const aavePoolAddresses = createChainAddressMap([
+        [base.id, "0xA238Dd80C259a72e81d7e4664a9801593F98d1c5"],
+        [optimism.id, "0x794a61358D6845594F94dc1DB02A252b5b4814aD"]
+      ])
 
-    const orchOnTargetBalanceBefore = await pubClientTarget.readContract({
-      address: mcUSDC.addressOn(base.id),
-      abi: erc20Abi,
-      functionName: "balanceOf",
-      args: [mcNexus.addressOn(base.id)!]
-    })
+      // 💎 aUSDC (AAVE interest-bearing USDC)
+      const aUSDCAddresses = createChainAddressMap([
+        [base.id, "0x4e65fE4DbA92790696d040ac24Aa414708F5c0AB"],
+        [optimism.id, "0x625E7708f30cA75bfd92586e17077590C60eb4cD"]
+      ])
 
-    const actualInputAmount = parseUnits("1", decimals)
-    const benchmarkInputAmount = parseUnits("2", decimals)
+      // 🚀 Across SpokePool addresses
+      const acrossSpokePool = createChainAddressMap([
+        [base.id, "0x09aea4b2242abc8bb4bb78d537a67a245a7bec64"],
+        [optimism.id, "0x6f26Bf09B1C792e3228e5467807a900A503c0281"]
+      ])
 
-    const trigger: Trigger = {
-      chainId: optimism.id,
-      tokenAddress: mcUSDC.addressOn(optimism.id),
-      amount: actualInputAmount,
-    }
+      const orchOnTargetBalanceBefore = await pubClientTarget.readContract({
+        address: mcUSDC.addressOn(base.id),
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [mcNexus.addressOn(base.id)!]
+      })
 
-    const callAcrossInstructions = await mcNexus.buildComposable({
-      type: 'acrossIntent',
-      data: {
-        pool: acrossSpokePool[optimism.id],
-        depositor: mcNexus.addressOn(optimism.id)!, // WOULD IT EVEN WORK? FUNDING USEROP/ACTION SHOULD BE THERE => NEED TO CHECK IT IN THE USEROP
-        recipient: mcNexus.addressOn(base.id)!,
-        inputToken: mcUSDC.addressOn(optimism.id),
-        outputToken: mcUSDC.addressOn(base.id),
-        approximateExpectedInputAmount: benchmarkInputAmount,
-        originChainId: optimism.id,
-        destinationChainId: base.id,
-        message: '0x',
-        relayerAddress: zeroAddress,
+      const actualInputAmount = parseUnits("1", decimals)
+      const benchmarkInputAmount = parseUnits("2", decimals)
+
+      const trigger: Trigger = {
+        chainId: optimism.id,
+        tokenAddress: mcUSDC.addressOn(optimism.id),
+        amount: actualInputAmount
       }
-    })
 
-    const fusionQuote = await meeClient.getFusionQuote({
-      trigger,
-      instructions: callAcrossInstructions,
-      feeToken
-    })
+      const callAcrossInstructions = await mcNexus.buildComposable({
+        type: "acrossIntent",
+        data: {
+          pool: acrossSpokePool[optimism.id],
+          depositor: mcNexus.addressOn(optimism.id)!, // WOULD IT EVEN WORK? FUNDING USEROP/ACTION SHOULD BE THERE => NEED TO CHECK IT IN THE USEROP
+          recipient: mcNexus.addressOn(base.id)!,
+          inputToken: mcUSDC.addressOn(optimism.id),
+          outputToken: mcUSDC.addressOn(base.id),
+          approximateExpectedInputAmount: benchmarkInputAmount,
+          originChainId: optimism.id,
+          destinationChainId: base.id,
+          message: "0x",
+          relayerAddress: zeroAddress
+        }
+      })
 
-    console.log(fusionQuote.quote.userOps[1]);
-     
-    const { hash } = await meeClient.executeFusionQuote({ fusionQuote })
-    console.log(hash)
+      const fusionQuote = await meeClient.getFusionQuote({
+        trigger,
+        instructions: callAcrossInstructions,
+        feeToken
+      })
 
-    const receipt = await meeClient.waitForSupertransactionReceipt({
-      hash,
-      confirmations: TEST_BLOCK_CONFIRMATIONS
-    })
+      const { hash } = await meeClient.executeFusionQuote({ fusionQuote })
+      console.log(hash)
 
-    expect(receipt).toBeDefined()
-    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
-    
-    
-    const orchOnPaymentBalanceAfter = await pubClient.readContract({
-      address: mcUSDC.addressOn(optimism.id),
-      abi: erc20Abi,
-      functionName: "balanceOf",
-      args: [mcNexus.addressOn(optimism.id)!]
-    })
-    
-    expect(orchOnPaymentBalanceAfter).toEqual(0n)
+      const receipt = await meeClient.waitForSupertransactionReceipt({
+        hash,
+        confirmations: TEST_BLOCK_CONFIRMATIONS
+      })
 
-    const orchOnTargetBalanceAfter = await pubClientTarget.readContract({
-      address: mcUSDC.addressOn(base.id),
-      abi: erc20Abi,
-      functionName: "balanceOf",
-      args: [mcNexus.addressOn(base.id)!]
-    })
+      expect(receipt).toBeDefined()
+      expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
 
-    // expect the balance to be balance before + actual input amount - fees and fees are not more than 30%
-    expect(orchOnTargetBalanceAfter).toBeGreaterThanOrEqual(orchOnTargetBalanceBefore + (actualInputAmount * 3n) / 10n)
+      const orchOnPaymentBalanceAfter = await pubClient.readContract({
+        address: mcUSDC.addressOn(optimism.id),
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [mcNexus.addressOn(optimism.id)!]
+      })
 
-  })
+      expect(orchOnPaymentBalanceAfter).toEqual(0n)
+
+      const orchOnTargetBalanceAfter = await pubClientTarget.readContract({
+        address: mcUSDC.addressOn(base.id),
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [mcNexus.addressOn(base.id)!]
+      })
+
+      // expect the balance to be balance before + actual input amount - fees and fees are not more than 30%
+      expect(orchOnTargetBalanceAfter).toBeGreaterThanOrEqual(
+        orchOnTargetBalanceBefore + (actualInputAmount * 3n) / 10n
+      )
+    }
+  )
 })

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -2,24 +2,26 @@ import {
   type Address,
   type Hex,
   concatHex,
-  encodeFunctionData,
   formatUnits,
   getAddress,
   padHex,
   parseAbi,
   zeroAddress
 } from "viem"
-import type { Instruction } from "../../../clients/decorators/mee"
-import { runtimeERC20BalanceOf } from "../../../modules/utils/composabilityCalls"
-import type { BaseInstructionsParams } from "../build"
-import { buildRawComposable } from "./buildRawComposable"
-import buildTransfer from "./buildTransfer"
-import { createChainAddressMap } from "../../../modules/utils/createChainAddressMap"
 import { base, optimism } from "viem/chains"
+import type { Instruction } from "../../../clients/decorators/mee"
+import {
+  runtimeERC20BalanceOf,
+  type RuntimeERC20BalanceOfParams
+} from "../../../modules/utils/composabilityCalls"
+import { createChainAddressMap } from "../../../modules/utils/createChainAddressMap"
+import type { BaseInstructionsParams } from "../build"
+import { buildComposableUtil } from "./buildComposable"
+import buildTransfer from "./buildTransfer"
 
 const acrossIntentWrappers = createChainAddressMap([
-  [Number(base.id), "0xB78dEafFE8448230b89f0979Ef861F453b3F1e02"],
-  [Number(optimism.id), "0xfE86086f5B4731459cB43128e2Dba8248b90600E"]
+  [Number(base.id), "0xB9F82b52Afde09D0E2CC0748a66D1Df76C18A1c7"],
+  [Number(optimism.id), "0x74FebC53e98d85827E57E27F5c4ECD5A138a70A5"]
 ])
 
 // 🚀 Across SpokePool addresses
@@ -36,6 +38,7 @@ export type BuildAcrossIntentComposableParams = {
   recipient: Address
   inputToken: Address
   outputToken: Address
+  runtimeParams: RuntimeERC20BalanceOfParams
   approximateExpectedInputAmount: bigint // approximate amount of deposited tokens.
   originChainId: number
   destinationChainId: number
@@ -57,12 +60,13 @@ export const buildAcrossIntentComposable = async (
     recipient,
     inputToken,
     outputToken,
+    runtimeParams,
+    approximateExpectedInputAmount,
     originChainId,
     destinationChainId,
     message,
     relayerAddress,
     gasLimit,
-    approximateExpectedInputAmount,
     pool = acrossSpokePool[originChainId]
   } = parameters
 
@@ -75,11 +79,7 @@ export const buildAcrossIntentComposable = async (
     {
       chainId: originChainId,
       tokenAddress: inputToken,
-      amount: runtimeERC20BalanceOf({
-        // transfers the entire balance
-        targetAddress: depositor,
-        tokenAddress: inputToken
-      }),
+      amount: runtimeERC20BalanceOf(runtimeParams), // use without changes
       recipient: acrossIntentWrappers[originChainId]
     }
   )
@@ -106,8 +106,6 @@ export const buildAcrossIntentComposable = async (
     (approximateExpectedOutputAmount * outputRatioPrecision) /
     approximateExpectedInputAmount
 
-  console.log("outputRatio", outputRatio)
-
   // make a packed uint256 where the first (most significant) 16 bits are the output ratio
   // and the last 16 bits (least significant) are the output ratio precision
   const outputRatioPacked = concatHex([
@@ -117,14 +115,20 @@ export const buildAcrossIntentComposable = async (
 
   // Define Across SpokePool WRAPPER ABI
   const acrossSpokePoolWrapperAbi = parseAbi([
-    "function depositV3Composable(address pool, address depositor, address recipient, address inputToken, address outputToken, uint256 outputRatioPacked, uint256 destinationChainId, address exclusiveRelayer, uint32 quoteTimestamp, uint32 fillDeadline, uint32 exclusivityDeadline, bytes calldata message) external payable"
+    "function depositV3Composable(address pool, address depositor, address recipient, address inputToken, address outputToken, uint256 inputAmount, uint256 outputRatioPacked, uint256 destinationChainId, address exclusiveRelayer, uint32 quoteTimestamp, uint32 fillDeadline, uint32 exclusivityDeadline, bytes calldata message) external payable"
   ])
 
-  // Build the deposit transaction
-  const transactionRequest = {
-    to: pool,
-    chainId: originChainId,
-    data: encodeFunctionData({
+  const wrapperRuntimeBalance = runtimeERC20BalanceOf({
+    targetAddress: acrossIntentWrappers[originChainId],
+    tokenAddress: runtimeParams.tokenAddress,
+    constraints: runtimeParams.constraints
+  })
+
+  const depositToPoolInstruction = await buildComposableUtil(
+    baseParams,
+    {
+      // BuildComposableParameters
+      to: acrossIntentWrappers[originChainId],
       abi: acrossSpokePoolWrapperAbi,
       functionName: "depositV3Composable",
       args: [
@@ -133,23 +137,20 @@ export const buildAcrossIntentComposable = async (
         recipient,
         inputToken,
         outputToken,
-        BigInt(outputRatioPacked),
-        BigInt(destinationChainId),
+        wrapperRuntimeBalance, // the runtime param
+        outputRatioPacked,
+        destinationChainId,
         relayerAddress ?? zeroAddress,
         Number(fees.timestamp),
         Number(fees.fillDeadline),
-        0, // exclusivityDeadline
-        message ?? "0x" // message
-      ]
-    })
-  }
-
-  const depositToPoolInstruction = await buildRawComposable(baseParams, {
-    to: acrossIntentWrappers[originChainId],
-    calldata: transactionRequest.data,
-    chainId: originChainId,
-    gasLimit
-  })
+        0,
+        message ?? "0x"
+      ],
+      chainId: originChainId,
+      gasLimit
+    },
+    true // efficientMode
+  )
 
   return [...transferFromNexusToWrapperInstruction, ...depositToPoolInstruction]
 }

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -70,6 +70,10 @@ export const buildAcrossIntentComposable = async (
     pool = acrossSpokePool[originChainId]
   } = parameters
 
+  if (destinationChainId === originChainId) {
+    throw new Error("Destination chain and origin should be different")
+  }
+
   // 1. Transfer from Nexus to Wrapper
   // It is required because Across SpokePool deposit functions
   // do transferFrom(msg.sender, address(this), amount)
@@ -266,7 +270,7 @@ export async function getAcrossSuggestedFees(
 
   if (!response.ok) {
     throw new Error(
-      `HTTP error! status: ${response.status} with url: ${url.toString()}`
+      `HTTP error! status: ${response.status}, message: ${response.statusText} <= with url: ${url.toString()}`
     )
   }
 

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -11,8 +11,8 @@ import {
 import { base, optimism } from "viem/chains"
 import type { Instruction } from "../../../clients/decorators/mee"
 import {
-  runtimeERC20BalanceOf,
-  type RuntimeERC20BalanceOfParams
+  type RuntimeERC20BalanceOfParams,
+  runtimeERC20BalanceOf
 } from "../../../modules/utils/composabilityCalls"
 import { createChainAddressMap } from "../../../modules/utils/createChainAddressMap"
 import type { BaseInstructionsParams } from "../build"
@@ -38,7 +38,7 @@ export type BuildAcrossIntentComposableParams = {
   recipient: Address
   inputToken: Address
   outputToken: Address
-  runtimeParams: RuntimeERC20BalanceOfParams
+  inputAmountRuntimeParams: RuntimeERC20BalanceOfParams
   approximateExpectedInputAmount: bigint // approximate amount of deposited tokens.
   originChainId: number
   destinationChainId: number
@@ -60,7 +60,7 @@ export const buildAcrossIntentComposable = async (
     recipient,
     inputToken,
     outputToken,
-    runtimeParams,
+    inputAmountRuntimeParams,
     approximateExpectedInputAmount,
     originChainId,
     destinationChainId,
@@ -79,7 +79,7 @@ export const buildAcrossIntentComposable = async (
     {
       chainId: originChainId,
       tokenAddress: inputToken,
-      amount: runtimeERC20BalanceOf(runtimeParams), // use without changes
+      amount: runtimeERC20BalanceOf(inputAmountRuntimeParams), // use without changes
       recipient: acrossIntentWrappers[originChainId]
     }
   )
@@ -120,8 +120,8 @@ export const buildAcrossIntentComposable = async (
 
   const wrapperRuntimeBalance = runtimeERC20BalanceOf({
     targetAddress: acrossIntentWrappers[originChainId],
-    tokenAddress: runtimeParams.tokenAddress,
-    constraints: runtimeParams.constraints
+    tokenAddress: inputAmountRuntimeParams.tokenAddress,
+    constraints: inputAmountRuntimeParams.constraints
   })
 
   const depositToPoolInstruction = await buildComposableUtil(

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -5,27 +5,33 @@ import {
   encodeFunctionData,
   formatUnits,
   getAddress,
-  isAddress,
   padHex,
   parseAbi,
-  parseUnits,
   zeroAddress
 } from "viem"
 import type { Instruction } from "../../../clients/decorators/mee"
 import { runtimeERC20BalanceOf } from "../../../modules/utils/composabilityCalls"
 import type { BaseInstructionsParams } from "../build"
-import buildApprove from "./buildApprove"
 import { buildRawComposable } from "./buildRawComposable"
 import buildTransfer from "./buildTransfer"
+import { createChainAddressMap } from "../../../modules/utils/createChainAddressMap"
+import { base, optimism } from "viem/chains"
 
-export const ACROSS_INTENT_WRAPPER_ADDRESS =
-  "0xfE86086f5B4731459cB43128e2Dba8248b90600E" // OPTIMISM MAINNET ONLY
+const acrossIntentWrappers = createChainAddressMap([
+  [Number(base.id), "0xB78dEafFE8448230b89f0979Ef861F453b3F1e02"],
+  [Number(optimism.id), "0xfE86086f5B4731459cB43128e2Dba8248b90600E"]
+])
+
+// 🚀 Across SpokePool addresses
+const acrossSpokePool = createChainAddressMap([
+  [Number(base.id), "0x09aea4b2242abc8bb4bb78d537a67a245a7bec64"],
+  [Number(optimism.id), "0x6f26Bf09B1C792e3228e5467807a900A503c0281"]
+])
 
 /**
  * Parameters for building a raw composable instruction
  */
 export type BuildAcrossIntentComposableParams = {
-  pool: Address
   depositor: Address
   recipient: Address
   inputToken: Address
@@ -35,6 +41,7 @@ export type BuildAcrossIntentComposableParams = {
   destinationChainId: number
   message?: Hex
   relayerAddress?: Address
+  pool?: Address
   gasLimit?: bigint
 }
 
@@ -46,7 +53,6 @@ export const buildAcrossIntentComposable = async (
   parameters: BuildAcrossIntentComposableParams
 ): Promise<Instruction[]> => {
   const {
-    pool,
     depositor,
     recipient,
     inputToken,
@@ -56,10 +62,14 @@ export const buildAcrossIntentComposable = async (
     message,
     relayerAddress,
     gasLimit,
-    approximateExpectedInputAmount
+    approximateExpectedInputAmount,
+    pool = acrossSpokePool[originChainId]
   } = parameters
 
   // 1. Transfer from Nexus to Wrapper
+  // It is required because Across SpokePool deposit functions
+  // do transferFrom(msg.sender, address(this), amount)
+  // so we need Wrapper to actually have this balance
   const transferFromNexusToWrapperInstruction = await buildTransfer(
     baseParams,
     {
@@ -70,12 +80,11 @@ export const buildAcrossIntentComposable = async (
         targetAddress: depositor,
         tokenAddress: inputToken
       }),
-      recipient: ACROSS_INTENT_WRAPPER_ADDRESS
+      recipient: acrossIntentWrappers[originChainId]
     }
   )
 
   // 2. Deposit to Pool
-
   const fees = await getAcrossSuggestedFees({
     amount: approximateExpectedInputAmount,
     originChainId,
@@ -99,13 +108,12 @@ export const buildAcrossIntentComposable = async (
 
   console.log("outputRatio", outputRatio)
 
-  //make a packed uint256 where the first (most significant) 16 bits are the output ratio and the last 16 bits (least significant) are the output ratio precision
+  // make a packed uint256 where the first (most significant) 16 bits are the output ratio
+  // and the last 16 bits (least significant) are the output ratio precision
   const outputRatioPacked = concatHex([
     padHex(outputRatio.toString(16) as `0x${string}`, { size: 16 }),
     padHex(outputRatioPrecision.toString(16) as `0x${string}`, { size: 16 })
   ])
-
-  // console.log('outputRatioPacked', outputRatioPacked.toString(16))
 
   // Define Across SpokePool WRAPPER ABI
   const acrossSpokePoolWrapperAbi = parseAbi([
@@ -137,7 +145,7 @@ export const buildAcrossIntentComposable = async (
   }
 
   const depositToPoolInstruction = await buildRawComposable(baseParams, {
-    to: ACROSS_INTENT_WRAPPER_ADDRESS, // TODO: make this dynamic based on the chain id
+    to: acrossIntentWrappers[originChainId],
     calldata: transactionRequest.data,
     chainId: originChainId,
     gasLimit
@@ -248,8 +256,6 @@ export async function getAcrossSuggestedFees(
     url.searchParams.append("referrer", getAddress(referrer))
   }
 
-  console.log("url", url.toString())
-
   const response = await fetch(url.toString(), {
     method: "GET",
     headers: {
@@ -258,7 +264,9 @@ export async function getAcrossSuggestedFees(
   })
 
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`)
+    throw new Error(
+      `HTTP error! status: ${response.status} with url: ${url.toString()}`
+    )
   }
 
   const data = (await response.json()) as {

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -20,8 +20,8 @@ import { buildComposableUtil } from "./buildComposable"
 import buildTransfer from "./buildTransfer"
 
 const acrossIntentWrappers = createChainAddressMap([
-  [Number(base.id), "0xB9F82b52Afde09D0E2CC0748a66D1Df76C18A1c7"],
-  [Number(optimism.id), "0x74FebC53e98d85827E57E27F5c4ECD5A138a70A5"]
+  [Number(base.id), "0x000000E2E47D694bDAa5a46056A894e747ED2854"],
+  [Number(optimism.id), "0x000000E2E47D694bDAa5a46056A894e747ED2854"]
 ])
 
 // 🚀 Across SpokePool addresses

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -1,0 +1,341 @@
+import { type Address, type Hex, isAddress, getAddress, formatUnits, parseUnits, parseAbi, encodeFunctionData, zeroAddress, concatHex, padHex } from "viem"
+import type { Instruction } from "../../../clients/decorators/mee"
+import type { BaseInstructionsParams } from "../build"
+import { buildRawComposable } from "./buildRawComposable"
+import buildTransfer from "./buildTransfer"
+import { runtimeERC20BalanceOf } from "../../../modules/utils/composabilityCalls"
+import buildApprove from "./buildApprove"
+
+export const ACROSS_INTENT_WRAPPER_ADDRESS = '0xfE86086f5B4731459cB43128e2Dba8248b90600E' // OPTIMISM MAINNET ONLY
+
+/**
+ * Parameters for building a raw composable instruction
+ */
+export type BuildAcrossIntentComposableParams = {
+  pool: Address,
+  depositor: Address
+  recipient: Address
+  inputToken: Address
+  outputToken: Address
+  approximateExpectedInputAmount: bigint // approximate amount of deposited tokens.
+  originChainId: number
+  destinationChainId: number
+  message?: Hex
+  relayerAddress?: Address
+  gasLimit?: bigint
+}
+
+/**
+ * Builds an instruction for across
+ */
+export const buildAcrossIntentComposable = async (
+  baseParams: BaseInstructionsParams,
+  parameters: BuildAcrossIntentComposableParams
+): Promise<Instruction[]> => {
+  
+  const { pool, depositor, recipient, inputToken, outputToken, originChainId, destinationChainId, message, relayerAddress, gasLimit, approximateExpectedInputAmount } = parameters
+
+  // 1. Transfer from Nexus to Wrapper
+  const transferFromNexusToWrapperInstruction = await buildTransfer(baseParams, {
+    chainId: originChainId,
+    tokenAddress: inputToken,
+    amount: runtimeERC20BalanceOf({ // transfers the entire balance
+      targetAddress: depositor,
+      tokenAddress: inputToken
+    }),
+    recipient: ACROSS_INTENT_WRAPPER_ADDRESS
+  })
+
+  // 2. Deposit to Pool
+
+  const fees = await getAcrossSuggestedFees({
+    amount: approximateExpectedInputAmount,
+    originChainId,
+    inputToken,
+    destinationChainId,
+    outputToken
+  })
+
+  // Calculate output amount after fees
+  const { outputAmount: approximateExpectedOutputAmount } = calculateAcrossFees({
+    fees,
+    amount: approximateExpectedInputAmount
+  })
+
+  const outputRatioPrecision = 10000n // 5 decimal places
+  const outputRatio = (approximateExpectedOutputAmount * outputRatioPrecision) / approximateExpectedInputAmount
+  
+  console.log('outputRatio', outputRatio)
+
+  //make a packed uint256 where the first (most significant) 16 bits are the output ratio and the last 16 bits (least significant) are the output ratio precision
+  const outputRatioPacked = concatHex([
+    padHex(outputRatio.toString(16) as `0x${string}`, { size: 16 }),
+    padHex(outputRatioPrecision.toString(16) as `0x${string}`, { size: 16 })
+  ])
+
+  // console.log('outputRatioPacked', outputRatioPacked.toString(16))
+
+  // Define Across SpokePool WRAPPER ABI
+  const acrossSpokePoolWrapperAbi = parseAbi([
+    'function depositV3Composable(address pool, address depositor, address recipient, address inputToken, address outputToken, uint256 outputRatioPacked, uint256 destinationChainId, address exclusiveRelayer, uint32 quoteTimestamp, uint32 fillDeadline, uint32 exclusivityDeadline, bytes calldata message) external payable'
+  ])
+
+  // Build the deposit transaction
+  const transactionRequest = {
+    to: pool,
+    chainId: originChainId,
+    data: encodeFunctionData({
+      abi: acrossSpokePoolWrapperAbi,
+      functionName: 'depositV3Composable',
+      args: [
+        pool,
+        depositor,
+        recipient,
+        inputToken,
+        outputToken,
+        BigInt(outputRatioPacked),
+        BigInt(destinationChainId),
+        relayerAddress ?? zeroAddress,
+        Number(fees.timestamp),
+        Number(fees.fillDeadline),
+        0,                                        // exclusivityDeadline
+        message ?? '0x'                                      // message
+      ]
+    })
+  }
+
+  const depositToPoolInstruction = await buildRawComposable(baseParams, {
+    to: ACROSS_INTENT_WRAPPER_ADDRESS, // TODO: make this dynamic based on the chain id
+    calldata: transactionRequest.data,
+    chainId: originChainId,
+    gasLimit
+  })
+
+  return [
+    ...transferFromNexusToWrapperInstruction,
+    ...depositToPoolInstruction
+  ]
+}
+
+export default buildAcrossIntentComposable
+
+/**
+ * -------------------------------------------------------------
+ *  Across Protocol Quote Service — typed with viem
+ * -------------------------------------------------------------
+ */
+ 
+export type SuggestedFeesParameters = {
+  inputToken: Address;
+  outputToken: Address;
+  originChainId: number;
+  destinationChainId: number;
+  amount: bigint;
+  depositor?: Address;
+  recipient?: Address;
+  message?: Hex;
+  relayerAddress?: Address;
+  referrer?: Address;
+};
+ 
+export type Fee = {
+  pct: bigint;
+  total: bigint;
+};
+ 
+export type Limits = {
+  minDeposit: bigint;
+  maxDeposit: bigint;
+  maxDepositInstant: bigint;
+  maxDepositShortDelay: bigint;
+  recommendedDepositInstant: bigint;
+};
+ 
+export type SuggestedFeesReturnType = {
+  totalRelayFee: Fee;
+  relayerCapitalFee: Fee;
+  relayerGasFee: Fee;
+  lpFee: Fee;
+  timestamp: bigint;
+  isAmountTooLow: boolean;
+  quoteBlock: bigint;
+  spokePoolAddress: Address;
+  fillDeadline: bigint;
+  limits: Limits;
+};
+ 
+export type GetSuggestedFeesErrorType = Error;
+ 
+/**
+ * Gets suggested fees for Across Protocol bridge transfer
+ * 
+ * @example
+ * const fees = await getAcrossSuggestedFees({
+ *   inputToken: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+ *   outputToken: '0x4200000000000000000000000000000000000006',
+ *   originChainId: 1,
+ *   destinationChainId: 10,
+ *   amount: parseEther('1')
+ * })
+ */
+export async function getAcrossSuggestedFees(
+  parameters: SuggestedFeesParameters
+): Promise<SuggestedFeesReturnType> {
+  const {
+    inputToken,
+    outputToken,
+    originChainId,
+    destinationChainId,
+    amount,
+    depositor,
+    recipient,
+    message,
+    relayerAddress,
+    referrer
+  } = parameters;
+ 
+  const url = new URL('https://app.across.to/api/suggested-fees');
+  
+  // Validate and format addresses
+  url.searchParams.append('inputToken', getAddress(inputToken));
+  url.searchParams.append('outputToken', getAddress(outputToken));
+  url.searchParams.append('originChainId', originChainId.toString());
+  url.searchParams.append('destinationChainId', destinationChainId.toString());
+  url.searchParams.append('amount', amount.toString());
+  
+  if (depositor) {
+    url.searchParams.append('depositor', getAddress(depositor));
+  }
+  if (recipient) {
+    url.searchParams.append('recipient', getAddress(recipient));
+  }
+  if (message) {
+    url.searchParams.append('message', message);
+  }
+  if (relayerAddress) {
+    url.searchParams.append('relayerAddress', getAddress(relayerAddress));
+  }
+  if (referrer) {
+    url.searchParams.append('referrer', getAddress(referrer));
+  }
+
+  console.log("url", url.toString());
+ 
+  const response = await fetch(url.toString(), {
+    method: 'GET',
+    headers: {
+      'Accept': 'application/json',
+    },
+  });
+ 
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+ 
+  const data = await response.json() as {
+    totalRelayFee: { pct: string; total: string };
+    relayerCapitalFee: { pct: string; total: string };
+    relayerGasFee: { pct: string; total: string };
+    lpFee: { pct: string; total: string };
+    timestamp: string;
+    isAmountTooLow: boolean;
+    quoteBlock: string;
+    spokePoolAddress: string;
+    expectedFillTimeSec: string;
+    fillDeadline: string;
+    limits: {
+      minDeposit: string;
+      maxDeposit: string;
+      maxDepositInstant: string;
+      maxDepositShortDelay: string;
+      recommendedDepositInstant: string;
+    };
+  };
+  
+  // Parse response to bigint types
+  return {
+    totalRelayFee: {
+      pct: BigInt(data.totalRelayFee.pct),
+      total: BigInt(data.totalRelayFee.total)
+    },
+    relayerCapitalFee: {
+      pct: BigInt(data.relayerCapitalFee.pct),
+      total: BigInt(data.relayerCapitalFee.total)
+    },
+    relayerGasFee: {
+      pct: BigInt(data.relayerGasFee.pct),
+      total: BigInt(data.relayerGasFee.total)
+    },
+    lpFee: {
+      pct: BigInt(data.lpFee.pct),
+      total: BigInt(data.lpFee.total)
+    },
+    timestamp: BigInt(data.timestamp),
+    isAmountTooLow: data.isAmountTooLow,
+    quoteBlock: BigInt(data.quoteBlock),
+    spokePoolAddress: getAddress(data.spokePoolAddress),
+    fillDeadline: BigInt(data.fillDeadline),
+    limits: {
+      minDeposit: BigInt(data.limits.minDeposit),
+      maxDeposit: BigInt(data.limits.maxDeposit),
+      maxDepositInstant: BigInt(data.limits.maxDepositInstant),
+      maxDepositShortDelay: BigInt(data.limits.maxDepositShortDelay),
+      recommendedDepositInstant: BigInt(data.limits.recommendedDepositInstant)
+    }
+  };
+}
+ 
+/**
+ * Calculates total fees from suggested fees response
+ * 
+ * @example
+ * const result = calculateAcrossFees({
+ *   fees,
+ *   amount: parseEther('1')
+ * })
+ * 
+ * console.log(result.totalFees) // 0.005n (example)
+ * console.log(result.outputAmount) // 0.995n (example)
+ */
+export type CalculateAcrossFeesParameters = {
+  fees: SuggestedFeesReturnType;
+  amount: bigint;
+};
+ 
+export type CalculateAcrossFeesReturnType = {
+  totalFees: bigint;
+  relayerFees: bigint;
+  lpFees: bigint;
+  outputAmount: bigint;
+};
+ 
+export function calculateAcrossFees(
+  parameters: CalculateAcrossFeesParameters
+): CalculateAcrossFeesReturnType {
+  const { fees, amount } = parameters;
+  
+  // Calculate fees based on percentages (denominated in 1e18)
+  const PRECISION = 10n ** 18n;
+  
+  const relayerFees = (amount * fees.totalRelayFee.pct) / PRECISION;
+  const lpFees = (amount * fees.lpFee.pct) / PRECISION;
+  const totalFees = relayerFees + lpFees;
+  const outputAmount = amount - totalFees;
+  
+  return {
+    totalFees,
+    relayerFees,
+    lpFees,
+    outputAmount
+  };
+}
+ 
+/**
+ * Formats Across fee percentage to human readable format
+ * 
+ * @example
+ * formatAcrossFeePercentage(376607094864283n) // "0.0376607094864283"
+ */
+export function formatAcrossFeePercentage(pct: bigint): string {
+  return formatUnits(pct, 16); // Across uses 1e18 for 100%, so 1e16 for 1%
+}

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -19,9 +19,17 @@ import type { BaseInstructionsParams } from "../build"
 import { buildComposableUtil } from "./buildComposable"
 import buildTransfer from "./buildTransfer"
 
+/**
+ * Default Across Intent Wrapper address
+ */
+const defaultAcrossIntentWrapperAddress = "0x000000E2E47D694bDAa5a46056A894e747ED2854"
+
+/**
+ * Across Intent Wrapper address per chain
+ * Should be set for a chain, if it does not match the default one on this given chain
+ */
 const acrossIntentWrappers = createChainAddressMap([
-  [Number(base.id), "0x000000E2E47D694bDAa5a46056A894e747ED2854"],
-  [Number(optimism.id), "0x000000E2E47D694bDAa5a46056A894e747ED2854"]
+  // [Number(base.id), "0x000000E2E47D694bDAa5a46056A894e747ED2854"],
 ])
 
 // 🚀 Across SpokePool addresses
@@ -74,6 +82,8 @@ export const buildAcrossIntentComposable = async (
     throw new Error("Destination chain and origin should be different")
   }
 
+  const acrossIntentWrapperOnOrigin = _getAcrossIntentWrapper(originChainId)
+
   // 1. Transfer from Nexus to Wrapper
   // It is required because Across SpokePool deposit functions
   // do transferFrom(msg.sender, address(this), amount)
@@ -84,7 +94,7 @@ export const buildAcrossIntentComposable = async (
       chainId: originChainId,
       tokenAddress: inputToken,
       amount: runtimeERC20BalanceOf(inputAmountRuntimeParams), // use without changes
-      recipient: acrossIntentWrappers[originChainId]
+      recipient: acrossIntentWrapperOnOrigin
     }
   )
 
@@ -123,7 +133,7 @@ export const buildAcrossIntentComposable = async (
   ])
 
   const wrapperRuntimeBalance = runtimeERC20BalanceOf({
-    targetAddress: acrossIntentWrappers[originChainId],
+    targetAddress: acrossIntentWrapperOnOrigin,
     tokenAddress: inputAmountRuntimeParams.tokenAddress,
     constraints: inputAmountRuntimeParams.constraints
   })
@@ -132,7 +142,7 @@ export const buildAcrossIntentComposable = async (
     baseParams,
     {
       // BuildComposableParameters
-      to: acrossIntentWrappers[originChainId],
+      to: acrossIntentWrapperOnOrigin,
       abi: acrossSpokePoolWrapperAbi,
       functionName: "depositV3Composable",
       args: [
@@ -208,6 +218,26 @@ export type SuggestedFeesReturnType = {
 
 export type GetSuggestedFeesErrorType = Error
 
+export type AcrossFeesApiResponse = {
+  totalRelayFee: { pct: string; total: string }
+  relayerCapitalFee: { pct: string; total: string }
+  relayerGasFee: { pct: string; total: string }
+  lpFee: { pct: string; total: string }
+  timestamp: string
+  isAmountTooLow: boolean
+  quoteBlock: string
+  spokePoolAddress: string
+  expectedFillTimeSec: string
+  fillDeadline: string
+  limits: {
+    minDeposit: string
+    maxDeposit: string
+    maxDepositInstant: string
+    maxDepositShortDelay: string
+    recommendedDepositInstant: string
+  }
+}
+
 /**
  * Gets suggested fees for Across Protocol bridge transfer
  *
@@ -274,25 +304,7 @@ export async function getAcrossSuggestedFees(
     )
   }
 
-  const data = (await response.json()) as {
-    totalRelayFee: { pct: string; total: string }
-    relayerCapitalFee: { pct: string; total: string }
-    relayerGasFee: { pct: string; total: string }
-    lpFee: { pct: string; total: string }
-    timestamp: string
-    isAmountTooLow: boolean
-    quoteBlock: string
-    spokePoolAddress: string
-    expectedFillTimeSec: string
-    fillDeadline: string
-    limits: {
-      minDeposit: string
-      maxDeposit: string
-      maxDepositInstant: string
-      maxDepositShortDelay: string
-      recommendedDepositInstant: string
-    }
-  }
+  const data = (await response.json()) as AcrossFeesApiResponse
 
   // Parse response to bigint types
   return {
@@ -380,4 +392,11 @@ export function calculateAcrossFees(
  */
 export function formatAcrossFeePercentage(pct: bigint): string {
   return formatUnits(pct, 16) // Across uses 1e18 for 100%, so 1e16 for 1%
+}
+
+const _getAcrossIntentWrapper = (chainId: number) => {
+  if (acrossIntentWrappers[chainId]) {
+    return acrossIntentWrappers[chainId]
+  }
+  return defaultAcrossIntentWrapperAddress
 }

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -1,18 +1,31 @@
-import { type Address, type Hex, isAddress, getAddress, formatUnits, parseUnits, parseAbi, encodeFunctionData, zeroAddress, concatHex, padHex } from "viem"
+import {
+  type Address,
+  type Hex,
+  concatHex,
+  encodeFunctionData,
+  formatUnits,
+  getAddress,
+  isAddress,
+  padHex,
+  parseAbi,
+  parseUnits,
+  zeroAddress
+} from "viem"
 import type { Instruction } from "../../../clients/decorators/mee"
+import { runtimeERC20BalanceOf } from "../../../modules/utils/composabilityCalls"
 import type { BaseInstructionsParams } from "../build"
+import buildApprove from "./buildApprove"
 import { buildRawComposable } from "./buildRawComposable"
 import buildTransfer from "./buildTransfer"
-import { runtimeERC20BalanceOf } from "../../../modules/utils/composabilityCalls"
-import buildApprove from "./buildApprove"
 
-export const ACROSS_INTENT_WRAPPER_ADDRESS = '0xfE86086f5B4731459cB43128e2Dba8248b90600E' // OPTIMISM MAINNET ONLY
+export const ACROSS_INTENT_WRAPPER_ADDRESS =
+  "0xfE86086f5B4731459cB43128e2Dba8248b90600E" // OPTIMISM MAINNET ONLY
 
 /**
  * Parameters for building a raw composable instruction
  */
 export type BuildAcrossIntentComposableParams = {
-  pool: Address,
+  pool: Address
   depositor: Address
   recipient: Address
   inputToken: Address
@@ -32,19 +45,34 @@ export const buildAcrossIntentComposable = async (
   baseParams: BaseInstructionsParams,
   parameters: BuildAcrossIntentComposableParams
 ): Promise<Instruction[]> => {
-  
-  const { pool, depositor, recipient, inputToken, outputToken, originChainId, destinationChainId, message, relayerAddress, gasLimit, approximateExpectedInputAmount } = parameters
+  const {
+    pool,
+    depositor,
+    recipient,
+    inputToken,
+    outputToken,
+    originChainId,
+    destinationChainId,
+    message,
+    relayerAddress,
+    gasLimit,
+    approximateExpectedInputAmount
+  } = parameters
 
   // 1. Transfer from Nexus to Wrapper
-  const transferFromNexusToWrapperInstruction = await buildTransfer(baseParams, {
-    chainId: originChainId,
-    tokenAddress: inputToken,
-    amount: runtimeERC20BalanceOf({ // transfers the entire balance
-      targetAddress: depositor,
-      tokenAddress: inputToken
-    }),
-    recipient: ACROSS_INTENT_WRAPPER_ADDRESS
-  })
+  const transferFromNexusToWrapperInstruction = await buildTransfer(
+    baseParams,
+    {
+      chainId: originChainId,
+      tokenAddress: inputToken,
+      amount: runtimeERC20BalanceOf({
+        // transfers the entire balance
+        targetAddress: depositor,
+        tokenAddress: inputToken
+      }),
+      recipient: ACROSS_INTENT_WRAPPER_ADDRESS
+    }
+  )
 
   // 2. Deposit to Pool
 
@@ -57,15 +85,19 @@ export const buildAcrossIntentComposable = async (
   })
 
   // Calculate output amount after fees
-  const { outputAmount: approximateExpectedOutputAmount } = calculateAcrossFees({
-    fees,
-    amount: approximateExpectedInputAmount
-  })
+  const { outputAmount: approximateExpectedOutputAmount } = calculateAcrossFees(
+    {
+      fees,
+      amount: approximateExpectedInputAmount
+    }
+  )
 
   const outputRatioPrecision = 10000n // 5 decimal places
-  const outputRatio = (approximateExpectedOutputAmount * outputRatioPrecision) / approximateExpectedInputAmount
-  
-  console.log('outputRatio', outputRatio)
+  const outputRatio =
+    (approximateExpectedOutputAmount * outputRatioPrecision) /
+    approximateExpectedInputAmount
+
+  console.log("outputRatio", outputRatio)
 
   //make a packed uint256 where the first (most significant) 16 bits are the output ratio and the last 16 bits (least significant) are the output ratio precision
   const outputRatioPacked = concatHex([
@@ -77,7 +109,7 @@ export const buildAcrossIntentComposable = async (
 
   // Define Across SpokePool WRAPPER ABI
   const acrossSpokePoolWrapperAbi = parseAbi([
-    'function depositV3Composable(address pool, address depositor, address recipient, address inputToken, address outputToken, uint256 outputRatioPacked, uint256 destinationChainId, address exclusiveRelayer, uint32 quoteTimestamp, uint32 fillDeadline, uint32 exclusivityDeadline, bytes calldata message) external payable'
+    "function depositV3Composable(address pool, address depositor, address recipient, address inputToken, address outputToken, uint256 outputRatioPacked, uint256 destinationChainId, address exclusiveRelayer, uint32 quoteTimestamp, uint32 fillDeadline, uint32 exclusivityDeadline, bytes calldata message) external payable"
   ])
 
   // Build the deposit transaction
@@ -86,7 +118,7 @@ export const buildAcrossIntentComposable = async (
     chainId: originChainId,
     data: encodeFunctionData({
       abi: acrossSpokePoolWrapperAbi,
-      functionName: 'depositV3Composable',
+      functionName: "depositV3Composable",
       args: [
         pool,
         depositor,
@@ -98,8 +130,8 @@ export const buildAcrossIntentComposable = async (
         relayerAddress ?? zeroAddress,
         Number(fees.timestamp),
         Number(fees.fillDeadline),
-        0,                                        // exclusivityDeadline
-        message ?? '0x'                                      // message
+        0, // exclusivityDeadline
+        message ?? "0x" // message
       ]
     })
   }
@@ -111,10 +143,7 @@ export const buildAcrossIntentComposable = async (
     gasLimit
   })
 
-  return [
-    ...transferFromNexusToWrapperInstruction,
-    ...depositToPoolInstruction
-  ]
+  return [...transferFromNexusToWrapperInstruction, ...depositToPoolInstruction]
 }
 
 export default buildAcrossIntentComposable
@@ -124,51 +153,51 @@ export default buildAcrossIntentComposable
  *  Across Protocol Quote Service — typed with viem
  * -------------------------------------------------------------
  */
- 
+
 export type SuggestedFeesParameters = {
-  inputToken: Address;
-  outputToken: Address;
-  originChainId: number;
-  destinationChainId: number;
-  amount: bigint;
-  depositor?: Address;
-  recipient?: Address;
-  message?: Hex;
-  relayerAddress?: Address;
-  referrer?: Address;
-};
- 
+  inputToken: Address
+  outputToken: Address
+  originChainId: number
+  destinationChainId: number
+  amount: bigint
+  depositor?: Address
+  recipient?: Address
+  message?: Hex
+  relayerAddress?: Address
+  referrer?: Address
+}
+
 export type Fee = {
-  pct: bigint;
-  total: bigint;
-};
- 
+  pct: bigint
+  total: bigint
+}
+
 export type Limits = {
-  minDeposit: bigint;
-  maxDeposit: bigint;
-  maxDepositInstant: bigint;
-  maxDepositShortDelay: bigint;
-  recommendedDepositInstant: bigint;
-};
- 
+  minDeposit: bigint
+  maxDeposit: bigint
+  maxDepositInstant: bigint
+  maxDepositShortDelay: bigint
+  recommendedDepositInstant: bigint
+}
+
 export type SuggestedFeesReturnType = {
-  totalRelayFee: Fee;
-  relayerCapitalFee: Fee;
-  relayerGasFee: Fee;
-  lpFee: Fee;
-  timestamp: bigint;
-  isAmountTooLow: boolean;
-  quoteBlock: bigint;
-  spokePoolAddress: Address;
-  fillDeadline: bigint;
-  limits: Limits;
-};
- 
-export type GetSuggestedFeesErrorType = Error;
- 
+  totalRelayFee: Fee
+  relayerCapitalFee: Fee
+  relayerGasFee: Fee
+  lpFee: Fee
+  timestamp: bigint
+  isAmountTooLow: boolean
+  quoteBlock: bigint
+  spokePoolAddress: Address
+  fillDeadline: bigint
+  limits: Limits
+}
+
+export type GetSuggestedFeesErrorType = Error
+
 /**
  * Gets suggested fees for Across Protocol bridge transfer
- * 
+ *
  * @example
  * const fees = await getAcrossSuggestedFees({
  *   inputToken: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
@@ -192,66 +221,66 @@ export async function getAcrossSuggestedFees(
     message,
     relayerAddress,
     referrer
-  } = parameters;
- 
-  const url = new URL('https://app.across.to/api/suggested-fees');
-  
+  } = parameters
+
+  const url = new URL("https://app.across.to/api/suggested-fees")
+
   // Validate and format addresses
-  url.searchParams.append('inputToken', getAddress(inputToken));
-  url.searchParams.append('outputToken', getAddress(outputToken));
-  url.searchParams.append('originChainId', originChainId.toString());
-  url.searchParams.append('destinationChainId', destinationChainId.toString());
-  url.searchParams.append('amount', amount.toString());
-  
+  url.searchParams.append("inputToken", getAddress(inputToken))
+  url.searchParams.append("outputToken", getAddress(outputToken))
+  url.searchParams.append("originChainId", originChainId.toString())
+  url.searchParams.append("destinationChainId", destinationChainId.toString())
+  url.searchParams.append("amount", amount.toString())
+
   if (depositor) {
-    url.searchParams.append('depositor', getAddress(depositor));
+    url.searchParams.append("depositor", getAddress(depositor))
   }
   if (recipient) {
-    url.searchParams.append('recipient', getAddress(recipient));
+    url.searchParams.append("recipient", getAddress(recipient))
   }
   if (message) {
-    url.searchParams.append('message', message);
+    url.searchParams.append("message", message)
   }
   if (relayerAddress) {
-    url.searchParams.append('relayerAddress', getAddress(relayerAddress));
+    url.searchParams.append("relayerAddress", getAddress(relayerAddress))
   }
   if (referrer) {
-    url.searchParams.append('referrer', getAddress(referrer));
+    url.searchParams.append("referrer", getAddress(referrer))
   }
 
-  console.log("url", url.toString());
- 
+  console.log("url", url.toString())
+
   const response = await fetch(url.toString(), {
-    method: 'GET',
+    method: "GET",
     headers: {
-      'Accept': 'application/json',
-    },
-  });
- 
+      Accept: "application/json"
+    }
+  })
+
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
+    throw new Error(`HTTP error! status: ${response.status}`)
   }
- 
-  const data = await response.json() as {
-    totalRelayFee: { pct: string; total: string };
-    relayerCapitalFee: { pct: string; total: string };
-    relayerGasFee: { pct: string; total: string };
-    lpFee: { pct: string; total: string };
-    timestamp: string;
-    isAmountTooLow: boolean;
-    quoteBlock: string;
-    spokePoolAddress: string;
-    expectedFillTimeSec: string;
-    fillDeadline: string;
+
+  const data = (await response.json()) as {
+    totalRelayFee: { pct: string; total: string }
+    relayerCapitalFee: { pct: string; total: string }
+    relayerGasFee: { pct: string; total: string }
+    lpFee: { pct: string; total: string }
+    timestamp: string
+    isAmountTooLow: boolean
+    quoteBlock: string
+    spokePoolAddress: string
+    expectedFillTimeSec: string
+    fillDeadline: string
     limits: {
-      minDeposit: string;
-      maxDeposit: string;
-      maxDepositInstant: string;
-      maxDepositShortDelay: string;
-      recommendedDepositInstant: string;
-    };
-  };
-  
+      minDeposit: string
+      maxDeposit: string
+      maxDepositInstant: string
+      maxDepositShortDelay: string
+      recommendedDepositInstant: string
+    }
+  }
+
   // Parse response to bigint types
   return {
     totalRelayFee: {
@@ -282,60 +311,60 @@ export async function getAcrossSuggestedFees(
       maxDepositShortDelay: BigInt(data.limits.maxDepositShortDelay),
       recommendedDepositInstant: BigInt(data.limits.recommendedDepositInstant)
     }
-  };
+  }
 }
- 
+
 /**
  * Calculates total fees from suggested fees response
- * 
+ *
  * @example
  * const result = calculateAcrossFees({
  *   fees,
  *   amount: parseEther('1')
  * })
- * 
+ *
  * console.log(result.totalFees) // 0.005n (example)
  * console.log(result.outputAmount) // 0.995n (example)
  */
 export type CalculateAcrossFeesParameters = {
-  fees: SuggestedFeesReturnType;
-  amount: bigint;
-};
- 
+  fees: SuggestedFeesReturnType
+  amount: bigint
+}
+
 export type CalculateAcrossFeesReturnType = {
-  totalFees: bigint;
-  relayerFees: bigint;
-  lpFees: bigint;
-  outputAmount: bigint;
-};
- 
+  totalFees: bigint
+  relayerFees: bigint
+  lpFees: bigint
+  outputAmount: bigint
+}
+
 export function calculateAcrossFees(
   parameters: CalculateAcrossFeesParameters
 ): CalculateAcrossFeesReturnType {
-  const { fees, amount } = parameters;
-  
+  const { fees, amount } = parameters
+
   // Calculate fees based on percentages (denominated in 1e18)
-  const PRECISION = 10n ** 18n;
-  
-  const relayerFees = (amount * fees.totalRelayFee.pct) / PRECISION;
-  const lpFees = (amount * fees.lpFee.pct) / PRECISION;
-  const totalFees = relayerFees + lpFees;
-  const outputAmount = amount - totalFees;
-  
+  const PRECISION = 10n ** 18n
+
+  const relayerFees = (amount * fees.totalRelayFee.pct) / PRECISION
+  const lpFees = (amount * fees.lpFee.pct) / PRECISION
+  const totalFees = relayerFees + lpFees
+  const outputAmount = amount - totalFees
+
   return {
     totalFees,
     relayerFees,
     lpFees,
     outputAmount
-  };
+  }
 }
- 
+
 /**
  * Formats Across fee percentage to human readable format
- * 
+ *
  * @example
  * formatAcrossFeePercentage(376607094864283n) // "0.0376607094864283"
  */
 export function formatAcrossFeePercentage(pct: bigint): string {
-  return formatUnits(pct, 16); // Across uses 1e18 for 100%, so 1e16 for 1%
+  return formatUnits(pct, 16) // Across uses 1e18 for 100%, so 1e16 for 1%
 }

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -22,7 +22,8 @@ import buildTransfer from "./buildTransfer"
 /**
  * Default Across Intent Wrapper address
  */
-const defaultAcrossIntentWrapperAddress = "0x000000E2E47D694bDAa5a46056A894e747ED2854"
+const defaultAcrossIntentWrapperAddress =
+  "0x000000E2E47D694bDAa5a46056A894e747ED2854"
 
 /**
  * Across Intent Wrapper address per chain
@@ -395,8 +396,9 @@ export function formatAcrossFeePercentage(pct: bigint): string {
 }
 
 const _getAcrossIntentWrapper = (chainId: number) => {
-  if (acrossIntentWrappers[chainId]) {
-    return acrossIntentWrappers[chainId]
+  const acrossIntentWrapper = acrossIntentWrappers.get(chainId)
+  if (acrossIntentWrapper) {
+    return acrossIntentWrapper
   }
   return defaultAcrossIntentWrapperAddress
 }

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     testTimeout: 500_000,
     hookTimeout: 250_000,
     fileParallelism: false,
-    retry: 2
+    retry: 0
   }
 })

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     testTimeout: 500_000,
     hookTimeout: 250_000,
     fileParallelism: false,
-    retry: 0
+    retry: 2
   }
 })


### PR DESCRIPTION
This PR adds support for a new typeof a composable call builder: Across Composable Intent.

It allows using the whole runtime erc20 balance of the multichain smart account as the input for bridging and it ensures the output amount is adjusted accordingly

❗❗ ❗  Alert: it uses unaudited experimental Across Wrapper Contract, see [here](https://github.com/bcnmy/composability/pull/8).

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality for handling "across intent composable" actions in the SDK. It adds new types, instructions, and tests to facilitate cross-chain operations, enhancing the composability of transactions.

### Detailed summary
- Added `BuildAcrossIntentComposableInstruction` type for across intent actions.
- Implemented `buildAcrossIntentComposable` function for creating composable instructions.
- Updated `buildComposable` to handle "acrossIntent" type.
- Created tests for `buildAcrossIntentComposable` to validate functionality.
- Introduced fee calculation and fetching mechanisms for across protocol transactions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->