### PR TITLE
fix: fixed mmdtk verification gas limit issue

### DIFF
--- a/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
+++ b/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
@@ -6,6 +6,8 @@ import { type GetQuotePayload, getQuote } from "./getQuote"
 import type { GetQuoteParams } from "./getQuote"
 import type { TokenTrigger, Trigger } from "./signPermitQuote"
 
+export const DEFAULT_VERIFICATION_GAS_LIMIT_FOR_MM_DTK = 200_000n
+
 /**
  * Response payload for a MM DTK quote request.
  * Combines the standard quote payload with MM DTK-specific trigger information.
@@ -81,6 +83,7 @@ export const getMmDtkQuote = async (
     cleanUps,
     instructions,
     gasLimit,
+    verificationGasLimit,
     delegatorSmartAccount,
     ...rest
   } = parameters
@@ -112,6 +115,8 @@ export const getMmDtkQuote = async (
     eoa: sender, // it is not an EOA, but a smart account in this case, however param is named `eoa` for backward compatibility, see `GetQuoteParams` type for more details
     instructions: batchedInstructions,
     gasLimit: gasLimit || triggerGasLimit,
+    verificationGasLimit:
+      verificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT_FOR_MM_DTK,
     ...(cleanUps ? { cleanUps } : {}),
     ...rest
   })

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -31,6 +31,7 @@ export const CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION =
   USEROP_MIN_EXEC_WINDOW_DURATION / 2
 
 export const DEFAULT_GAS_LIMIT = 75_000n
+export const DEFAULT_VERIFICATION_GAS_LIMIT = 150_000n
 
 /**
  * Represents an abstract call to be executed in the transaction.
@@ -234,6 +235,10 @@ export type GetQuoteParams = SupertransactionLike & {
    */
   gasLimit?: bigint
   /**
+   * verificationGasLimit option to override the default payment verification gas limit
+   */
+  verificationGasLimit?: bigint
+  /**
    * token cleanup option to pull the funds on failure or dust cleanup
    */
   cleanUps?: CleanUp[]
@@ -363,6 +368,8 @@ export type PaymentInfo = {
   nonce: string
   /** Chain ID where the payment will be processed */
   chainId: string
+  /** Payment userop verificationGasLimit */
+  verificationGasLimit?: bigint
   /** EIP7702Auth */
   eip7702Auth?: MeeAuthorization
   /** Short encoding flag @see QuoteRequest.shortEncoding */
@@ -684,7 +691,7 @@ export const getQuote = async (
 const preparePaymentInfo = async (
   client: BaseMeeClient,
   parameters: GetQuoteParams & {
-    paymentVerificationGasLimit?: { verificationGasLimit: string }
+    paymentVerificationGasLimit?: { verificationGasLimit: bigint }
   }
 ) => {
   const {
@@ -694,6 +701,7 @@ const preparePaymentInfo = async (
     feePayer,
     delegate = false,
     gasLimit,
+    verificationGasLimit,
     authorization,
     sponsorship,
     sponsorshipOptions,
@@ -740,6 +748,8 @@ const preparePaymentInfo = async (
       token,
       nonce,
       callGasLimit: gasLimit || DEFAULT_GAS_LIMIT,
+      verificationGasLimit:
+        verificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT,
       chainId: chainId.toString(),
       sponsorshipUrl,
       ...(eoaOrFeePayer ? { eoa: eoaOrFeePayer } : {}),
@@ -801,6 +811,8 @@ const preparePaymentInfo = async (
       token: feeToken.address,
       nonce: nonce.nonce.toString(),
       callGasLimit: gasLimit || DEFAULT_GAS_LIMIT,
+      verificationGasLimit:
+        verificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT,
       chainId: feeToken.chainId.toString(),
       ...(eoaOrFeePayer ? { eoa: eoaOrFeePayer } : {}),
       ...initData,
@@ -990,7 +1002,7 @@ export type resolveVerificationGasLimitParams = {
  * Returns the verification gas limit for the userOp, to be spread
  */
 export type verificationGasLimitPayload = {
-  verificationGasLimit: string
+  verificationGasLimit: bigint
 }
 
 /**
@@ -1041,12 +1053,12 @@ const resolveVerificationGasLimitForPaymentChain = (
       if (index === 0) {
         // return increased verification gas limit for the first userOp
         // as it this userOp will be enabling the permission => requires more gas
-        return { verificationGasLimit: "1000000" }
+        return { verificationGasLimit: 10_00_000n }
       }
     }
     // return slighly increased verification gas limit
     // for USE session userOps
-    return { verificationGasLimit: "250000" }
+    return { verificationGasLimit: 250_000n }
   }
   return undefined
 }
@@ -1070,10 +1082,10 @@ const resolveVerificationGasLimitForNonPaymentChain = (
     if (index === 0) {
       // return increased verification gas limit for payment userOp
       // in a non-sponsored superTxn
-      return { verificationGasLimit: "1000000" }
+      return { verificationGasLimit: 10_00_000n }
     }
     // for all other userOps, return USE session verification gas limit
-    return { verificationGasLimit: "250000" }
+    return { verificationGasLimit: 250_000n }
   }
   return undefined
 }
@@ -1097,7 +1109,7 @@ const resolvePaymentUserOpVerificationGasLimit = (
     if (!sponsorship) {
       // return increased verification gas limit for payment userOp
       // in a non-sponsored superTxn
-      return { verificationGasLimit: "1000000" }
+      return { verificationGasLimit: 10_00_000n }
     }
     // if it is sponsorship, the payment userOp won't even use Smart Sessions Module
     // so doesn't need any custom verification gas limit

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -1053,7 +1053,7 @@ const resolveVerificationGasLimitForPaymentChain = (
       if (index === 0) {
         // return increased verification gas limit for the first userOp
         // as it this userOp will be enabling the permission => requires more gas
-        return { verificationGasLimit: 10_00_000n }
+        return { verificationGasLimit: 1_000_000n }
       }
     }
     // return slighly increased verification gas limit
@@ -1082,7 +1082,7 @@ const resolveVerificationGasLimitForNonPaymentChain = (
     if (index === 0) {
       // return increased verification gas limit for payment userOp
       // in a non-sponsored superTxn
-      return { verificationGasLimit: 10_00_000n }
+      return { verificationGasLimit: 1_000_000n }
     }
     // for all other userOps, return USE session verification gas limit
     return { verificationGasLimit: 250_000n }
@@ -1109,7 +1109,7 @@ const resolvePaymentUserOpVerificationGasLimit = (
     if (!sponsorship) {
       // return increased verification gas limit for payment userOp
       // in a non-sponsored superTxn
-      return { verificationGasLimit: 10_00_000n }
+      return { verificationGasLimit: 1_000_000n }
     }
     // if it is sponsorship, the payment userOp won't even use Smart Sessions Module
     // so doesn't need any custom verification gas limit


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on introducing and refining the `verificationGasLimit` feature across the `getMmDtkQuote` and `getQuote` functionalities, enhancing gas limit management for transactions.

### Detailed summary
- Added `DEFAULT_VERIFICATION_GAS_LIMIT_FOR_MM_DTK` constant in `getMmDtkQuote.ts`.
- Introduced `verificationGasLimit` parameter in `getMmDtkQuote` function.
- Added `DEFAULT_VERIFICATION_GAS_LIMIT` constant in `getQuote.ts`.
- Updated `GetQuoteParams` type to include `verificationGasLimit`.
- Modified `preparePaymentInfo` to handle `verificationGasLimit` as `bigint`.
- Updated return types for `verificationGasLimit` to `bigint` in multiple places.
- Adjusted verification gas limit return values to use `bigint` literals.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->