### PR TITLE
fix: permit sig fix

### DIFF
--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -16,6 +16,7 @@ import { TokenWithPermitAbi } from "../../../constants/abi/TokenWithPermitAbi"
 import type { BaseMeeClient } from "../../createMeeClient"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { AbstractCall, GetQuotePayload } from "./getQuote"
+import { type EIP712DomainReturn } from "../../../account"
 
 /**
  * Represents the payload for a signable permit quote, omitting the "account" field from SignTypedDataParameters.
@@ -222,9 +223,23 @@ export const prepareSignablePermitQuotePayload = async (
         return value.value
       }
       if (value.status === "rejected") {
-        if (key === "version") {
-          // Some tokens do not implement version; default to "1"
-          return "1"
+        if (key === "nonce") {
+          // Tokens must implement the nonces function, otherwise we throw a error here
+          throw new Error(
+            "Permit signing failed: Token does not implement nonces(). This function is required for EIP-2612 compliance."
+          )
+        }
+
+        if (key === "domainSeparator") {
+          // Tokens must implement the domainSeparator function, otherwise we throw a error here
+          throw new Error(
+            "Permit signing failed: Token does not implement DOMAIN_SEPARATOR(). This function is required for EIP-712 domain separation."
+          )
+        }
+
+        if (key === "name" || key === "version") {
+          // Some tokens do not implement name and version; defaults to undefined
+          return undefined
         }
 
         if (key === "eip712Domain") {
@@ -232,22 +247,41 @@ export const prepareSignablePermitQuotePayload = async (
           return []
         }
       }
-      throw new Error(`Failed to get value: ${value.reason}`)
     }
-  ) as [
-    bigint,
-    string,
-    string,
-    Hex,
-    [Hex, string, string, bigint, Address, Hex, bigint[]]
-  ]
+  ) as [bigint, string, string, Hex, EIP712DomainReturn]
 
   const [, name_, version_] = eip712Domain
 
+  if (version && version_) {
+    if (version !== version_)
+      console.warn(
+        "Warning: Mismatch between token version() and eip712Domain().version. This may cause permit signature verification to fail."
+      )
+  }
+
+  if (name && name_) {
+    if (name !== name_)
+      console.warn(
+        "Warning: Mismatch between token name() and eip712Domain().name. This may cause permit signature verification to fail."
+      )
+  }
+
+  if (!name && !name_) {
+    throw new Error(
+      "Permit signing failed: Token name is missing. Neither name() nor eip712Domain().name is available."
+    )
+  }
+
+  if (!version && !version_) {
+    throw new Error(
+      "Permit signing failed: Token version is missing. Neither version() nor eip712Domain().version is available."
+    )
+  }
+
   const signablePermitQuotePayload = {
     domain: {
-      name: name_ || name,
-      version: version_ || version,
+      name: name_ || name, // name from eip712Domain is mostly safe and more priority is given
+      version: version_ || version, // version from eip712Domain is mostly safe and more priority is given
       chainId: trigger.chainId,
       verifyingContract: trigger.tokenAddress
     },

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -247,6 +247,9 @@ export const prepareSignablePermitQuotePayload = async (
           return []
         }
       }
+
+      // Fallback return value instead of throwing error
+      return undefined
     }
   ) as [bigint, string, string, Hex, EIP712DomainReturn]
 

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -209,26 +209,40 @@ export const prepareSignablePermitQuotePayload = async (
     token.read.eip712Domain()
   ])
 
-  const [nonce, name, version, domainSeparator, eip712Domain] = values.map((value, i) => {
-    const key = ["nonce", "name", "version", "domainSeparator", "eip712Domain"][i]
-    if (value.status === "fulfilled") {
-      return value.value
-    }
-    if (value.status === "rejected") {
-      if (key === "version") {
-        // Some tokens do not implement version; default to "1"
-        return "1"
+  const [nonce, name, version, domainSeparator, eip712Domain] = values.map(
+    (value, i) => {
+      const key = [
+        "nonce",
+        "name",
+        "version",
+        "domainSeparator",
+        "eip712Domain"
+      ][i]
+      if (value.status === "fulfilled") {
+        return value.value
       }
+      if (value.status === "rejected") {
+        if (key === "version") {
+          // Some tokens do not implement version; default to "1"
+          return "1"
+        }
 
-      if (key === "eip712Domain") {
-        // Some tokens do not implement eip712Domain; default to []
-        return []
+        if (key === "eip712Domain") {
+          // Some tokens do not implement eip712Domain; default to []
+          return []
+        }
       }
+      throw new Error(`Failed to get value: ${value.reason}`)
     }
-    throw new Error(`Failed to get value: ${value.reason}`)
-  }) as [bigint, string, string, Hex, [Hex, string, string, bigint, Address, Hex, bigint[]]]
+  ) as [
+    bigint,
+    string,
+    string,
+    Hex,
+    [Hex, string, string, bigint, Address, Hex, bigint[]]
+  ]
 
-  const [, name_, version_] = eip712Domain;
+  const [, name_, version_] = eip712Domain
 
   const signablePermitQuotePayload = {
     domain: {

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -10,13 +10,13 @@ import {
   getContract,
   parseSignature
 } from "viem"
+import type { EIP712DomainReturn } from "../../../account"
 import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
 import { PERMIT_TYPEHASH } from "../../../constants"
 import { TokenWithPermitAbi } from "../../../constants/abi/TokenWithPermitAbi"
 import type { BaseMeeClient } from "../../createMeeClient"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { AbstractCall, GetQuotePayload } from "./getQuote"
-import { type EIP712DomainReturn } from "../../../account"
 
 /**
  * Represents the payload for a signable permit quote, omitting the "account" field from SignTypedDataParameters.

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -205,25 +205,35 @@ export const prepareSignablePermitQuotePayload = async (
     token.read.nonces([owner]),
     token.read.name(),
     token.read.version(),
-    token.read.DOMAIN_SEPARATOR()
+    token.read.DOMAIN_SEPARATOR(),
+    token.read.eip712Domain()
   ])
 
-  const [nonce, name, version, domainSeparator] = values.map((value, i) => {
-    const key = ["nonce", "name", "version", "domainSeparator"][i]
+  const [nonce, name, version, domainSeparator, eip712Domain] = values.map((value, i) => {
+    const key = ["nonce", "name", "version", "domainSeparator", "eip712Domain"][i]
     if (value.status === "fulfilled") {
       return value.value
     }
-    if (value.status === "rejected" && key === "version") {
-      // Some tokens do not implement version; default to "1"
-      return "1"
+    if (value.status === "rejected") {
+      if (key === "version") {
+        // Some tokens do not implement version; default to "1"
+        return "1"
+      }
+
+      if (key === "eip712Domain") {
+        // Some tokens do not implement eip712Domain; default to []
+        return []
+      }
     }
     throw new Error(`Failed to get value: ${value.reason}`)
-  }) as [bigint, string, string, `0x${string}`]
+  }) as [bigint, string, string, Hex, [Hex, string, string, bigint, Address, Hex, bigint[]]]
+
+  const [, name_, version_] = eip712Domain;
 
   const signablePermitQuotePayload = {
     domain: {
-      name,
-      version,
+      name: name_ || name,
+      version: version_ || version,
       chainId: trigger.chainId,
       verifyingContract: trigger.tokenAddress
     },
@@ -250,8 +260,8 @@ export const prepareSignablePermitQuotePayload = async (
     signablePayload: signablePermitQuotePayload,
     metadata: {
       nonce,
-      name,
-      version,
+      name: name_ || name,
+      version: version_ || version,
       domainSeparator,
       owner,
       spender,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `prepareSignablePermitQuotePayload` function in `signPermitQuote.ts` to improve error handling and ensure compliance with EIP-2612 and EIP-712 standards by adding checks for the presence of necessary token properties.

### Detailed summary
- Added import for `EIP712DomainReturn`.
- Extended the values array to include `eip712Domain`.
- Improved error handling for missing token properties (nonces, domainSeparator, name, version, eip712Domain).
- Introduced warnings for mismatches between token and domain values.
- Updated the `signablePermitQuotePayload` to prioritize values from `eip712Domain`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->