### PR TITLE
feat: adding multichain 7702 auth support

### DIFF
--- a/src/sdk/account/decorators/waitForTransactionReceipts.ts
+++ b/src/sdk/account/decorators/waitForTransactionReceipts.ts
@@ -39,7 +39,10 @@ export const waitForTransactionReceipts = async (
 ): Promise<WaitForTransactionReceiptPayload> => {
   const receipts = await Promise.all(
     parameters.account.deployments.map(({ publicClient }, i) =>
-      publicClient.waitForTransactionReceipt({ hash: parameters.hashes[i] })
+      publicClient.waitForTransactionReceipt({
+        hash: parameters.hashes[i],
+        confirmations: 5
+      })
     )
   )
   const failure = receipts.find((receipt) => receipt.status !== "success")

--- a/src/sdk/account/toNexusAccount.ts
+++ b/src/sdk/account/toNexusAccount.ts
@@ -188,10 +188,16 @@ export type NonceInfo = {
  * @param multiChain - Whether to use the multi-chain authorization. Defaults to false.
  */
 export type DelegationParams = {
-  authorization?: SignAuthorizationReturnType
-  multiChain?: boolean
   delegatedContract?: Address
-}
+} & OneOf<
+  | {
+      authorization: SignAuthorizationReturnType
+    }
+  | {
+      multiChain: boolean
+    }
+  | { chainId: number }
+>
 
 /**
  * UnDelegation type
@@ -840,7 +846,8 @@ export const toNexusAccount = async (
     const {
       authorization: authorization_,
       multiChain,
-      delegatedContract
+      delegatedContract,
+      chainId
     } = params || {}
 
     const contractAddress = delegatedContract || meeConfig.implementationAddress
@@ -848,11 +855,12 @@ export const toNexusAccount = async (
     const authorization: SignAuthorizationReturnType =
       authorization_ ||
       (await walletClient.signAuthorization({
-        contractAddress
+        contractAddress,
+        chainId: multiChain ? 0 : chainId
       }))
 
     const eip7702Auth: MeeAuthorization = {
-      chainId: `0x${(multiChain ? 0 : chain.id).toString(16)}` as Hex,
+      chainId: `0x${(authorization.chainId).toString(16)}` as Hex,
       address: authorization.address as Hex,
       nonce: `0x${authorization.nonce.toString(16)}` as Hex,
       r: authorization.r as Hex,

--- a/src/sdk/clients/createMeeClient.test.ts
+++ b/src/sdk/clients/createMeeClient.test.ts
@@ -458,7 +458,7 @@ describe("mee.createMeeClient.delegated", async () => {
 
     const quote = await meeClient.getQuote({
       delegate: true,
-      authorization: dummyAuth,
+      authorizations: [dummyAuth],
       instructions: [
         {
           calls: [

--- a/src/sdk/clients/createMeeClient.ts
+++ b/src/sdk/clients/createMeeClient.ts
@@ -6,7 +6,7 @@ import { type GetInfoPayload, getInfo, meeActions } from "./decorators/mee"
 
 const isStagingOrTesting = isStaging() || isTesting()
 
-export const getDefaultMEENetworkUrl = (isStaging: boolean = false) => {
+export const getDefaultMEENetworkUrl = (isStaging = false) => {
   if (isStaging) {
     return "https://staging-network.biconomy.io/v1"
   }
@@ -14,7 +14,7 @@ export const getDefaultMEENetworkUrl = (isStaging: boolean = false) => {
   return "https://network.biconomy.io/v1"
 }
 
-export const getDefaultMEENetworkApiKey = (isStaging: boolean = false) => {
+export const getDefaultMEENetworkApiKey = (isStaging = false) => {
   if (isStaging) {
     return "mee_3ZhZhHx3hmKrBQxacr283dHt"
   }

--- a/src/sdk/clients/createMeeClient.ts
+++ b/src/sdk/clients/createMeeClient.ts
@@ -6,16 +6,33 @@ import { type GetInfoPayload, getInfo, meeActions } from "./decorators/mee"
 
 const isStagingOrTesting = isStaging() || isTesting()
 
+export const getDefaultMEENetworkUrl = (isStaging: boolean = false) => {
+  if (isStaging) {
+    return "https://staging-network.biconomy.io/v1"
+  }
+
+  return "https://network.biconomy.io/v1"
+}
+
+export const getDefaultMEENetworkApiKey = (isStaging: boolean = false) => {
+  if (isStaging) {
+    return "mee_3ZhZhHx3hmKrBQxacr283dHt"
+  }
+
+  return "mee_3ZZmXCSod4xVXDRCZ5k5LTHg"
+}
+
 /**
  * Default URL for the MEE node service
  */
-export const DEFAULT_PATHFINDER_URL = isStagingOrTesting
-  ? "https://staging-network.biconomy.io/v1"
-  : "https://network.biconomy.io/v1"
+export const DEFAULT_PATHFINDER_URL =
+  getDefaultMEENetworkUrl(isStagingOrTesting)
 
-export const DEFAULT_PATHFINDER_API_KEY = isStagingOrTesting
-  ? "mee_3ZhZhHx3hmKrBQxacr283dHt"
-  : "mee_3ZZmXCSod4xVXDRCZ5k5LTHg"
+/**
+ * Default API key for the MEE node service
+ */
+export const DEFAULT_PATHFINDER_API_KEY =
+  getDefaultMEENetworkApiKey(isStagingOrTesting)
 
 /**
  * Constants for sponshorship

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -8,10 +8,9 @@ import {
   publicActions
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
-import { base, baseSepolia, optimism, optimismSepolia } from "viem/chains"
+import { baseSepolia, optimismSepolia } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import {
-  MAINNET_RPC_URLS,
   TESTNET_RPC_URLS,
   TEST_BLOCK_CONFIRMATIONS,
   getTestChainConfig,
@@ -25,7 +24,7 @@ import {
   setAllowance,
   transferErc20
 } from "../../../../test/testUtils"
-import { LARGE_DEFAULT_GAS_LIMIT, getMeeScanLink } from "../../../account"
+import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
@@ -1855,7 +1854,7 @@ describe("mee.getQuote", () => {
         }
       })
     ).rejects.toThrow(
-      "Invalid multichain authorizations. Missing chainId zero authorization for the following chains: 11155420, 84532"
+      "Invalid authorizations: The nonce for some of the chains are same. Missing multichain authorization for the following chains: 11155420, 84532"
     )
   })
 
@@ -1927,7 +1926,7 @@ describe("mee.getQuote", () => {
         }
       })
     ).rejects.toThrow(
-      "Invalid multichain authorizations, nonce on all the chains are not same. You need to pass authorizations for the following chains: 11155420"
+      "Invalid authorizations: The nonce for all the chains are not same. You need to pass specific authorizations for the following chains: 11155420"
     )
   })
 
@@ -2013,7 +2012,7 @@ describe("mee.getQuote", () => {
         }
       })
     ).rejects.toThrow(
-      "Invalid authorizations, more than one auth passed for multichain authorization."
+      "Invalid authorizations: The nonce for all the chains are zero and only one multichain authorization is expected"
     )
   })
 
@@ -2070,7 +2069,7 @@ describe("mee.getQuote", () => {
         }
       })
     ).rejects.toThrow(
-      "Invalid multichain authorization. Chain ID zero is expected in the authorization"
+      "Invalid authorizations: Multichain authorization should be signed with chain ID zero"
     )
   })
 
@@ -2196,232 +2195,401 @@ describe("mee.getQuote", () => {
     )
   })
 
-  // test("Test here", async () => {
-  //   const baseWalletClient = createWalletClient({
-  //     account: eoaAccount,
-  //     chain: base,
-  //     transport: http(MAINNET_RPC_URLS[base.id])
-  //   }).extend(publicActions)
+  test("Should execute multiple 7702 delegation supertx with manual auth and single chain auth with sponsorship", async () => {
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
 
-  //   const optimismWalletClient = createWalletClient({
-  //     account: eoaAccount,
-  //     chain: optimism,
-  //     transport: http(MAINNET_RPC_URLS[optimism.id])
-  //   }).extend(publicActions)
+    const optimismSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimismSepolia,
+      transport: http(TESTNET_RPC_URLS[optimismSepolia.id])
+    }).extend(publicActions)
 
-  //   const mcNexus = await toMultichainNexusAccount({
-  //     signer: eoaAccount,
-  //     chainConfigurations: [
-  //       {
-  //         chain: base,
-  //         transport: http(MAINNET_RPC_URLS[base.id]),
-  //         version: getMEEVersion(MEEVersion.V2_1_0)
-  //       },
-  //       {
-  //         chain: optimism,
-  //         transport: http(MAINNET_RPC_URLS[optimism.id]),
-  //         version: getMEEVersion(MEEVersion.V2_1_0)
-  //       }
-  //     ],
-  //     accountAddress: eoaAccount.address
-  //   })
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
 
-  //   const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
-  //   const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
-  //     optimism.id,
-  //     true
-  //   )
+    let isDelegated = await mcNexus.isDelegated()
 
-  //   const baseAuth = await baseWalletClient.signAuthorization({
-  //     contractAddress: baseMcNexusVersion.implementationAddress
-  //   })
+    if (isDelegated) {
+      await mcNexus.unDelegate()
+      isDelegated = await mcNexus.isDelegated()
+    }
 
-  //   const optimismAuth = await optimismWalletClient.signAuthorization({
-  //     contractAddress: optimismMcNexusVersion.implementationAddress
-  //   })
+    expect(isDelegated).toBe(false)
 
-  //   const meeClient = await createMeeClient({
-  //     account: mcNexus,
-  //     apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-  //   })
+    const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      baseSepolia.id,
+      true
+    )
 
-  //   const baseTransfer = await mcNexus.build({
-  //     type: "transfer",
-  //     data: {
-  //       recipient: eoaAccount.address,
-  //       chainId: base.id,
-  //       amount: 1n,
-  //       tokenAddress: mcUSDC.addressOn(base.id)
-  //     }
-  //   })
+    const { version: optimismSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      optimismSepolia.id,
+      true
+    )
 
-  //   const optimismTransfer = await mcNexus.build({
-  //     type: "transfer",
-  //     data: {
-  //       recipient: eoaAccount.address,
-  //       chainId: optimism.id,
-  //       amount: 1n,
-  //       tokenAddress: mcUSDC.addressOn(optimism.id)
-  //     }
-  //   })
+    const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: baseSepoliaMcNexusVersion.implementationAddress
+    })
 
-  //   const quote = await meeClient.getQuote({
-  //     sponsorship: true,
-  //     delegate: true,
-  //     authorizations: [baseAuth, optimismAuth],
-  //     instructions: [...baseTransfer, ...optimismTransfer]
-  //   })
+    const optimismSepoliaAuth =
+      await optimismSepoliaWalletClient.signAuthorization({
+        contractAddress: optimismSepoliaMcNexusVersion.implementationAddress
+      })
 
-  //   expect(quote).toBeDefined()
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
 
-  //   expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-  //   expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
 
-  //   expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-  //   expect(quote.userOps[1].eip7702Auth).toBeDefined()
-  //   expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-  //     baseMcNexusVersion.implementationAddress
-  //   )
-  //   expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
-  //   expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
-  //   expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
-  //   expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
-  //   expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
 
-  //   expect(quote.userOps[2].userOp.initCode).to.eq("0x")
-  //   expect(quote.userOps[2].eip7702Auth).toBeDefined()
-  //   expect(quote.userOps[2].eip7702Auth?.address).to.eq(
-  //     optimismMcNexusVersion.implementationAddress
-  //   )
-  //   expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
-  //   expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
-  //   expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
-  //   expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
-  //   expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
-  // })
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      sponsorshipOptions: {
+        url: DEFAULT_PATHFINDER_URL,
+        gasTank: {
+          address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+          token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+          chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+        }
+      },
+      delegate: true,
+      authorizations: [baseSepoliaAuth, optimismSepoliaAuth],
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
+    })
 
-  // // TODO: Need to improve the test coverage on execution here
-  // test("Test here", async () => {
-  //   const baseSepoliaWalletClient = createWalletClient({
-  //     account: eoaAccount,
-  //     chain: baseSepolia,
-  //     transport: http(TESTNET_RPC_URLS[baseSepolia.id])
-  //   }).extend(publicActions)
+    expect(quote).toBeDefined()
 
-  //   const optimismSepoliaWalletClient = createWalletClient({
-  //     account: eoaAccount,
-  //     chain: optimismSepolia,
-  //     transport: http(TESTNET_RPC_URLS[optimismSepolia.id])
-  //   }).extend(publicActions)
+    const { hash } = await meeClient.executeQuote({ quote })
 
-  //   const mcNexus = await toMultichainNexusAccount({
-  //     signer: eoaAccount,
-  //     chainConfigurations: [
-  //       {
-  //         chain: baseSepolia,
-  //         transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-  //         version: getMEEVersion(MEEVersion.V2_1_0)
-  //       },
-  //       {
-  //         chain: optimismSepolia,
-  //         transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-  //         version: getMEEVersion(MEEVersion.V2_1_0)
-  //       }
-  //     ],
-  //     accountAddress: eoaAccount.address
-  //   })
+    expect(hash).toBeDefined()
 
-  //   let isDelegated = await mcNexus.isDelegated()
-  //   console.log("Is delegated: ", isDelegated)
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+      confirmations: 5
+    })
 
-  //   if (isDelegated) {
-  //     console.log("Undelegating the 7702 delegation")
-  //     await mcNexus.unDelegate()
+    expect(receipt).toBeDefined()
+    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
 
-  //     isDelegated = await mcNexus.isDelegated()
-  //     console.log("Is delegated: ", isDelegated)
-  //   }
+    isDelegated = await mcNexus.isDelegated()
 
-  //   const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
-  //     baseSepolia.id,
-  //     true
-  //   )
-  //   const { version: optimismSepoliaMcNexusVersion } = mcNexus.deploymentOn(
-  //     optimismSepolia.id,
-  //     true
-  //   )
+    expect(isDelegated).toBe(true)
 
-  //   const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
-  //     contractAddress: baseSepoliaMcNexusVersion.implementationAddress
-  //   })
+    if (isDelegated) {
+      await mcNexus.unDelegate()
 
-  //   const optimismSepoliaAuth =
-  //     await optimismSepoliaWalletClient.signAuthorization({
-  //       contractAddress: optimismSepoliaMcNexusVersion.implementationAddress
-  //     })
+      isDelegated = await mcNexus.isDelegated()
+    }
 
-  //   const meeClient = await createMeeClient({
-  //     account: mcNexus,
-  //     apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-  //   })
+    expect(isDelegated).toBe(false)
+  })
 
-  //   const baseSepoliaTransfer = await mcNexus.build({
-  //     type: "transfer",
-  //     data: {
-  //       recipient: eoaAccount.address,
-  //       chainId: baseSepolia.id,
-  //       amount: 1n,
-  //       tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
-  //     }
-  //   })
+  test("Should execute multiple 7702 delegation supertx with authomatic auth and single chain auth", async () => {
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
 
-  //   const optimismSepoliaTransfer = await mcNexus.build({
-  //     type: "transfer",
-  //     data: {
-  //       recipient: eoaAccount.address,
-  //       chainId: optimismSepolia.id,
-  //       amount: 1n,
-  //       tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
-  //     }
-  //   })
+    let isDelegated = await mcNexus.isDelegated()
 
-  //   const quote = await meeClient.getQuote({
-  //     sponsorship: true,
-  //     sponsorshipOptions: {
-  //       url: DEFAULT_PATHFINDER_URL,
-  //       gasTank: {
-  //         address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
-  //         token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
-  //         chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
-  //       }
-  //     },
-  //     delegate: true,
-  //     authorizations: [baseSepoliaAuth, optimismSepoliaAuth],
-  //     instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
-  //   })
+    if (isDelegated) {
+      await mcNexus.unDelegate()
+      isDelegated = await mcNexus.isDelegated()
+    }
 
-  //   expect(quote).toBeDefined()
+    expect(isDelegated).toBe(false)
 
-  //   const { hash } = await meeClient.executeQuote({ quote })
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
 
-  //   expect(hash).toBeDefined()
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
 
-  //   const receipt = await meeClient.waitForSupertransactionReceipt({
-  //     hash,
-  //     confirmations: 5
-  //   })
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
 
-  //   console.log(getMeeScanLink(hash))
+    const quote = await meeClient.getQuote({
+      delegate: true,
+      authorizations: [],
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer],
+      feeToken: {
+        address: testnetMcTestUSDCP.addressOn(optimismSepolia.id),
+        chainId: optimismSepolia.id
+      }
+    })
 
-  //   expect(receipt).toBeDefined()
-  //   expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+    expect(quote).toBeDefined()
 
-  //   isDelegated = await mcNexus.isDelegated()
+    const { hash } = await meeClient.executeQuote({ quote })
 
-  //   if (isDelegated) {
-  //     console.log("Undelegating the 7702 delegation")
-  //     await mcNexus.unDelegate()
-  //     console.log("Is delegated: ", isDelegated)
-  //   }
-  // })
+    expect(hash).toBeDefined()
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+      confirmations: 5
+    })
+
+    expect(receipt).toBeDefined()
+    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+
+    isDelegated = await mcNexus.isDelegated()
+
+    expect(isDelegated).toBe(true)
+
+    if (isDelegated) {
+      await mcNexus.unDelegate()
+
+      isDelegated = await mcNexus.isDelegated()
+    }
+
+    expect(isDelegated).toBe(false)
+  })
+
+  test("Should execute multichain 7702 delegation supertx with manual auth", async () => {
+    // New account, so the nonce on all the chains are zero
+    const eoaAccount = privateKeyToAccount(generatePrivateKey())
+
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    let isDelegated = await mcNexus.isDelegated()
+    expect(isDelegated).toBe(false)
+
+    const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      baseSepolia.id,
+      true
+    )
+
+    const multichainAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: baseSepoliaMcNexusVersion.implementationAddress,
+      chainId: 0
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 0n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 0n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      sponsorshipOptions: {
+        url: DEFAULT_PATHFINDER_URL,
+        gasTank: {
+          address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+          token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+          chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+        }
+      },
+      delegate: true,
+      multichain7702Auth: true,
+      authorizations: [multichainAuth],
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    const { hash } = await meeClient.executeQuote({ quote: quote })
+
+    expect(hash).toBeDefined()
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+      confirmations: 5
+    })
+
+    expect(receipt).toBeDefined()
+    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+
+    isDelegated = await mcNexus.isDelegated()
+
+    expect(isDelegated).toBe(true)
+  })
+
+  test("Should execute multichain 7702 delegation supertx with automatic auth", async () => {
+    // New account, so the nonce on all the chains are zero
+    const eoaAccount = privateKeyToAccount(generatePrivateKey())
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    let isDelegated = await mcNexus.isDelegated()
+    expect(isDelegated).toBe(false)
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 0n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 0n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      sponsorshipOptions: {
+        url: DEFAULT_PATHFINDER_URL,
+        gasTank: {
+          address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+          token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+          chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+        }
+      },
+      delegate: true,
+      multichain7702Auth: true,
+      authorizations: [],
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    const { hash } = await meeClient.executeQuote({ quote: quote })
+
+    expect(hash).toBeDefined()
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+      confirmations: 5
+    })
+
+    expect(receipt).toBeDefined()
+    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+
+    isDelegated = await mcNexus.isDelegated()
+
+    expect(isDelegated).toBe(true)
+  })
 })

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -2409,7 +2409,7 @@ describe("mee.getQuote", () => {
     expect(isDelegated).toBe(false)
   })
 
-  test("Should execute multichain 7702 delegation supertx with manual auth", async () => {
+  test("Should execute multichain 7702 delegation supertx with manual multichain auth", async () => {
     // New account, so the nonce on all the chains are zero
     const eoaAccount = privateKeyToAccount(generatePrivateKey())
 

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -2135,6 +2135,67 @@ describe("mee.getQuote", () => {
     )
   })
 
+  test("Should SDK throw an error for single chain authorization if the multichain auth is passed", async () => {
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    const multichainAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: 0
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    await expect(
+      meeClient.getQuote({
+        delegate: true,
+        authorizations: [multichainAuth],
+        instructions: [...baseSepoliaTransfer],
+        feeToken: {
+          address: testnetMcTestUSDCP.addressOn(optimismSepolia.id),
+          chainId: optimismSepolia.id
+        }
+      })
+    ).rejects.toThrow(
+      "Authorizations are missing for the following chains: 11155420, 84532"
+    )
+  })
+
   // test("Test here", async () => {
   //   const baseWalletClient = createWalletClient({
   //     account: eoaAccount,

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -2195,7 +2195,7 @@ describe("mee.getQuote", () => {
     )
   })
 
-  test("Should execute multiple 7702 delegation supertx with manual auth and single chain auth with sponsorship", async () => {
+  test("Should execute multiple 7702 delegation supertx with manual single chain authorisations with sponsorship", async () => {
     const baseSepoliaWalletClient = createWalletClient({
       account: eoaAccount,
       chain: baseSepolia,

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -40,7 +40,8 @@ import {
   DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
   DEFAULT_PATHFINDER_URL,
   type MeeClient,
-  createMeeClient
+  createMeeClient,
+  getDefaultMEENetworkUrl
 } from "../../createMeeClient"
 import {
   CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION,
@@ -1257,690 +1258,6 @@ describe("mee.getQuote", () => {
   })
 
   test("Should SDK automatically inject 7702 auth for multiple chains", async () => {
-    const baseWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: base,
-      transport: http(MAINNET_RPC_URLS[base.id])
-    }).extend(publicActions)
-
-    const optimismWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: optimism,
-      transport: http(MAINNET_RPC_URLS[optimism.id])
-    }).extend(publicActions)
-
-    const mcNexus = await toMultichainNexusAccount({
-      signer: eoaAccount,
-      chainConfigurations: [
-        {
-          chain: base,
-          transport: http(MAINNET_RPC_URLS[base.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        },
-        {
-          chain: optimism,
-          transport: http(MAINNET_RPC_URLS[optimism.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        }
-      ],
-      accountAddress: eoaAccount.address
-    })
-
-    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
-    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
-      optimism.id,
-      true
-    )
-
-    // Auth is only being signed manually here for comparision purposes
-    const baseAuth = await baseWalletClient.signAuthorization({
-      contractAddress: baseMcNexusVersion.implementationAddress
-    })
-
-    // Auth is only being signed manually here for comparision purposes
-    const optimismAuth = await optimismWalletClient.signAuthorization({
-      contractAddress: optimismMcNexusVersion.implementationAddress
-    })
-
-    const meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-    })
-
-    const baseTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: base.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(base.id)
-      }
-    })
-
-    const optimismTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: optimism.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(optimism.id)
-      }
-    })
-
-    const quote = await meeClient.getQuote({
-      sponsorship: true,
-      delegate: true,
-      authorizations: [], // No auth is added. So the SDK should add auth message in all userOps with multichain context
-      instructions: [...baseTransfer, ...optimismTransfer]
-    })
-
-    expect(quote).toBeDefined()
-
-    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
-
-    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[1].eip7702Auth).toBeDefined()
-    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-      baseMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
-    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
-    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
-    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
-    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
-
-    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[2].eip7702Auth).toBeDefined()
-    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
-      optimismMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
-    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
-    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
-    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
-    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
-  })
-
-  test("Should SDK automatically inject 7702 auth for multiple chains with partial manual auths defined", async () => {
-    const baseWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: base,
-      transport: http(MAINNET_RPC_URLS[base.id])
-    }).extend(publicActions)
-
-    const optimismWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: optimism,
-      transport: http(MAINNET_RPC_URLS[optimism.id])
-    }).extend(publicActions)
-
-    const mcNexus = await toMultichainNexusAccount({
-      signer: eoaAccount,
-      chainConfigurations: [
-        {
-          chain: base,
-          transport: http(MAINNET_RPC_URLS[base.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        },
-        {
-          chain: optimism,
-          transport: http(MAINNET_RPC_URLS[optimism.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        }
-      ],
-      accountAddress: eoaAccount.address
-    })
-
-    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
-    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
-      optimism.id,
-      true
-    )
-
-    // Auth is only being signed manually here for comparision purposes
-    const baseAuth = await baseWalletClient.signAuthorization({
-      contractAddress: baseMcNexusVersion.implementationAddress
-    })
-
-    const optimismAuth = await optimismWalletClient.signAuthorization({
-      contractAddress: optimismMcNexusVersion.implementationAddress
-    })
-
-    const meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-    })
-
-    const baseTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: base.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(base.id)
-      }
-    })
-
-    const optimismTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: optimism.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(optimism.id)
-      }
-    })
-
-    const quote = await meeClient.getQuote({
-      sponsorship: true,
-      delegate: true,
-      // Only optimism auth is added. So the SDK should add auth message for remaining chains in all userOps with multichain context
-      authorizations: [optimismAuth],
-      instructions: [...baseTransfer, ...optimismTransfer]
-    })
-
-    expect(quote).toBeDefined()
-
-    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
-
-    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[1].eip7702Auth).toBeDefined()
-    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-      baseMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
-    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
-    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
-    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
-    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
-
-    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[2].eip7702Auth).toBeDefined()
-    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
-      optimismMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
-    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
-    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
-    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
-    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
-  })
-
-  test("Should SDK inject manually signed 7702 auth for multiple chains", async () => {
-    const baseWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: base,
-      transport: http(MAINNET_RPC_URLS[base.id])
-    }).extend(publicActions)
-
-    const optimismWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: optimism,
-      transport: http(MAINNET_RPC_URLS[optimism.id])
-    }).extend(publicActions)
-
-    const mcNexus = await toMultichainNexusAccount({
-      signer: eoaAccount,
-      chainConfigurations: [
-        {
-          chain: base,
-          transport: http(MAINNET_RPC_URLS[base.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        },
-        {
-          chain: optimism,
-          transport: http(MAINNET_RPC_URLS[optimism.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        }
-      ],
-      accountAddress: eoaAccount.address
-    })
-
-    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
-    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
-      optimism.id,
-      true
-    )
-
-    const baseAuth = await baseWalletClient.signAuthorization({
-      contractAddress: baseMcNexusVersion.implementationAddress
-    })
-
-    const optimismAuth = await optimismWalletClient.signAuthorization({
-      contractAddress: optimismMcNexusVersion.implementationAddress
-    })
-
-    const meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-    })
-
-    const baseTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: base.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(base.id)
-      }
-    })
-
-    const optimismTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: optimism.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(optimism.id)
-      }
-    })
-
-    const quote = await meeClient.getQuote({
-      sponsorship: true,
-      delegate: true,
-      // Both base and optimism auth added manually.
-      // order doesn't matter
-      authorizations: [optimismAuth, baseAuth],
-      instructions: [...baseTransfer, ...optimismTransfer]
-    })
-
-    expect(quote).toBeDefined()
-
-    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
-
-    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[1].eip7702Auth).toBeDefined()
-    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-      baseMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
-    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
-    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
-    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
-    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
-
-    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[2].eip7702Auth).toBeDefined()
-    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
-      optimismMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
-    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
-    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
-    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
-    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
-  })
-
-  test("Should SDK ignore manually signed 7702 auth if the userOps doesn't exist for the chain", async () => {
-    const baseWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: base,
-      transport: http(MAINNET_RPC_URLS[base.id])
-    }).extend(publicActions)
-
-    const optimismWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: optimism,
-      transport: http(MAINNET_RPC_URLS[optimism.id])
-    }).extend(publicActions)
-
-    const mcNexus = await toMultichainNexusAccount({
-      signer: eoaAccount,
-      chainConfigurations: [
-        {
-          chain: base,
-          transport: http(MAINNET_RPC_URLS[base.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        },
-        {
-          chain: optimism,
-          transport: http(MAINNET_RPC_URLS[optimism.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        }
-      ],
-      accountAddress: eoaAccount.address
-    })
-
-    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
-    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
-      optimism.id,
-      true
-    )
-
-    const baseAuth = await baseWalletClient.signAuthorization({
-      contractAddress: baseMcNexusVersion.implementationAddress
-    })
-
-    const optimismAuth = await optimismWalletClient.signAuthorization({
-      contractAddress: optimismMcNexusVersion.implementationAddress
-    })
-
-    const meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-    })
-
-    const baseTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: base.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(base.id)
-      }
-    })
-
-    const quote = await meeClient.getQuote({
-      sponsorship: true,
-      delegate: true,
-      // Both base and optimism auth added manually.
-      // order doesn't matter
-      authorizations: [optimismAuth, baseAuth],
-      instructions: [...baseTransfer]
-    })
-
-    expect(quote).toBeDefined()
-
-    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
-
-    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[1].eip7702Auth).toBeDefined()
-    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-      baseMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
-    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
-    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
-    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
-    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
-  })
-
-  test("Should SDK automatically inject one 7702 auth with chain id zero", async () => {
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain: base,
-      transport: http(MAINNET_RPC_URLS[base.id])
-    }).extend(publicActions)
-
-    const mcNexus = await toMultichainNexusAccount({
-      signer: eoaAccount,
-      chainConfigurations: [
-        {
-          chain: base,
-          transport: http(MAINNET_RPC_URLS[base.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        },
-        {
-          chain: optimism,
-          transport: http(MAINNET_RPC_URLS[optimism.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        }
-      ],
-      accountAddress: eoaAccount.address
-    })
-
-    const { version } = mcNexus.deploymentOn(base.id, true)
-
-    // Auth is only being signed manually here for comparision purposes
-    const auth = await walletClient.signAuthorization({
-      contractAddress: version.implementationAddress,
-      chainId: 0
-    })
-
-    const meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-    })
-
-    const baseTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: base.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(base.id)
-      }
-    })
-
-    const optimismTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: optimism.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(optimism.id)
-      }
-    })
-
-    const quote = await meeClient.getQuote({
-      sponsorship: true,
-      delegate: true,
-      multichain7702Auth: true,
-      authorizations: [],
-      instructions: [...baseTransfer, ...optimismTransfer]
-    })
-
-    expect(quote).toBeDefined()
-
-    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
-
-    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[1].eip7702Auth).toBeDefined()
-    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-      version.implementationAddress
-    )
-    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(auth.chainId)
-    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(auth.nonce)
-    expect(quote.userOps[1].eip7702Auth?.r).to.eq(auth.r)
-    expect(quote.userOps[1].eip7702Auth?.s).to.eq(auth.s)
-    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(auth.yParity)
-
-    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[2].eip7702Auth).toBeDefined()
-    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
-      version.implementationAddress
-    )
-    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(auth.chainId)
-    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(auth.nonce)
-    expect(quote.userOps[2].eip7702Auth?.r).to.eq(auth.r)
-    expect(quote.userOps[2].eip7702Auth?.s).to.eq(auth.s)
-    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(auth.yParity)
-  })
-
-  test("Should SDK use manually injected 7702 auth with chain id zero for all chains", async () => {
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain: base,
-      transport: http(MAINNET_RPC_URLS[base.id])
-    }).extend(publicActions)
-
-    const mcNexus = await toMultichainNexusAccount({
-      signer: eoaAccount,
-      chainConfigurations: [
-        {
-          chain: base,
-          transport: http(MAINNET_RPC_URLS[base.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        },
-        {
-          chain: optimism,
-          transport: http(MAINNET_RPC_URLS[optimism.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        }
-      ],
-      accountAddress: eoaAccount.address
-    })
-
-    const { version } = mcNexus.deploymentOn(base.id, true)
-
-    const auth = await walletClient.signAuthorization({
-      contractAddress: version.implementationAddress,
-      chainId: 0
-    })
-
-    const meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-    })
-
-    const baseTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: base.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(base.id)
-      }
-    })
-
-    const optimismTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: optimism.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(optimism.id)
-      }
-    })
-
-    const quote = await meeClient.getQuote({
-      delegate: true,
-      multichain7702Auth: true,
-      authorizations: [auth],
-      instructions: [...baseTransfer, ...optimismTransfer],
-      feeToken: { address: mcUSDC.addressOn(optimism.id), chainId: optimism.id }
-    })
-
-    expect(quote).toBeDefined()
-
-    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[0].eip7702Auth).toBeDefined()
-
-    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[1].eip7702Auth).toBeDefined()
-    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-      version.implementationAddress
-    )
-    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(auth.chainId)
-    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(auth.nonce)
-    expect(quote.userOps[1].eip7702Auth?.r).to.eq(auth.r)
-    expect(quote.userOps[1].eip7702Auth?.s).to.eq(auth.s)
-    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(auth.yParity)
-
-    expect(quote.userOps[2].eip7702Auth).not.toBeDefined()
-  })
-
-  test("Test here", async () => {
-    const baseWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: base,
-      transport: http(MAINNET_RPC_URLS[base.id])
-    }).extend(publicActions)
-
-    const optimismWalletClient = createWalletClient({
-      account: eoaAccount,
-      chain: optimism,
-      transport: http(MAINNET_RPC_URLS[optimism.id])
-    }).extend(publicActions)
-
-    const mcNexus = await toMultichainNexusAccount({
-      signer: eoaAccount,
-      chainConfigurations: [
-        {
-          chain: base,
-          transport: http(MAINNET_RPC_URLS[base.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        },
-        {
-          chain: optimism,
-          transport: http(MAINNET_RPC_URLS[optimism.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
-        }
-      ],
-      accountAddress: eoaAccount.address
-    })
-
-    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
-    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
-      optimism.id,
-      true
-    )
-
-    const baseAuth = await baseWalletClient.signAuthorization({
-      contractAddress: baseMcNexusVersion.implementationAddress
-    })
-
-    const optimismAuth = await optimismWalletClient.signAuthorization({
-      contractAddress: optimismMcNexusVersion.implementationAddress
-    })
-
-    const meeClient = await createMeeClient({
-      account: mcNexus,
-      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
-    })
-
-    const baseTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: base.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(base.id)
-      }
-    })
-
-    const optimismTransfer = await mcNexus.build({
-      type: "transfer",
-      data: {
-        recipient: eoaAccount.address,
-        chainId: optimism.id,
-        amount: 1n,
-        tokenAddress: mcUSDC.addressOn(optimism.id)
-      }
-    })
-
-    const quote = await meeClient.getQuote({
-      sponsorship: true,
-      delegate: true,
-      authorizations: [baseAuth, optimismAuth],
-      instructions: [...baseTransfer, ...optimismTransfer]
-    })
-
-    expect(quote).toBeDefined()
-
-    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
-
-    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[1].eip7702Auth).toBeDefined()
-    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
-      baseMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
-    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
-    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
-    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
-    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
-
-    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
-    expect(quote.userOps[2].eip7702Auth).toBeDefined()
-    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
-      optimismMcNexusVersion.implementationAddress
-    )
-    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
-    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
-    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
-    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
-    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
-  })
-
-  // TODO: Need to improve the test coverage on execution here
-  test("Test here", async () => {
     const baseSepoliaWalletClient = createWalletClient({
       account: eoaAccount,
       chain: baseSepolia,
@@ -1970,16 +1287,125 @@ describe("mee.getQuote", () => {
       accountAddress: eoaAccount.address
     })
 
-    let isDelegated = await mcNexus.isDelegated()
-    console.log("Is delegated: ", isDelegated)
+    const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      baseSepolia.id,
+      true
+    )
+    const { version: optimismSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      optimismSepolia.id,
+      true
+    )
 
-    if (isDelegated) {
-      console.log("Undelegating the 7702 delegation")
-      await mcNexus.unDelegate()
+    // Auth is only being signed manually here for comparision purposes
+    const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: baseSepoliaMcNexusVersion.implementationAddress
+    })
 
-      isDelegated = await mcNexus.isDelegated()
-      console.log("Is delegated: ", isDelegated)
-    }
+    // Auth is only being signed manually here for comparision purposes
+    const optimismSepoliaAuth =
+      await optimismSepoliaWalletClient.signAuthorization({
+        contractAddress: optimismSepoliaMcNexusVersion.implementationAddress
+      })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      sponsorshipOptions: {
+        url: getDefaultMEENetworkUrl(true),
+        gasTank: {
+          address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+          token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+          chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+        }
+      },
+      delegate: true,
+      authorizations: [], // No auth is added. So the SDK should add auth message in all userOps with multichain context
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseSepoliaMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(baseSepolia.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseSepoliaAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseSepoliaAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseSepoliaAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseSepoliaAuth.yParity)
+
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      optimismSepoliaMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimismSepolia.id)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismSepoliaAuth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismSepoliaAuth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismSepoliaAuth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(
+      optimismSepoliaAuth.yParity
+    )
+  })
+
+  test("Should SDK inject manually signed 7702 auth for multiple chains", async () => {
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const optimismSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimismSepolia,
+      transport: http(TESTNET_RPC_URLS[optimismSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
 
     const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
       baseSepolia.id,
@@ -2027,7 +1453,7 @@ describe("mee.getQuote", () => {
     const quote = await meeClient.getQuote({
       sponsorship: true,
       sponsorshipOptions: {
-        url: DEFAULT_PATHFINDER_URL,
+        url: getDefaultMEENetworkUrl(true),
         gasTank: {
           address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
           token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
@@ -2035,32 +1461,906 @@ describe("mee.getQuote", () => {
         }
       },
       delegate: true,
-      authorizations: [baseSepoliaAuth, optimismSepoliaAuth],
+      // Both baseSepolia and optimismSepolia auth added manually.
+      // order doesn't matter
+      authorizations: [optimismSepoliaAuth, baseSepoliaAuth],
       instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
     })
 
     expect(quote).toBeDefined()
 
-    const { hash } = await meeClient.executeQuote({ quote })
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
 
-    expect(hash).toBeDefined()
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseSepoliaMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(baseSepolia.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseSepoliaAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseSepoliaAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseSepoliaAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseSepoliaAuth.yParity)
 
-    const receipt = await meeClient.waitForSupertransactionReceipt({
-      hash,
-      confirmations: 5
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      optimismSepoliaMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimismSepolia.id)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismSepoliaAuth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismSepoliaAuth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismSepoliaAuth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(
+      optimismSepoliaAuth.yParity
+    )
+  })
+
+  test("Should SDK ignore manually signed 7702 auth if the userOps doesn't exist for the chain", async () => {
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const optimismSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimismSepolia,
+      transport: http(TESTNET_RPC_URLS[optimismSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
     })
 
-    console.log(getMeeScanLink(hash))
+    const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      baseSepolia.id,
+      true
+    )
+    const { version: optimismSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      optimismSepolia.id,
+      true
+    )
 
-    expect(receipt).toBeDefined()
-    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+    const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: baseSepoliaMcNexusVersion.implementationAddress
+    })
 
-    isDelegated = await mcNexus.isDelegated()
+    const optimismSepoliaAuth =
+      await optimismSepoliaWalletClient.signAuthorization({
+        contractAddress: optimismSepoliaMcNexusVersion.implementationAddress
+      })
 
-    if (isDelegated) {
-      console.log("Undelegating the 7702 delegation")
-      await mcNexus.unDelegate()
-      console.log("Is delegated: ", isDelegated)
-    }
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      sponsorshipOptions: {
+        url: getDefaultMEENetworkUrl(true),
+        gasTank: {
+          address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+          token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+          chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+        }
+      },
+      delegate: true,
+      // Both baseSepolia and optimismSepolia auth added manually.
+      // order doesn't matter
+      authorizations: [optimismSepoliaAuth, baseSepoliaAuth],
+      instructions: [...baseSepoliaTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseSepoliaMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(baseSepolia.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseSepoliaAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseSepoliaAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseSepoliaAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseSepoliaAuth.yParity)
   })
+
+  test("Should SDK automatically inject one 7702 auth with chain id zero if the nonce on all the chains are same", async () => {
+    const eoaAccount = privateKeyToAccount(generatePrivateKey())
+
+    const walletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    // Auth is only being signed manually here for comparision purposes
+    const auth = await walletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: 0
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      sponsorshipOptions: {
+        url: getDefaultMEENetworkUrl(true),
+        gasTank: {
+          address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+          token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+          chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+        }
+      },
+      delegate: true,
+      multichain7702Auth: true,
+      authorizations: [],
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      version.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(auth.chainId)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(auth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(auth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(auth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(auth.yParity)
+
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      version.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(auth.chainId)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(auth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(auth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(auth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(auth.yParity)
+  })
+
+  test("Should SDK use manually injected 7702 auth with chain id zero for all chains if the nonce are same", async () => {
+    const eoaAccount = privateKeyToAccount(generatePrivateKey())
+
+    const walletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    const auth = await walletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: 0
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      delegate: true,
+      multichain7702Auth: true,
+      authorizations: [auth],
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer],
+      feeToken: {
+        address: testnetMcTestUSDCP.addressOn(optimismSepolia.id),
+        chainId: optimismSepolia.id
+      }
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      version.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(auth.chainId)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(auth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(auth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(auth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(auth.yParity)
+
+    expect(quote.userOps[2].eip7702Auth).not.toBeDefined()
+  })
+
+  test("Should SDK throw an error if invalid 7702 auth is used", async () => {
+    const eoaAccount = privateKeyToAccount(generatePrivateKey())
+
+    const walletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    const invalidAuth = await walletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: 1 // Signing for ETH chain which makes it invalid for this sprtx
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    await expect(
+      meeClient.getQuote({
+        delegate: true,
+        multichain7702Auth: true,
+        authorizations: [invalidAuth],
+        instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer],
+        feeToken: {
+          address: testnetMcTestUSDCP.addressOn(optimismSepolia.id),
+          chainId: optimismSepolia.id
+        }
+      })
+    ).rejects.toThrow(
+      "Invalid multichain authorizations. Missing chainId zero authorization for the following chains: 11155420, 84532"
+    )
+  })
+
+  test("Should SDK throw an error if 7702 auth is not sufficient for all the chains", async () => {
+    const walletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    const auth = await walletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: baseSepolia.id
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    await expect(
+      meeClient.getQuote({
+        delegate: true,
+        multichain7702Auth: true,
+        authorizations: [auth],
+        instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer],
+        feeToken: {
+          address: testnetMcTestUSDCP.addressOn(optimismSepolia.id),
+          chainId: optimismSepolia.id
+        }
+      })
+    ).rejects.toThrow(
+      "Invalid multichain authorizations, nonce on all the chains are not same. You need to pass authorizations for the following chains: 11155420"
+    )
+  })
+
+  test("Should SDK throw an error if nonces on all the chains are same and custom 7702 auths are passed more than one", async () => {
+    const eoaAccount = privateKeyToAccount(generatePrivateKey())
+
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const optimismSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimismSepolia,
+      transport: http(TESTNET_RPC_URLS[optimismSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: baseSepolia.id
+    })
+
+    const optimismSepoliaAuth =
+      await optimismSepoliaWalletClient.signAuthorization({
+        contractAddress: version.implementationAddress,
+        chainId: optimismSepolia.id
+      })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    await expect(
+      meeClient.getQuote({
+        delegate: true,
+        multichain7702Auth: true,
+        authorizations: [baseSepoliaAuth, optimismSepoliaAuth],
+        instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer],
+        feeToken: {
+          address: testnetMcTestUSDCP.addressOn(optimismSepolia.id),
+          chainId: optimismSepolia.id
+        }
+      })
+    ).rejects.toThrow(
+      "Invalid authorizations, more than one auth passed for multichain authorization."
+    )
+  })
+
+  test("Should SDK throw an error if non zero chain id auth is passed for multichain and one chain sprtx", async () => {
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: baseSepolia.id
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    await expect(
+      meeClient.getQuote({
+        delegate: true,
+        multichain7702Auth: true,
+        authorizations: [baseSepoliaAuth],
+        instructions: [...baseSepoliaTransfer],
+        feeToken: {
+          address: testnetMcTestUSDCP.addressOn(baseSepolia.id),
+          chainId: baseSepolia.id
+        }
+      })
+    ).rejects.toThrow(
+      "Invalid multichain authorization. Chain ID zero is expected in the authorization"
+    )
+  })
+
+  test("Should SDK throw an error for single chain authorization if the custom auth is not sufficient", async () => {
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
+
+    const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: baseSepolia.id
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    await expect(
+      meeClient.getQuote({
+        delegate: true,
+        authorizations: [baseSepoliaAuth],
+        instructions: [...baseSepoliaTransfer],
+        feeToken: {
+          address: testnetMcTestUSDCP.addressOn(optimismSepolia.id),
+          chainId: optimismSepolia.id
+        }
+      })
+    ).rejects.toThrow(
+      "Authorizations are missing for the following chains: 11155420"
+    )
+  })
+
+  // test("Test here", async () => {
+  //   const baseWalletClient = createWalletClient({
+  //     account: eoaAccount,
+  //     chain: base,
+  //     transport: http(MAINNET_RPC_URLS[base.id])
+  //   }).extend(publicActions)
+
+  //   const optimismWalletClient = createWalletClient({
+  //     account: eoaAccount,
+  //     chain: optimism,
+  //     transport: http(MAINNET_RPC_URLS[optimism.id])
+  //   }).extend(publicActions)
+
+  //   const mcNexus = await toMultichainNexusAccount({
+  //     signer: eoaAccount,
+  //     chainConfigurations: [
+  //       {
+  //         chain: base,
+  //         transport: http(MAINNET_RPC_URLS[base.id]),
+  //         version: getMEEVersion(MEEVersion.V2_1_0)
+  //       },
+  //       {
+  //         chain: optimism,
+  //         transport: http(MAINNET_RPC_URLS[optimism.id]),
+  //         version: getMEEVersion(MEEVersion.V2_1_0)
+  //       }
+  //     ],
+  //     accountAddress: eoaAccount.address
+  //   })
+
+  //   const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
+  //   const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
+  //     optimism.id,
+  //     true
+  //   )
+
+  //   const baseAuth = await baseWalletClient.signAuthorization({
+  //     contractAddress: baseMcNexusVersion.implementationAddress
+  //   })
+
+  //   const optimismAuth = await optimismWalletClient.signAuthorization({
+  //     contractAddress: optimismMcNexusVersion.implementationAddress
+  //   })
+
+  //   const meeClient = await createMeeClient({
+  //     account: mcNexus,
+  //     apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+  //   })
+
+  //   const baseTransfer = await mcNexus.build({
+  //     type: "transfer",
+  //     data: {
+  //       recipient: eoaAccount.address,
+  //       chainId: base.id,
+  //       amount: 1n,
+  //       tokenAddress: mcUSDC.addressOn(base.id)
+  //     }
+  //   })
+
+  //   const optimismTransfer = await mcNexus.build({
+  //     type: "transfer",
+  //     data: {
+  //       recipient: eoaAccount.address,
+  //       chainId: optimism.id,
+  //       amount: 1n,
+  //       tokenAddress: mcUSDC.addressOn(optimism.id)
+  //     }
+  //   })
+
+  //   const quote = await meeClient.getQuote({
+  //     sponsorship: true,
+  //     delegate: true,
+  //     authorizations: [baseAuth, optimismAuth],
+  //     instructions: [...baseTransfer, ...optimismTransfer]
+  //   })
+
+  //   expect(quote).toBeDefined()
+
+  //   expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+  //   expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+  //   expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+  //   expect(quote.userOps[1].eip7702Auth).toBeDefined()
+  //   expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+  //     baseMcNexusVersion.implementationAddress
+  //   )
+  //   expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
+  //   expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
+  //   expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
+  //   expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
+  //   expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
+
+  //   expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+  //   expect(quote.userOps[2].eip7702Auth).toBeDefined()
+  //   expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+  //     optimismMcNexusVersion.implementationAddress
+  //   )
+  //   expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
+  //   expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
+  //   expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
+  //   expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
+  //   expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
+  // })
+
+  // // TODO: Need to improve the test coverage on execution here
+  // test("Test here", async () => {
+  //   const baseSepoliaWalletClient = createWalletClient({
+  //     account: eoaAccount,
+  //     chain: baseSepolia,
+  //     transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+  //   }).extend(publicActions)
+
+  //   const optimismSepoliaWalletClient = createWalletClient({
+  //     account: eoaAccount,
+  //     chain: optimismSepolia,
+  //     transport: http(TESTNET_RPC_URLS[optimismSepolia.id])
+  //   }).extend(publicActions)
+
+  //   const mcNexus = await toMultichainNexusAccount({
+  //     signer: eoaAccount,
+  //     chainConfigurations: [
+  //       {
+  //         chain: baseSepolia,
+  //         transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+  //         version: getMEEVersion(MEEVersion.V2_1_0)
+  //       },
+  //       {
+  //         chain: optimismSepolia,
+  //         transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+  //         version: getMEEVersion(MEEVersion.V2_1_0)
+  //       }
+  //     ],
+  //     accountAddress: eoaAccount.address
+  //   })
+
+  //   let isDelegated = await mcNexus.isDelegated()
+  //   console.log("Is delegated: ", isDelegated)
+
+  //   if (isDelegated) {
+  //     console.log("Undelegating the 7702 delegation")
+  //     await mcNexus.unDelegate()
+
+  //     isDelegated = await mcNexus.isDelegated()
+  //     console.log("Is delegated: ", isDelegated)
+  //   }
+
+  //   const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+  //     baseSepolia.id,
+  //     true
+  //   )
+  //   const { version: optimismSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+  //     optimismSepolia.id,
+  //     true
+  //   )
+
+  //   const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+  //     contractAddress: baseSepoliaMcNexusVersion.implementationAddress
+  //   })
+
+  //   const optimismSepoliaAuth =
+  //     await optimismSepoliaWalletClient.signAuthorization({
+  //       contractAddress: optimismSepoliaMcNexusVersion.implementationAddress
+  //     })
+
+  //   const meeClient = await createMeeClient({
+  //     account: mcNexus,
+  //     apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+  //   })
+
+  //   const baseSepoliaTransfer = await mcNexus.build({
+  //     type: "transfer",
+  //     data: {
+  //       recipient: eoaAccount.address,
+  //       chainId: baseSepolia.id,
+  //       amount: 1n,
+  //       tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+  //     }
+  //   })
+
+  //   const optimismSepoliaTransfer = await mcNexus.build({
+  //     type: "transfer",
+  //     data: {
+  //       recipient: eoaAccount.address,
+  //       chainId: optimismSepolia.id,
+  //       amount: 1n,
+  //       tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+  //     }
+  //   })
+
+  //   const quote = await meeClient.getQuote({
+  //     sponsorship: true,
+  //     sponsorshipOptions: {
+  //       url: DEFAULT_PATHFINDER_URL,
+  //       gasTank: {
+  //         address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+  //         token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+  //         chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+  //       }
+  //     },
+  //     delegate: true,
+  //     authorizations: [baseSepoliaAuth, optimismSepoliaAuth],
+  //     instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
+  //   })
+
+  //   expect(quote).toBeDefined()
+
+  //   const { hash } = await meeClient.executeQuote({ quote })
+
+  //   expect(hash).toBeDefined()
+
+  //   const receipt = await meeClient.waitForSupertransactionReceipt({
+  //     hash,
+  //     confirmations: 5
+  //   })
+
+  //   console.log(getMeeScanLink(hash))
+
+  //   expect(receipt).toBeDefined()
+  //   expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+
+  //   isDelegated = await mcNexus.isDelegated()
+
+  //   if (isDelegated) {
+  //     console.log("Undelegating the 7702 delegation")
+  //     await mcNexus.unDelegate()
+  //     console.log("Is delegated: ", isDelegated)
+  //   }
+  // })
 })

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -8,9 +8,10 @@ import {
   publicActions
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
-import { baseSepolia } from "viem/chains"
+import { base, baseSepolia, optimism, optimismSepolia } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import {
+  MAINNET_RPC_URLS,
   TESTNET_RPC_URLS,
   TEST_BLOCK_CONFIRMATIONS,
   getTestChainConfig,
@@ -24,10 +25,10 @@ import {
   setAllowance,
   transferErc20
 } from "../../../../test/testUtils"
-import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account"
+import { LARGE_DEFAULT_GAS_LIMIT, getMeeScanLink } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
-import { DEFAULT_MEE_VERSION } from "../../../constants"
+import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
 import { getMEEVersion } from "../../../modules"
 import {
@@ -1253,5 +1254,813 @@ describe("mee.getQuote", () => {
       tokenAddress
     )
     expect(feeAccountErc20Balance).toBe(0n)
+  })
+
+  test("Should SDK automatically inject 7702 auth for multiple chains", async () => {
+    const baseWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: base,
+      transport: http(MAINNET_RPC_URLS[base.id])
+    }).extend(publicActions)
+
+    const optimismWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimism,
+      transport: http(MAINNET_RPC_URLS[optimism.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: base,
+          transport: http(MAINNET_RPC_URLS[base.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimism,
+          transport: http(MAINNET_RPC_URLS[optimism.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
+    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
+      optimism.id,
+      true
+    )
+
+    // Auth is only being signed manually here for comparision purposes
+    const baseAuth = await baseWalletClient.signAuthorization({
+      contractAddress: baseMcNexusVersion.implementationAddress
+    })
+
+    // Auth is only being signed manually here for comparision purposes
+    const optimismAuth = await optimismWalletClient.signAuthorization({
+      contractAddress: optimismMcNexusVersion.implementationAddress
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: base.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(base.id)
+      }
+    })
+
+    const optimismTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimism.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(optimism.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      delegate: true,
+      authorizations: [], // No auth is added. So the SDK should add auth message in all userOps with multichain context
+      instructions: [...baseTransfer, ...optimismTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
+
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      optimismMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
+  })
+
+  test("Should SDK automatically inject 7702 auth for multiple chains with partial manual auths defined", async () => {
+    const baseWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: base,
+      transport: http(MAINNET_RPC_URLS[base.id])
+    }).extend(publicActions)
+
+    const optimismWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimism,
+      transport: http(MAINNET_RPC_URLS[optimism.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: base,
+          transport: http(MAINNET_RPC_URLS[base.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimism,
+          transport: http(MAINNET_RPC_URLS[optimism.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
+    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
+      optimism.id,
+      true
+    )
+
+    // Auth is only being signed manually here for comparision purposes
+    const baseAuth = await baseWalletClient.signAuthorization({
+      contractAddress: baseMcNexusVersion.implementationAddress
+    })
+
+    const optimismAuth = await optimismWalletClient.signAuthorization({
+      contractAddress: optimismMcNexusVersion.implementationAddress
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: base.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(base.id)
+      }
+    })
+
+    const optimismTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimism.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(optimism.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      delegate: true,
+      // Only optimism auth is added. So the SDK should add auth message for remaining chains in all userOps with multichain context
+      authorizations: [optimismAuth],
+      instructions: [...baseTransfer, ...optimismTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
+
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      optimismMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
+  })
+
+  test("Should SDK inject manually signed 7702 auth for multiple chains", async () => {
+    const baseWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: base,
+      transport: http(MAINNET_RPC_URLS[base.id])
+    }).extend(publicActions)
+
+    const optimismWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimism,
+      transport: http(MAINNET_RPC_URLS[optimism.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: base,
+          transport: http(MAINNET_RPC_URLS[base.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimism,
+          transport: http(MAINNET_RPC_URLS[optimism.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
+    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
+      optimism.id,
+      true
+    )
+
+    const baseAuth = await baseWalletClient.signAuthorization({
+      contractAddress: baseMcNexusVersion.implementationAddress
+    })
+
+    const optimismAuth = await optimismWalletClient.signAuthorization({
+      contractAddress: optimismMcNexusVersion.implementationAddress
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: base.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(base.id)
+      }
+    })
+
+    const optimismTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimism.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(optimism.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      delegate: true,
+      // Both base and optimism auth added manually.
+      // order doesn't matter
+      authorizations: [optimismAuth, baseAuth],
+      instructions: [...baseTransfer, ...optimismTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
+
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      optimismMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
+  })
+
+  test("Should SDK ignore manually signed 7702 auth if the userOps doesn't exist for the chain", async () => {
+    const baseWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: base,
+      transport: http(MAINNET_RPC_URLS[base.id])
+    }).extend(publicActions)
+
+    const optimismWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimism,
+      transport: http(MAINNET_RPC_URLS[optimism.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: base,
+          transport: http(MAINNET_RPC_URLS[base.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimism,
+          transport: http(MAINNET_RPC_URLS[optimism.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
+    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
+      optimism.id,
+      true
+    )
+
+    const baseAuth = await baseWalletClient.signAuthorization({
+      contractAddress: baseMcNexusVersion.implementationAddress
+    })
+
+    const optimismAuth = await optimismWalletClient.signAuthorization({
+      contractAddress: optimismMcNexusVersion.implementationAddress
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: base.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(base.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      delegate: true,
+      // Both base and optimism auth added manually.
+      // order doesn't matter
+      authorizations: [optimismAuth, baseAuth],
+      instructions: [...baseTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
+  })
+
+  test("Should SDK automatically inject one 7702 auth with chain id zero", async () => {
+    const walletClient = createWalletClient({
+      account: eoaAccount,
+      chain: base,
+      transport: http(MAINNET_RPC_URLS[base.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: base,
+          transport: http(MAINNET_RPC_URLS[base.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimism,
+          transport: http(MAINNET_RPC_URLS[optimism.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(base.id, true)
+
+    // Auth is only being signed manually here for comparision purposes
+    const auth = await walletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: 0
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: base.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(base.id)
+      }
+    })
+
+    const optimismTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimism.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(optimism.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      delegate: true,
+      multichain7702Auth: true,
+      authorizations: [],
+      instructions: [...baseTransfer, ...optimismTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      version.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(auth.chainId)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(auth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(auth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(auth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(auth.yParity)
+
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      version.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(auth.chainId)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(auth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(auth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(auth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(auth.yParity)
+  })
+
+  test("Should SDK use manually injected 7702 auth with chain id zero for all chains", async () => {
+    const walletClient = createWalletClient({
+      account: eoaAccount,
+      chain: base,
+      transport: http(MAINNET_RPC_URLS[base.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: base,
+          transport: http(MAINNET_RPC_URLS[base.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimism,
+          transport: http(MAINNET_RPC_URLS[optimism.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version } = mcNexus.deploymentOn(base.id, true)
+
+    const auth = await walletClient.signAuthorization({
+      contractAddress: version.implementationAddress,
+      chainId: 0
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: base.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(base.id)
+      }
+    })
+
+    const optimismTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimism.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(optimism.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      delegate: true,
+      multichain7702Auth: true,
+      authorizations: [auth],
+      instructions: [...baseTransfer, ...optimismTransfer],
+      feeToken: { address: mcUSDC.addressOn(optimism.id), chainId: optimism.id }
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      version.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(auth.chainId)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(auth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(auth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(auth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(auth.yParity)
+
+    expect(quote.userOps[2].eip7702Auth).not.toBeDefined()
+  })
+
+  test("Test here", async () => {
+    const baseWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: base,
+      transport: http(MAINNET_RPC_URLS[base.id])
+    }).extend(publicActions)
+
+    const optimismWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimism,
+      transport: http(MAINNET_RPC_URLS[optimism.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: base,
+          transport: http(MAINNET_RPC_URLS[base.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimism,
+          transport: http(MAINNET_RPC_URLS[optimism.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    const { version: baseMcNexusVersion } = mcNexus.deploymentOn(base.id, true)
+    const { version: optimismMcNexusVersion } = mcNexus.deploymentOn(
+      optimism.id,
+      true
+    )
+
+    const baseAuth = await baseWalletClient.signAuthorization({
+      contractAddress: baseMcNexusVersion.implementationAddress
+    })
+
+    const optimismAuth = await optimismWalletClient.signAuthorization({
+      contractAddress: optimismMcNexusVersion.implementationAddress
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: base.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(base.id)
+      }
+    })
+
+    const optimismTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimism.id,
+        amount: 1n,
+        tokenAddress: mcUSDC.addressOn(optimism.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      delegate: true,
+      authorizations: [baseAuth, optimismAuth],
+      instructions: [...baseTransfer, ...optimismTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    expect(quote.userOps[0].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[0].eip7702Auth).not.toBeDefined()
+
+    expect(quote.userOps[1].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[1].eip7702Auth).toBeDefined()
+    expect(quote.userOps[1].eip7702Auth?.address).to.eq(
+      baseMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[1].eip7702Auth?.chainId).to.eq(base.id)
+    expect(quote.userOps[1].eip7702Auth?.nonce).to.eq(baseAuth.nonce)
+    expect(quote.userOps[1].eip7702Auth?.r).to.eq(baseAuth.r)
+    expect(quote.userOps[1].eip7702Auth?.s).to.eq(baseAuth.s)
+    expect(quote.userOps[1].eip7702Auth?.yParity).to.eq(baseAuth.yParity)
+
+    expect(quote.userOps[2].userOp.initCode).to.eq("0x")
+    expect(quote.userOps[2].eip7702Auth).toBeDefined()
+    expect(quote.userOps[2].eip7702Auth?.address).to.eq(
+      optimismMcNexusVersion.implementationAddress
+    )
+    expect(quote.userOps[2].eip7702Auth?.chainId).to.eq(optimism.id)
+    expect(quote.userOps[2].eip7702Auth?.nonce).to.eq(optimismAuth.nonce)
+    expect(quote.userOps[2].eip7702Auth?.r).to.eq(optimismAuth.r)
+    expect(quote.userOps[2].eip7702Auth?.s).to.eq(optimismAuth.s)
+    expect(quote.userOps[2].eip7702Auth?.yParity).to.eq(optimismAuth.yParity)
+  })
+
+  // TODO: Need to improve the test coverage on execution here
+  test("Test here", async () => {
+    const baseSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: baseSepolia,
+      transport: http(TESTNET_RPC_URLS[baseSepolia.id])
+    }).extend(publicActions)
+
+    const optimismSepoliaWalletClient = createWalletClient({
+      account: eoaAccount,
+      chain: optimismSepolia,
+      transport: http(TESTNET_RPC_URLS[optimismSepolia.id])
+    }).extend(publicActions)
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0)
+        }
+      ],
+      accountAddress: eoaAccount.address
+    })
+
+    let isDelegated = await mcNexus.isDelegated()
+    console.log("Is delegated: ", isDelegated)
+
+    if (isDelegated) {
+      console.log("Undelegating the 7702 delegation")
+      await mcNexus.unDelegate()
+
+      isDelegated = await mcNexus.isDelegated()
+      console.log("Is delegated: ", isDelegated)
+    }
+
+    const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      baseSepolia.id,
+      true
+    )
+    const { version: optimismSepoliaMcNexusVersion } = mcNexus.deploymentOn(
+      optimismSepolia.id,
+      true
+    )
+
+    const baseSepoliaAuth = await baseSepoliaWalletClient.signAuthorization({
+      contractAddress: baseSepoliaMcNexusVersion.implementationAddress
+    })
+
+    const optimismSepoliaAuth =
+      await optimismSepoliaWalletClient.signAuthorization({
+        contractAddress: optimismSepoliaMcNexusVersion.implementationAddress
+      })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
+    })
+
+    const baseSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: baseSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(baseSepolia.id)
+      }
+    })
+
+    const optimismSepoliaTransfer = await mcNexus.build({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        chainId: optimismSepolia.id,
+        amount: 1n,
+        tokenAddress: testnetMcTestUSDCP.addressOn(optimismSepolia.id)
+      }
+    })
+
+    const quote = await meeClient.getQuote({
+      sponsorship: true,
+      sponsorshipOptions: {
+        url: DEFAULT_PATHFINDER_URL,
+        gasTank: {
+          address: DEFAULT_MEE_TESTNET_SPONSORSHIP_PAYMASTER_ACCOUNT,
+          token: DEFAULT_MEE_TESTNET_SPONSORSHIP_TOKEN_ADDRESS,
+          chainId: DEFAULT_MEE_TESTNET_SPONSORSHIP_CHAIN_ID
+        }
+      },
+      delegate: true,
+      authorizations: [baseSepoliaAuth, optimismSepoliaAuth],
+      instructions: [...baseSepoliaTransfer, ...optimismSepoliaTransfer]
+    })
+
+    expect(quote).toBeDefined()
+
+    const { hash } = await meeClient.executeQuote({ quote })
+
+    expect(hash).toBeDefined()
+
+    const receipt = await meeClient.waitForSupertransactionReceipt({
+      hash,
+      confirmations: 5
+    })
+
+    console.log(getMeeScanLink(hash))
+
+    expect(receipt).toBeDefined()
+    expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
+
+    isDelegated = await mcNexus.isDelegated()
+
+    if (isDelegated) {
+      console.log("Undelegating the 7702 delegation")
+      await mcNexus.unDelegate()
+      console.log("Is delegated: ", isDelegated)
+    }
   })
 })

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -641,11 +641,11 @@ export const getQuote = async (
             const missingAuthsByChainId: number[] = []
 
             for (const { chainId } of noncesAndChainIdsWithUniqueNonces) {
-              const isAuthExist = authorizations.some((auth) => {
+              const isAuthProvided = authorizations.some((auth) => {
                 return auth.chainId === chainId
               })
 
-              if (!isAuthExist) missingAuthsByChainId.push(chainId)
+              if (!isAuthProvided) missingAuthsByChainId.push(chainId)
             }
 
             if (missingAuthsByChainId.length > 0) {
@@ -657,11 +657,11 @@ export const getQuote = async (
 
           // For same multichain nonces ? Check for auth with zero id and throw error if it is not there
           if (noncesAndChainIdsWithSameNonces.length > 0) {
-            const isAuthExist = authorizations.some((auth) => {
+            const isAuthProvided = authorizations.some((auth) => {
               return auth.chainId === 0
             })
 
-            if (!isAuthExist) {
+            if (!isAuthProvided) {
               const chainIds = noncesAndChainIdsWithSameNonces.map(
                 (auth) => auth.chainId
               )
@@ -705,11 +705,11 @@ export const getQuote = async (
         const missingAuthsByChainId: number[] = []
 
         for (const chainId of sprtxChainIds) {
-          const isAuthExist = authorizations.some((auth) => {
+          const isAuthProvided = authorizations.some((auth) => {
             return auth.chainId === chainId
           })
 
-          if (!isAuthExist) missingAuthsByChainId.push(chainId)
+          if (!isAuthProvided) missingAuthsByChainId.push(chainId)
         }
 
         if (missingAuthsByChainId.length > 0) {

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -21,7 +21,8 @@ import {
   DEFAULT_MEE_SPONSORSHIP_CHAIN_ID,
   DEFAULT_MEE_SPONSORSHIP_PAYMASTER_ACCOUNT,
   DEFAULT_MEE_SPONSORSHIP_TOKEN_ADDRESS,
-  DEFAULT_PATHFINDER_URL
+  DEFAULT_PATHFINDER_URL,
+  getDefaultMEENetworkUrl
 } from "../../createMeeClient"
 
 export const USEROP_MIN_EXEC_WINDOW_DURATION = 180
@@ -761,9 +762,10 @@ export const getQuote = async (
   })
 
   if (sponsorship && sponsorshipOptions) {
+    // Both prod and staging network url is considered as biconomy hosted sponsorship service
     const isSelfHostedSponsorship = ![
-      DEFAULT_PATHFINDER_URL,
-      DEFAULT_PATHFINDER_URL
+      getDefaultMEENetworkUrl(false), // Prod
+      getDefaultMEENetworkUrl(true) // Staging
     ].includes(sponsorshipOptions.url)
 
     if (isSelfHostedSponsorship) {

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -33,6 +33,8 @@ export const CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION =
 export const DEFAULT_GAS_LIMIT = 75_000n
 export const DEFAULT_VERIFICATION_GAS_LIMIT = 150_000n
 
+type INIT_DATA_TYPE = "SINGLE_CHAIN_AUTH" | "MULTI_CHAIN_AUTH" | "INIT_CODE"
+
 /**
  * Represents an abstract call to be executed in the transaction.
  * Each call specifies a target contract and optional parameters.
@@ -538,7 +540,8 @@ export const getQuote = async (
     moduleAddress,
     shortEncodingSuperTxn = false,
     sponsorship = false,
-    sponsorshipOptions
+    sponsorshipOptions,
+    feeToken
   } = parameters
 
   const resolvedInstructions = await resolveInstructions(instructions)
@@ -565,83 +568,193 @@ export const getQuote = async (
     )
   }
 
-  const hasProcessedInitData: string[] = []
-  const hasProcessedMultichainEIP7702AuthData: string[] = []
+  const hasProcessedInitData: number[] = []
+
   const paymentVerificationGasLimit = resolvePaymentUserOpVerificationGasLimit({
     moduleAddress,
     sponsorship
   })
 
+  const initDataTypeByChainId = new Map<number, INIT_DATA_TYPE>()
+
+  const sprtxChainIdsSet = new Set<number>([])
+
+  // For non sponsored flow, fee token chainId needs to be included
+  if (feeToken) sprtxChainIdsSet.add(feeToken.chainId)
+
+  // Chains IDS from instructions are considered
+  for (const inx of resolvedInstructions) {
+    sprtxChainIdsSet.add(inx.chainId)
+  }
+
+  const sprtxChainIds = [...sprtxChainIdsSet]
+
+  if (delegate) {
+    if (multichain7702Auth) {
+      // Check for all the nonces are same only if there is more than one chain is involved in the sprtx
+      if (sprtxChainIds.length > 1) {
+        const noncesAndChainIds = await Promise.all(
+          sprtxChainIds.map(async (chainId) => {
+            const {
+              publicClient,
+              walletClient: {
+                account: { address }
+              }
+            } = account_.deploymentOn(chainId, true)
+            return {
+              chainId,
+              nonce: await publicClient.getTransactionCount({ address })
+            }
+          })
+        )
+
+        const nonceCountMap = noncesAndChainIds.reduce((map, { nonce }) => {
+          map.set(nonce, (map.get(nonce) || 0) + 1)
+          return map
+        }, new Map<number, number>())
+
+        // Chains with different nonces needs different authorizations
+        const noncesAndChainIdsWithUniqueNonces = noncesAndChainIds.filter(
+          (info) => nonceCountMap.get(info.nonce) === 1
+        )
+
+        // Chains with same nonces can reuse the same authorization which is signed only once
+        const noncesAndChainIdsWithSameNonces = noncesAndChainIds.filter(
+          (info) => nonceCountMap.get(info.nonce)! > 1
+        )
+
+        // If custom authorizations are passed, a series of validation is conducted here
+        if (authorizations.length > 0) {
+          // If noncesAndChainIdsWithUniqueNonces length is zero ? It means all the nonces are same and can be used for multichain
+          // It is expected to pass only one auth from outside the SDK.
+          if (
+            noncesAndChainIdsWithUniqueNonces.length === 0 &&
+            authorizations.length > 1
+          ) {
+            throw new Error(
+              "Invalid authorizations, more than one auth passed for multichain authorization."
+            )
+          }
+
+          // If multichain nonce are not same and custom auth are passed ? The auth should be sufficient orelse error will be thrown
+          if (noncesAndChainIdsWithUniqueNonces.length > 0) {
+            const missingAuthsByChainId: number[] = []
+
+            for (const { chainId } of noncesAndChainIdsWithUniqueNonces) {
+              const isAuthExist = authorizations.some((auth) => {
+                return auth.chainId === chainId
+              })
+
+              if (!isAuthExist) missingAuthsByChainId.push(chainId)
+            }
+
+            if (missingAuthsByChainId.length > 0) {
+              throw new Error(
+                `Invalid multichain authorizations, nonce on all the chains are not same. You need to pass authorizations for the following chains: ${missingAuthsByChainId.join(", ")}`
+              )
+            }
+          }
+
+          // For same multichain nonces ? Check for auth with zero id and throw error if it is not there
+          if (noncesAndChainIdsWithSameNonces.length > 0) {
+            const isAuthExist = authorizations.some((auth) => {
+              return auth.chainId === 0
+            })
+
+            if (!isAuthExist) {
+              const chainIds = noncesAndChainIdsWithSameNonces.map(
+                (auth) => auth.chainId
+              )
+              throw new Error(
+                `Invalid multichain authorizations. Missing chainId zero authorization for the following chains: ${chainIds.join(", ")}`
+              )
+            }
+          }
+        }
+
+        for (const chainId of sprtxChainIds) {
+          const isMultichainAuth = noncesAndChainIdsWithSameNonces.filter(
+            (info) => info.chainId === chainId
+          )
+          initDataTypeByChainId.set(
+            chainId,
+            isMultichainAuth ? "MULTI_CHAIN_AUTH" : "SINGLE_CHAIN_AUTH"
+          )
+        }
+      } else {
+        if (authorizations.length > 1) {
+          throw new Error(
+            "Invalid multichain authorization. Only one authorization is required for multichain 7702 flow"
+          )
+        }
+
+        if (authorizations.length === 1 && authorizations[0].chainId !== 0) {
+          throw new Error(
+            "Invalid multichain authorization. Chain ID zero is expected in the authorization"
+          )
+        }
+
+        // If only one chain is invloved. It can be directly treated as multichain
+        for (const chainId of sprtxChainIds) {
+          initDataTypeByChainId.set(chainId, "MULTI_CHAIN_AUTH")
+        }
+      }
+    } else {
+      // If custom authorizations are passed, a series of validation is conducted here
+      if (authorizations.length > 0) {
+        const missingAuthsByChainId: number[] = []
+
+        for (const chainId of sprtxChainIds) {
+          const isAuthExist = authorizations.some((auth) => {
+            return auth.chainId === chainId
+          })
+
+          if (!isAuthExist) missingAuthsByChainId.push(chainId)
+        }
+
+        if (missingAuthsByChainId.length > 0) {
+          throw new Error(
+            `Authorizations are missing for the following chains: ${missingAuthsByChainId.join(", ")}`
+          )
+        }
+      }
+
+      // All the auths will be treated as single chain auth without chain id zero
+      for (const chainId of sprtxChainIds) {
+        initDataTypeByChainId.set(chainId, "SINGLE_CHAIN_AUTH")
+      }
+    }
+  } else {
+    // No auth at all. Init code will be added if account is not deployed
+    for (const chainId of sprtxChainIds) {
+      initDataTypeByChainId.set(chainId, "INIT_CODE")
+    }
+  }
+
   const { paymentInfo, isInitDataProcessed } = await preparePaymentInfo(
     client,
     {
       ...parameters,
-      paymentVerificationGasLimit
+      paymentVerificationGasLimit,
+      initDataTypeByChainId
     }
   )
 
   let multichainEIP7702Auth: MeeAuthorization | undefined = undefined
 
+  const paymentAuthType = initDataTypeByChainId.get(
+    Number(paymentInfo.chainId)
+  )!
+
+  // If payment info has eip7702 auth ? It is an non sponsored flow and auth is prepared
   // If it is multichain auth and eip7702Auth prepared by either custom auth or SDK signed one
   // It will be used for other userOp for delegation.
-  if (multichain7702Auth) {
-    const chainIdsToCheckSet = new Set([Number(paymentInfo.chainId)])
-
-    for (const inx of resolvedInstructions) {
-      chainIdsToCheckSet.add(inx.chainId)
-    }
-
-    const chainIdsToCheck = [...chainIdsToCheckSet]
-
-    // Check for all the nonces are same only if there is more than one chain is involved in the sprtx
-    if (chainIdsToCheck.length > 1) {
-      const nonces = await Promise.all(
-        chainIdsToCheck.map(async (chainId) => {
-          const {
-            publicClient,
-            walletClient: {
-              account: { address }
-            }
-          } = account_.deploymentOn(chainId, true)
-          return await publicClient.getTransactionCount({ address })
-        })
-      )
-
-      if ([...new Set(nonces)].length > 1) {
-        throw new Error(
-          "Invalid multichain authorizations, nonce on all the chains is not same"
-        )
-      }
-    }
-
-    // For non sponsorship flow, eip7702 auth will be prepared in payment info util
-    if (paymentInfo.eip7702Auth) {
-      multichainEIP7702Auth = paymentInfo.eip7702Auth
-    } else {
-      // For sponsorship flow, eip7702 auth will not be prepared in payment info util
-      // So we have to prepare once and attach to one userOp for all possible chains
-      if (resolvedInstructions.length === 0) {
-        throw new Error(
-          "Atleast one instruction is required for super transaction"
-        )
-      }
-
-      const { chainId } = resolvedInstructions[0]
-      const smartAccount = account_.deploymentOn(chainId, true)
-
-      multichainEIP7702Auth = await prepare7702Auth(
-        smartAccount,
-        chainId,
-        authorizations,
-        multichain7702Auth
-      )
-    }
-
-    // This prevents the auth to be added for more than one userOp in same chain
-    hasProcessedMultichainEIP7702AuthData.push(paymentInfo.chainId)
+  if (paymentInfo.eip7702Auth && paymentAuthType === "MULTI_CHAIN_AUTH") {
+    multichainEIP7702Auth = paymentInfo.eip7702Auth
   }
 
-  if (isInitDataProcessed) hasProcessedInitData.push(paymentInfo.chainId)
+  if (isInitDataProcessed)
+    hasProcessedInitData.push(Number(paymentInfo.chainId))
 
   const preparedUserOps = await prepareUserOps(
     account_,
@@ -690,38 +803,47 @@ export const getQuote = async (
         }
 
         // If account is not deployed, either initCode or eip7702Auth needs to be attached.
-        if (!isAccountDeployed) {
-          // If multichain EIP7702 auth is available ? It means, 7702 mode and no initCode is there. So we have to use this multichain auth
-          // for all the chains once in any of the userOp.
-          if (multichainEIP7702Auth) {
-            // This prevents the multichain auth to be added for more than one userOp in same chain
-            if (!hasProcessedMultichainEIP7702AuthData.includes(chainId)) {
-              hasProcessedMultichainEIP7702AuthData.push(chainId)
+        // If init code or 7702 auth is already added for the chain ? Skip this
+        if (
+          !isAccountDeployed &&
+          !hasProcessedInitData.includes(Number(chainId))
+        ) {
+          // Mark as initData processed
+          hasProcessedInitData.push(Number(chainId))
+
+          const authType = initDataTypeByChainId.get(Number(chainId))!
+
+          // If multichain EIP7702 auth is available ? It means, 7702 mode and no initCode is there.
+          if (authType === "MULTI_CHAIN_AUTH") {
+            // Apply existing multichain auth where the chain Ids were same. So no need multiple auths to be signed
+            if (multichainEIP7702Auth) {
+              initDataOrUndefined = {
+                eip7702Auth: multichainEIP7702Auth
+              }
+            } else {
+              // This multichain auth will be used for the current chains and other chains which has the same nonce
+              multichainEIP7702Auth = await prepare7702Auth(
+                nexusAccount,
+                Number(chainId),
+                initDataTypeByChainId,
+                authorizations
+              )
 
               initDataOrUndefined = {
                 eip7702Auth: multichainEIP7702Auth
               }
             }
-          } else {
-            // If the initData is not already added
-            if (!hasProcessedInitData.includes(chainId)) {
-              // Mark as initData processed
-              hasProcessedInitData.push(chainId)
-
-              if (delegate) {
-                // If delegation ? Add the 7702 auth
-                initDataOrUndefined = {
-                  eip7702Auth: await prepare7702Auth(
-                    nexusAccount,
-                    Number(chainId),
-                    authorizations,
-                    false // This will be never multichain, so always false
-                  )
-                }
-              } else {
-                initDataOrUndefined = { initCode }
-              }
+          } else if (authType === "SINGLE_CHAIN_AUTH") {
+            initDataOrUndefined = {
+              eip7702Auth: await prepare7702Auth(
+                nexusAccount,
+                Number(chainId),
+                initDataTypeByChainId,
+                authorizations
+              )
             }
+          } else {
+            initDataOrUndefined = { initCode }
           }
         }
 
@@ -789,6 +911,7 @@ const preparePaymentInfo = async (
   client: BaseMeeClient,
   parameters: GetQuoteParams & {
     paymentVerificationGasLimit?: { verificationGasLimit: bigint }
+    initDataTypeByChainId: Map<number, INIT_DATA_TYPE>
   }
 ) => {
   const {
@@ -796,11 +919,9 @@ const preparePaymentInfo = async (
     eoa,
     feeToken,
     feePayer,
-    delegate = false,
     gasLimit,
     verificationGasLimit,
     authorizations = [],
-    multichain7702Auth = false,
     sponsorship,
     sponsorshipOptions,
     shortEncodingSuperTxn,
@@ -896,18 +1017,21 @@ const preparePaymentInfo = async (
     let initData: InitDataOrUndefined = undefined
 
     if (!isAccountDeployed) {
-      // If delegate is true, 7702 delegation is injected
-      if (delegate) {
+      const initDataType = parameters.initDataTypeByChainId.get(
+        feeToken.chainId
+      )!
+
+      if (initDataType === "INIT_CODE") {
+        initData = { initCode }
+      } else {
         initData = {
           eip7702Auth: await prepare7702Auth(
             validPaymentAccount,
             feeToken.chainId,
-            authorizations,
-            multichain7702Auth
+            parameters.initDataTypeByChainId,
+            authorizations
           )
         }
-      } else {
-        initData = { initCode }
       }
     }
 
@@ -939,32 +1063,23 @@ const preparePaymentInfo = async (
 const prepare7702Auth = async (
   smartAccount: ModularSmartAccount,
   chainId: number,
-  customAuthorizations: SignAuthorizationReturnType[] = [],
-  multichain7702Auth = false
+  initDataTypeByChainId: Map<number, INIT_DATA_TYPE>,
+  customAuthorizations: SignAuthorizationReturnType[] = []
 ): Promise<MeeAuthorization> => {
   let eip7702Auth: MeeAuthorization
 
-  if (multichain7702Auth) {
-    // If multichain auth ? Only one custom auth is expected with chain id zero
-    if (customAuthorizations.length > 1) {
-      throw new Error(
-        "For multichain 7702 authorization, custom authorizations should not be more than one"
-      )
-    }
+  const authType = initDataTypeByChainId.get(chainId)!
 
-    const authorization = customAuthorizations[0]
-
-    // If custom auth is there ? It needs to be signed with zero chain id
-    if (authorization && authorization.chainId !== 0) {
-      throw new Error(
-        "For multichain 7702 authorization, custom auth should be signed with zero chain id"
-      )
-    }
+  if (authType === "MULTI_CHAIN_AUTH") {
+    // if it is multichain auth ? custom auth will be filtered with zero chain id
+    const [authorization] = customAuthorizations.filter(
+      (auth) => auth.chainId === 0
+    )
 
     eip7702Auth = await smartAccount.toDelegation(
       authorization ? { authorization } : { multiChain: true }
     )
-  } else {
+  } else if (authType === "SINGLE_CHAIN_AUTH") {
     // if it is not multichain auth ? custom auth will be filtered for specific chain
     const [authorization] = customAuthorizations.filter((auth) => {
       return auth.chainId === Number(chainId)
@@ -973,6 +1088,9 @@ const prepare7702Auth = async (
     eip7702Auth = await smartAccount.toDelegation(
       authorization ? { authorization } : { chainId }
     )
+  } else {
+    // This should never happen in theory
+    throw new Error("Invalid authorization type")
   }
 
   return eip7702Auth

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -632,7 +632,7 @@ export const getQuote = async (
             authorizations.length > 1
           ) {
             throw new Error(
-              "Invalid authorizations, more than one auth passed for multichain authorization."
+              "Invalid authorizations: The nonce for all the chains are zero and only one multichain authorization is expected"
             )
           }
 
@@ -650,7 +650,7 @@ export const getQuote = async (
 
             if (missingAuthsByChainId.length > 0) {
               throw new Error(
-                `Invalid multichain authorizations, nonce on all the chains are not same. You need to pass authorizations for the following chains: ${missingAuthsByChainId.join(", ")}`
+                `Invalid authorizations: The nonce for all the chains are not same. You need to pass specific authorizations for the following chains: ${missingAuthsByChainId.join(", ")}`
               )
             }
           }
@@ -666,14 +666,14 @@ export const getQuote = async (
                 (auth) => auth.chainId
               )
               throw new Error(
-                `Invalid multichain authorizations. Missing chainId zero authorization for the following chains: ${chainIds.join(", ")}`
+                `Invalid authorizations: The nonce for some of the chains are same. Missing multichain authorization for the following chains: ${chainIds.join(", ")}`
               )
             }
           }
         }
 
         for (const chainId of sprtxChainIds) {
-          const isMultichainAuth = noncesAndChainIdsWithSameNonces.filter(
+          const [isMultichainAuth] = noncesAndChainIdsWithSameNonces.filter(
             (info) => info.chainId === chainId
           )
           initDataTypeByChainId.set(
@@ -684,13 +684,13 @@ export const getQuote = async (
       } else {
         if (authorizations.length > 1) {
           throw new Error(
-            "Invalid multichain authorization. Only one authorization is required for multichain 7702 flow"
+            "Invalid authorizations: The nonce for all the chains are zero and only one multichain authorization is expected"
           )
         }
 
         if (authorizations.length === 1 && authorizations[0].chainId !== 0) {
           throw new Error(
-            "Invalid multichain authorization. Chain ID zero is expected in the authorization"
+            "Invalid authorizations: Multichain authorization should be signed with chain ID zero"
           )
         }
 

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -7,7 +7,7 @@ import { addressEquals } from "../../../account/utils/Utils"
 import { LARGE_DEFAULT_GAS_LIMIT } from "../../../account/utils/getMultichainContract"
 import { resolveInstructions } from "../../../account/utils/resolveInstructions"
 import { SMART_SESSIONS_ADDRESS } from "../../../constants"
-import type { RuntimeValue } from "../../../modules"
+import type { ModularSmartAccount, RuntimeValue } from "../../../modules"
 import {
   type ComposableCall,
   greaterThanOrEqualTo,
@@ -293,6 +293,10 @@ export type GetQuoteParams = SupertransactionLike & {
          * Whether to delegate the transaction to the account
          */
         delegate?: false
+        /**
+         * Whether to delegate the transaction to the account with chain id zero
+         */
+        multichain7702Auth?: false
       }
     | {
         /**
@@ -300,10 +304,14 @@ export type GetQuoteParams = SupertransactionLike & {
          */
         delegate: true
         /**
-         * The authorization data for the transaction. Should be a valid Viem compatible Authorization param on chainId 0
+         * Whether to delegate the transaction to the account with chain id zero
+         */
+        multichain7702Auth?: boolean
+        /**
+         * The array of authorization data for the transaction. Should be a valid Viem compatible Authorization param
          * If not provided, the account will be delegated to the implementation address, using chainId 0.
          */
-        authorization?: SignAuthorizationReturnType
+        authorizations?: SignAuthorizationReturnType[]
       }
   >
 
@@ -524,7 +532,8 @@ export const getQuote = async (
     upperBoundTimestamp: upperBoundTimestamp_ = lowerBoundTimestamp_ +
       USEROP_MIN_EXEC_WINDOW_DURATION,
     delegate = false,
-    authorization,
+    authorizations = [],
+    multichain7702Auth = false,
     moduleAddress,
     shortEncodingSuperTxn = false,
     sponsorship = false,
@@ -556,6 +565,7 @@ export const getQuote = async (
   }
 
   const hasProcessedInitData: string[] = []
+  const hasProcessedMultichainEIP7702AuthData: string[] = []
   const paymentVerificationGasLimit = resolvePaymentUserOpVerificationGasLimit({
     moduleAddress,
     sponsorship
@@ -568,6 +578,67 @@ export const getQuote = async (
       paymentVerificationGasLimit
     }
   )
+
+  let multichainEIP7702Auth: MeeAuthorization | undefined = undefined
+
+  // If it is multichain auth and eip7702Auth prepared by either custom auth or SDK signed one
+  // It will be used for other userOp for delegation.
+  if (multichain7702Auth) {
+    const chainIdsToCheckSet = new Set([Number(paymentInfo.chainId)])
+
+    for (const inx of resolvedInstructions) {
+      chainIdsToCheckSet.add(inx.chainId)
+    }
+
+    const chainIdsToCheck = [...chainIdsToCheckSet]
+
+    // Check for all the nonces are same only if there is more than one chain is involved in the sprtx
+    if (chainIdsToCheck.length > 1) {
+      const nonces = await Promise.all(
+        chainIdsToCheck.map(async (chainId) => {
+          const {
+            publicClient,
+            walletClient: {
+              account: { address }
+            }
+          } = account_.deploymentOn(chainId, true)
+          return await publicClient.getTransactionCount({ address })
+        })
+      )
+
+      if ([...new Set(nonces)].length > 1) {
+        throw new Error(
+          "Invalid multichain authorizations, nonce on all the chains is not same"
+        )
+      }
+    }
+
+    // For non sponsorship flow, eip7702 auth will be prepared in payment info util
+    if (paymentInfo.eip7702Auth) {
+      multichainEIP7702Auth = paymentInfo.eip7702Auth
+    } else {
+      // For sponsorship flow, eip7702 auth will not be prepared in payment info util
+      // So we have to prepare once and attach to one userOp for all possible chains
+      if (resolvedInstructions.length === 0) {
+        throw new Error(
+          "Atleast one instruction is required for super transaction"
+        )
+      }
+
+      const { chainId } = resolvedInstructions[0]
+      const smartAccount = account_.deploymentOn(chainId, true)
+
+      multichainEIP7702Auth = await prepare7702Auth(
+        smartAccount,
+        chainId,
+        authorizations,
+        multichain7702Auth
+      )
+    }
+
+    // This prevents the auth to be added for more than one userOp in same chain
+    hasProcessedMultichainEIP7702AuthData.push(paymentInfo.chainId)
+  }
 
   if (isInitDataProcessed) hasProcessedInitData.push(paymentInfo.chainId)
 
@@ -612,20 +683,45 @@ export const getQuote = async (
         shortEncoding
       ]) => {
         let initDataOrUndefined: InitDataOrUndefined = undefined
+
         if (!indexPerChainId.has(chainId)) {
           indexPerChainId.set(chainId, 0)
         }
 
-        const shouldContainInitData =
-          !hasProcessedInitData.includes(chainId) && !isAccountDeployed
+        // If account is not deployed, either initCode or eip7702Auth needs to be attached.
+        if (!isAccountDeployed) {
+          // If multichain EIP7702 auth is available ? It means, 7702 mode and no initCode is there. So we have to use this multichain auth
+          // for all the chains once in any of the userOp.
+          if (multichainEIP7702Auth) {
+            // This prevents the multichain auth to be added for more than one userOp in same chain
+            if (!hasProcessedMultichainEIP7702AuthData.includes(chainId)) {
+              hasProcessedMultichainEIP7702AuthData.push(chainId)
 
-        if (shouldContainInitData) {
-          hasProcessedInitData.push(chainId)
-          initDataOrUndefined = delegate
-            ? {
-                eip7702Auth: await nexusAccount.toDelegation({ authorization })
+              initDataOrUndefined = {
+                eip7702Auth: multichainEIP7702Auth
               }
-            : { initCode }
+            }
+          } else {
+            // If the initData is not already added
+            if (!hasProcessedInitData.includes(chainId)) {
+              // Mark as initData processed
+              hasProcessedInitData.push(chainId)
+
+              if (delegate) {
+                // If delegation ? Add the 7702 auth
+                initDataOrUndefined = {
+                  eip7702Auth: await prepare7702Auth(
+                    nexusAccount,
+                    Number(chainId),
+                    authorizations,
+                    false // This will be never multichain, so always false
+                  )
+                }
+              } else {
+                initDataOrUndefined = { initCode }
+              }
+            }
+          }
         }
 
         const verificationGasLimit = resolveVerificationGasLimit({
@@ -701,7 +797,8 @@ const preparePaymentInfo = async (
     delegate = false,
     gasLimit,
     verificationGasLimit,
-    authorization,
+    authorizations = [],
+    multichain7702Auth = false,
     sponsorship,
     sponsorshipOptions,
     shortEncodingSuperTxn,
@@ -794,15 +891,23 @@ const preparePaymentInfo = async (
     ])
 
     // Do authorization only if required as it requires signing
-    const initData: InitDataOrUndefined = isAccountDeployed
-      ? undefined
-      : delegate
-        ? {
-            eip7702Auth: await validPaymentAccount.toDelegation({
-              authorization
-            })
-          }
-        : { initCode }
+    let initData: InitDataOrUndefined = undefined
+
+    if (!isAccountDeployed) {
+      // If delegate is true, 7702 delegation is injected
+      if (delegate) {
+        initData = {
+          eip7702Auth: await prepare7702Auth(
+            validPaymentAccount,
+            feeToken.chainId,
+            authorizations,
+            multichain7702Auth
+          )
+        }
+      } else {
+        initData = { initCode }
+      }
+    }
 
     paymentInfo = {
       sponsored: false,
@@ -827,6 +932,48 @@ const preparePaymentInfo = async (
   if (!paymentInfo) throw new Error("Failed to generate payment info")
 
   return { paymentInfo, isInitDataProcessed }
+}
+
+const prepare7702Auth = async (
+  smartAccount: ModularSmartAccount,
+  chainId: number,
+  customAuthorizations: SignAuthorizationReturnType[] = [],
+  multichain7702Auth = false
+): Promise<MeeAuthorization> => {
+  let eip7702Auth: MeeAuthorization
+
+  if (multichain7702Auth) {
+    // If multichain auth ? Only one custom auth is expected with chain id zero
+    if (customAuthorizations.length > 1) {
+      throw new Error(
+        "For multichain 7702 authorization, custom authorizations should not be more than one"
+      )
+    }
+
+    const authorization = customAuthorizations[0]
+
+    // If custom auth is there ? It needs to be signed with zero chain id
+    if (authorization && authorization.chainId !== 0) {
+      throw new Error(
+        "For multichain 7702 authorization, custom auth should be signed with zero chain id"
+      )
+    }
+
+    eip7702Auth = await smartAccount.toDelegation(
+      authorization ? { authorization } : { multiChain: true }
+    )
+  } else {
+    // if it is not multichain auth ? custom auth will be filtered for specific chain
+    const [authorization] = customAuthorizations.filter((auth) => {
+      return auth.chainId === Number(chainId)
+    })
+
+    eip7702Auth = await smartAccount.toDelegation(
+      authorization ? { authorization } : { chainId }
+    )
+  }
+
+  return eip7702Auth
 }
 
 const prepareUserOps = async (


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `MEE` client functionality, particularly around authorization handling for multichain transactions and improving the testing of these features.

### Detailed summary
- Updated `getQuote` to accept an array of `authorizations` instead of a single `authorization`.
- Introduced helper functions `getDefaultMEENetworkUrl` and `getDefaultMEENetworkApiKey`.
- Modified `DEFAULT_PATHFINDER_URL` and `DEFAULT_PATHFINDER_API_KEY` to use the new helper functions.
- Enhanced `DelegationParams` to include `chainId` as a required field.
- Improved handling of multichain authorizations in `getQuote`, including validation for unique and same nonces.
- Added tests to verify automatic and manual injection of `7702` authorization for multichain transactions.
- Enhanced error handling for invalid authorizations in various scenarios.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->