### PR TITLE
chore: refactor is payment token info

### DIFF
--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -12,7 +12,6 @@ import {
 import type { BaseMeeClient } from "../../createMeeClient"
 import getMmDtkQuote, { type GetMmDtkQuoteParams } from "./getMmDtkQuote"
 import getOnChainQuote, { type GetOnChainQuotePayload } from "./getOnChainQuote"
-import { getPaymentToken } from "./getPaymentToken"
 import getPermitQuote, { type GetPermitQuotePayload } from "./getPermitQuote"
 import {
   type CleanUp,
@@ -104,29 +103,10 @@ export const getFusionQuote = async (
   if (parameters.delegatorSmartAccount) {
     return getMmDtkQuote(client, parameters as GetMmDtkQuoteParams)
   }
-  // if it is not mm-dtk, then it is permit or on-chain
-
-  const feeToken = parameters.feeToken
-  const trigger = parameters.trigger
-  //let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
-
-  // can be no feeToken => no payment token specified if it is sponsorship
-  const paymentTokenInfo = feeToken
-    ? await getPaymentToken(client, {
-        tokenAddress: feeToken.address,
-        chainId: feeToken.chainId
-      })
-    : undefined
-
-  const { walletClient: triggerWalletClient } = client.account.deploymentOn(
-    trigger.chainId,
-    true
-  )
 
   const signatureType = await getQuoteType(
-    triggerWalletClient,
-    parameters,
-    paymentTokenInfo
+    client,
+    parameters
   )
 
   switch (signatureType) {

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -78,7 +78,7 @@ export type GetFusionQuoteParams = GetQuoteParams & {
  *   walletProvider: "metamask",
  *   trigger: {
  *     chainId: "1",
- *     token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC
+ *     tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC
  *   },
  *   instructions: [{
  *     to: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -78,7 +78,7 @@ export type GetFusionQuoteParams = GetQuoteParams & {
  *   walletProvider: "metamask",
  *   trigger: {
  *     chainId: "1",
- *     paymentToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC
+ *     token: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC
  *   },
  *   instructions: [{
  *     to: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -12,7 +12,7 @@ import {
 import type { BaseMeeClient } from "../../createMeeClient"
 import getMmDtkQuote, { type GetMmDtkQuoteParams } from "./getMmDtkQuote"
 import getOnChainQuote, { type GetOnChainQuotePayload } from "./getOnChainQuote"
-import { type GetPaymentTokenPayload, getPaymentToken } from "./getPaymentToken"
+import { getPaymentToken } from "./getPaymentToken"
 import getPermitQuote, { type GetPermitQuotePayload } from "./getPermitQuote"
 import {
   type CleanUp,
@@ -106,21 +106,25 @@ export const getFusionQuote = async (
   }
   // if it is not mm-dtk, then it is permit or on-chain
 
+  const feeToken = parameters.feeToken
   const trigger = parameters.trigger
+  //let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
 
-  let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
+  // can be no feeToken => no payment token specified if it is sponsorship
+  const paymentTokenInfo = feeToken
+    ? await getPaymentToken(client, {
+        tokenAddress: feeToken.address,
+        chainId: feeToken.chainId
+      })
+    : undefined
 
-  if (trigger.tokenAddress) {
-    paymentTokenInfo = await getPaymentToken(client, {
-      tokenAddress: trigger.tokenAddress,
-      chainId: trigger.chainId
-    })
-  }
-
-  const { walletClient } = client.account.deploymentOn(trigger.chainId, true)
+  const { walletClient: triggerWalletClient } = client.account.deploymentOn(
+    trigger.chainId,
+    true
+  )
 
   const signatureType = await getQuoteType(
-    walletClient,
+    triggerWalletClient,
     parameters,
     paymentTokenInfo
   )

--- a/src/sdk/clients/decorators/mee/getFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/getFusionQuote.ts
@@ -104,10 +104,7 @@ export const getFusionQuote = async (
     return getMmDtkQuote(client, parameters as GetMmDtkQuoteParams)
   }
 
-  const signatureType = await getQuoteType(
-    client,
-    parameters
-  )
+  const signatureType = await getQuoteType(client, parameters)
 
   switch (signatureType) {
     case "permit":

--- a/src/sdk/clients/decorators/mee/getGasToken.test.ts
+++ b/src/sdk/clients/decorators/mee/getGasToken.test.ts
@@ -61,8 +61,8 @@ describe("mee.getGasToken", () => {
       address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     })
     expect(result.chainId).toBe("1")
-    expect(result.supportedFeeTokens.length).to.be.greaterThanOrEqual(6)
-    expect(result.supportedFeeTokens[0].symbol).toBe("ETH")
+    expect(result.paymentTokens.length).to.be.greaterThanOrEqual(6)
+    expect(result.paymentTokens[0].symbol).toBe("ETH")
   })
 
   test("should throw error for invalid chain id", async () => {

--- a/src/sdk/clients/decorators/mee/getGasToken.test.ts
+++ b/src/sdk/clients/decorators/mee/getGasToken.test.ts
@@ -61,8 +61,8 @@ describe("mee.getGasToken", () => {
       address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     })
     expect(result.chainId).toBe("1")
-    expect(result.paymentTokens.length).to.be.greaterThanOrEqual(6)
-    expect(result.paymentTokens[0].symbol).toBe("ETH")
+    expect(result.supportedFeeTokens.length).to.be.greaterThanOrEqual(6)
+    expect(result.supportedFeeTokens[0].symbol).toBe("ETH")
   })
 
   test("should throw error for invalid chain id", async () => {

--- a/src/sdk/clients/decorators/mee/getGasToken.ts
+++ b/src/sdk/clients/decorators/mee/getGasToken.ts
@@ -51,7 +51,7 @@ export type GetGasTokenPayload = {
  *
  * @returns Promise resolving to {@link GetGasTokenPayload} containing:
  * - chainId: The chain identifier
- * - supportedFeeTokens: Array of supported payment tokens for gas fees
+ * - paymentTokens: Array of supported payment tokens for gas fees
  *
  * @example
  * ```typescript
@@ -62,7 +62,7 @@ export type GetGasTokenPayload = {
  * // Returns:
  * // {
  * //   chainId: "1",
- * //   supportedFeeTokens: [{
+ * //   paymentTokens: [{
  * //     name: "USD Coin",
  * //     address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  * //     symbol: "USDC",
@@ -86,7 +86,6 @@ export const getGasToken = async (
   if (!gasToken) {
     throw new Error(`Gas token not found for chain ${parameters.chainId}`)
   }
-  console.log("gasToken", gasToken)
   return gasToken
 }
 

--- a/src/sdk/clients/decorators/mee/getGasToken.ts
+++ b/src/sdk/clients/decorators/mee/getGasToken.ts
@@ -1,6 +1,6 @@
 import type { Address } from "viem/accounts"
 import type { BaseMeeClient } from "../../createMeeClient"
-import type { PaymentToken } from "./getPaymentToken"
+import type { SupportedFeeToken } from "./getSupportedFeeToken"
 
 /**
  * Parameters for retrieving gas token information
@@ -30,13 +30,13 @@ export type GetGasTokenPayload = {
   chainId: string
   /**
    * List of payment tokens that can be used for gas fees on this chain
-   * @see {@link PaymentToken} for detailed token structure
+   * @see {@link SupportedFeeToken} for detailed token structure
    */
-  paymentTokens: PaymentToken[]
+  supportedFeeTokens: SupportedFeeToken[]
   /**
    * This indicates that the network supports Arbitrary token payments as a fallback mechanism
    */
-  isArbitraryPaymentTokensSupported: boolean
+  isArbitraryFeeTokensSupported: boolean
 }
 
 /**
@@ -51,7 +51,7 @@ export type GetGasTokenPayload = {
  *
  * @returns Promise resolving to {@link GetGasTokenPayload} containing:
  * - chainId: The chain identifier
- * - paymentTokens: Array of supported payment tokens for gas fees
+ * - supportedFeeTokens: Array of supported payment tokens for gas fees
  *
  * @example
  * ```typescript
@@ -62,7 +62,7 @@ export type GetGasTokenPayload = {
  * // Returns:
  * // {
  * //   chainId: "1",
- * //   paymentTokens: [{
+ * //   supportedFeeTokens: [{
  * //     name: "USD Coin",
  * //     address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  * //     symbol: "USDC",

--- a/src/sdk/clients/decorators/mee/getGasToken.ts
+++ b/src/sdk/clients/decorators/mee/getGasToken.ts
@@ -32,7 +32,7 @@ export type GetGasTokenPayload = {
    * List of payment tokens that can be used for gas fees on this chain
    * @see {@link SupportedFeeToken} for detailed token structure
    */
-  supportedFeeTokens: SupportedFeeToken[]
+  paymentTokens: SupportedFeeToken[]
   /**
    * This indicates that the network supports Arbitrary token payments as a fallback mechanism
    */
@@ -86,6 +86,7 @@ export const getGasToken = async (
   if (!gasToken) {
     throw new Error(`Gas token not found for chain ${parameters.chainId}`)
   }
+  console.log("gasToken", gasToken)
   return gasToken
 }
 

--- a/src/sdk/clients/decorators/mee/getInfo.test.ts
+++ b/src/sdk/clients/decorators/mee/getInfo.test.ts
@@ -70,7 +70,8 @@ describe("mee.getInfo", () => {
     )
 
     const tokenSymbols = info.supportedGasTokens.flatMap(
-      ({ supportedFeeTokens }) => supportedFeeTokens.map(({ symbol }) => symbol)
+      ({ paymentTokens: supportedFeeTokens }) =>
+        supportedFeeTokens.map(({ symbol }) => symbol)
     )
 
     expect(supportedChains.length).toBeGreaterThan(0)
@@ -88,8 +89,8 @@ describe("mee.getInfo", () => {
       address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     })
     expect(result.chainId).toBe("1")
-    expect(result.supportedFeeTokens.length).to.be.greaterThanOrEqual(6)
-    expect(result.supportedFeeTokens[0].symbol).toBe("ETH")
+    expect(result.paymentTokens.length).to.be.greaterThanOrEqual(6)
+    expect(result.paymentTokens[0].symbol).toBe("ETH")
   })
 
   test("should throw error for invalid chain id", async () => {

--- a/src/sdk/clients/decorators/mee/getInfo.test.ts
+++ b/src/sdk/clients/decorators/mee/getInfo.test.ts
@@ -11,8 +11,8 @@ import { getMEEVersion } from "../../../modules"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import { getGasToken } from "./getGasToken"
 import getInfo from "./getInfo"
-import { getPaymentToken } from "./getPaymentToken"
 import type { FeeTokenInfo } from "./getQuote"
+import { getSupportedFeeToken } from "./getSupportedFeeToken"
 
 describe("mee.getInfo", () => {
   let network: NetworkConfig
@@ -69,8 +69,8 @@ describe("mee.getInfo", () => {
       Number(chainId)
     )
 
-    const tokenSymbols = info.supportedGasTokens.flatMap(({ paymentTokens }) =>
-      paymentTokens.map(({ symbol }) => symbol)
+    const tokenSymbols = info.supportedGasTokens.flatMap(
+      ({ supportedFeeTokens }) => supportedFeeTokens.map(({ symbol }) => symbol)
     )
 
     expect(supportedChains.length).toBeGreaterThan(0)
@@ -88,8 +88,8 @@ describe("mee.getInfo", () => {
       address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     })
     expect(result.chainId).toBe("1")
-    expect(result.paymentTokens.length).to.be.greaterThanOrEqual(6)
-    expect(result.paymentTokens[0].symbol).toBe("ETH")
+    expect(result.supportedFeeTokens.length).to.be.greaterThanOrEqual(6)
+    expect(result.supportedFeeTokens[0].symbol).toBe("ETH")
   })
 
   test("should throw error for invalid chain id", async () => {
@@ -103,25 +103,28 @@ describe("mee.getInfo", () => {
   })
 
   test("should return payment token and arbitrary token payment info for valid chain id and address", async () => {
-    const paymentTokenInfo = await getPaymentToken(meeClient, {
+    const supportedFeeTokenInfo = await getSupportedFeeToken(meeClient, {
       chainId: 1,
       tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     })
 
-    expect(paymentTokenInfo.isArbitraryPaymentTokensSupported).to.be.oneOf([
+    expect(supportedFeeTokenInfo.isArbitraryFeeTokensSupported).to.be.oneOf([
       true,
       false,
       null,
       undefined
     ])
 
-    expect(paymentTokenInfo.paymentToken).not.to.be.oneOf([undefined, null])
+    expect(supportedFeeTokenInfo.supportedFeeToken).not.to.be.oneOf([
+      undefined,
+      null
+    ])
 
-    if (paymentTokenInfo.paymentToken) {
-      expect(paymentTokenInfo.paymentToken.symbol).toBe("USDC")
+    if (supportedFeeTokenInfo.supportedFeeToken) {
+      expect(supportedFeeTokenInfo.supportedFeeToken.symbol).toBe("USDC")
       expect(
         addressEquals(
-          paymentTokenInfo.paymentToken.address,
+          supportedFeeTokenInfo.supportedFeeToken.address,
           "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
         )
       ).toBe(true)
@@ -129,17 +132,20 @@ describe("mee.getInfo", () => {
   })
 
   test("should return undefined payment token for invalid address", async () => {
-    const paymentTokenInfo = await getPaymentToken(meeClient, {
+    const supportedFeeTokenInfo = await getSupportedFeeToken(meeClient, {
       chainId: 1,
       tokenAddress: "0x1234567890123456789012345678901234567890"
     })
 
-    expect(paymentTokenInfo.isArbitraryPaymentTokensSupported).to.be.oneOf([
+    expect(supportedFeeTokenInfo.isArbitraryFeeTokensSupported).to.be.oneOf([
       true,
       false,
       null,
       undefined
     ])
-    expect(paymentTokenInfo.paymentToken).to.be.oneOf([undefined, null])
+    expect(supportedFeeTokenInfo.supportedFeeToken).to.be.oneOf([
+      undefined,
+      null
+    ])
   })
 })

--- a/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
+++ b/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
@@ -52,22 +52,6 @@ export type GetMmDtkQuoteParams = GetQuoteParams & {
  *
  * @returns Promise resolving to quote payload with permit-specific trigger information
  *
- * @example
- * ```typescript
- * const quote = await getPermitQuote(meeClient, {
- *   instructions: [{
- *     to: "0x742d35Cc6634C0532925a3b844Bc454e4438f44e",
- *     data: "0x...",
- *     value: "0"
- *   }],
- *   trigger: {
- *     paymentToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
- *     amount: "1000000", // 1 USDC (6 decimals)
- *     owner: "0x...", // Token owner address
- *     spender: "0x..." // Address approved to spend tokens
- *   }
- * });
- * ```
  *
  * @throws Will throw an error if:
  * - The trigger parameters are invalid

--- a/src/sdk/clients/decorators/mee/getOnChainQuote.ts
+++ b/src/sdk/clients/decorators/mee/getOnChainQuote.ts
@@ -63,7 +63,7 @@ export type GetOnChainQuoteParams = GetQuoteParams & {
  *     })
  *   ],
  *   trigger: {
- *     paymentToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+ *     tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
  *     amount: "1000000" // 1 USDC (6 decimals)
  *   }
  * });

--- a/src/sdk/clients/decorators/mee/getPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.ts
@@ -54,7 +54,7 @@ export type GetPermitQuoteParams = GetQuoteParams & {
  *     value: "0"
  *   }],
  *   trigger: {
- *     paymentToken: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
+ *     tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48", // USDC
  *     amount: "1000000", // 1 USDC (6 decimals)
  *     owner: "0x...", // Token owner address
  *     spender: "0x..." // Address approved to spend tokens

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -1,8 +1,14 @@
-import { http, type Chain, type LocalAccount, createWalletClient, type WalletClient } from "viem"
+import {
+  http,
+  type Chain,
+  type LocalAccount,
+  type WalletClient,
+  createWalletClient
+} from "viem"
 import { beforeAll, describe, expect, test } from "vitest"
 import type { GetFusionQuoteParams, GetQuoteParams } from "."
 import { toNetwork } from "../../../../test/testSetup"
-import { testnetMcTestUSDCP } from "../../../../test/testTokens"
+import { testnetMcTestUSDC, testnetMcTestUSDCP } from "../../../../test/testTokens"
 import type { NetworkConfig } from "../../../../test/testUtils"
 import {
   type MultichainSmartAccount,
@@ -244,12 +250,6 @@ describe("mee.getQuoteType", () => {
     )
   })
 
-   // Add the tests for isPermitTokenInfo function => all the logic branches
-  // 1. payment token not specified + arbitrary payment tokens supported
-  // 2. payment token not specified + arbitrary payment tokens not supported
-  // 3. payment token specified + payment token different from the trigger token
-  // 4. payment token specified + payment token same as the trigger token + permit enabled
-  // 5. payment token specified + payment token same as the trigger token + permit not enabled
   describe("isPermitTokenInfo", () => {
     test("Payment token not specified + arbitrary payment tokens supported", async () => {
       const paymentTokenInfo = await getPaymentToken(meeClient, {
@@ -259,17 +259,80 @@ describe("mee.getQuoteType", () => {
       paymentTokenInfo.isArbitraryPaymentTokensSupported = true
       expect(paymentTokenInfo.paymentToken).to.be.undefined
 
-      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, 
-        {
+      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, {
         tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
         chainId: chain.id,
         amount: 1n
-        } 
-      )
-      // if arbitrary payment tokens supported, 
+      })
+      // if arbitrary payment tokens supported,
       // should return true for the trigger token that supports permit
       expect(isPermit).to.be.true
     })
-  })
 
+    test("Payment token not specified + arbitrary payment tokens not supported", async () => {
+      const paymentTokenInfo = await getPaymentToken(meeClient, {
+        tokenAddress: "0x00000000000000000000000000000000000a11ce",
+        chainId: chain.id
+      })
+    
+      paymentTokenInfo.isArbitraryPaymentTokensSupported = false
+      expect(paymentTokenInfo.paymentToken).to.be.undefined
+
+      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, {
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        chainId: chain.id,
+        amount: 1n
+      })
+      // if arbitrary payment tokens not supported,
+      // should return false for the trigger token that supports permit
+      expect(isPermit).to.be.false
+    })
+
+    test("Payment token specified + payment token different from the trigger token", async () => {
+      const paymentTokenInfo = await getPaymentToken(meeClient, {
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        chainId: chain.id
+      })
+
+      const trigger = {
+        // not permittable token
+        tokenAddress: testnetMcTestUSDC.addressOn(chain.id), 
+        chainId: chain.id,
+        amount: 1n
+      }
+      
+      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, trigger)
+      // should be based on trigger token in this case and trigger token does not support permit
+      expect(isPermit).to.be.false 
+    })
+
+    test("Payment token specified + payment token same as the trigger token + permit enabled", async () => {
+      const paymentTokenInfo = await getPaymentToken(meeClient, {
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        chainId: chain.id
+      })
+      const trigger = {
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        chainId: chain.id,
+        amount: 1n
+      }
+      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, trigger)
+      expect(isPermit).to.be.true
+    })
+
+    test("Payment token specified + payment token same as the trigger token + permit not enabled", async () => {
+      const paymentTokenInfo = await getPaymentToken(meeClient, {
+        tokenAddress: testnetMcTestUSDC.addressOn(chain.id), // not permittable token
+        chainId: chain.id
+      })
+      
+      const trigger = {
+        tokenAddress: testnetMcTestUSDC.addressOn(chain.id), // not permittable token
+        chainId: chain.id,
+        amount: 1n
+      }
+      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, trigger)
+      expect(isPermit).to.be.false
+    })
+  })
 })

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -59,7 +59,7 @@ describe("mee.getQuoteType", () => {
     })
   })
 
-  test("Should get quote type for normal quote params", async () => {
+  test("Should get quote type for simple quote params", async () => {
     const transferInstruction = await mcNexus.buildComposable({
       type: "transfer",
       data: {
@@ -78,10 +78,10 @@ describe("mee.getQuoteType", () => {
       }
     }
 
-    expect(await getQuoteType(walletClient, quoteParam)).to.eq("simple")
+    expect(await getQuoteType(meeClient, quoteParam)).to.eq("simple")
   })
 
-  test("Should get quote type for normal quote payload", async () => {
+  test("Should get quote type for simple quote payload", async () => {
     const transferInstruction = await mcNexus.buildComposable({
       type: "transfer",
       data: {
@@ -100,7 +100,7 @@ describe("mee.getQuoteType", () => {
       }
     })
 
-    expect(await getQuoteType(walletClient, quote)).to.eq("simple")
+    expect(await getQuoteType(meeClient, quote)).to.eq("simple")
   })
 
   test("Should get quote type for permit quote param", async () => {
@@ -127,17 +127,8 @@ describe("mee.getQuoteType", () => {
       }
     }
 
-    let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
-
-    if (quoteParams.trigger.tokenAddress) {
-      paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: quoteParams.trigger.tokenAddress,
-        chainId: quoteParams.trigger.chainId
-      })
-    }
-
     expect(
-      await getQuoteType(walletClient, quoteParams, paymentTokenInfo)
+      await getQuoteType(meeClient, quoteParams)
     ).to.eq("permit")
   })
 
@@ -165,16 +156,7 @@ describe("mee.getQuoteType", () => {
       }
     })
 
-    let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
-
-    if (quote.trigger.tokenAddress) {
-      paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: quote.trigger.tokenAddress,
-        chainId: quote.trigger.chainId
-      })
-    }
-
-    expect(await getQuoteType(walletClient, quote, paymentTokenInfo)).to.eq(
+    expect(await getQuoteType(meeClient, quote)).to.eq(
       "permit"
     )
   })
@@ -203,16 +185,8 @@ describe("mee.getQuoteType", () => {
       }
     }
 
-    let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
-
-    if (quoteParam.trigger.tokenAddress) {
-      paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: quoteParam.trigger.tokenAddress,
-        chainId: quoteParam.trigger.chainId
-      })
-    }
     expect(
-      await getQuoteType(walletClient, quoteParam, paymentTokenInfo)
+      await getQuoteType(meeClient, quoteParam)
     ).to.eq("onchain")
   })
 
@@ -240,124 +214,34 @@ describe("mee.getQuoteType", () => {
       }
     })
 
-    let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
-
-    if (quote.trigger.tokenAddress) {
-      paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: quote.trigger.tokenAddress,
-        chainId: quote.trigger.chainId
-      })
-    }
-    expect(await getQuoteType(walletClient, quote, paymentTokenInfo)).to.eq(
+    expect(await getQuoteType(meeClient, quote)).to.eq(
       "onchain"
     )
   })
 
   describe("isPermitTokenInfo", () => {
-    test("Payment token not specified + arbitrary payment tokens supported", async () => {
-      const paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: "0x00000000000000000000000000000000000a11ce",
-        chainId: chain.id
-      })
-      paymentTokenInfo.isArbitraryPaymentTokensSupported = true
-      expect(paymentTokenInfo.paymentToken).to.be.undefined
-
-      const trigger = {
-        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
-        chainId: chain.id,
-        amount: 1n
-      }
-
-      const isPermit = await isPermitTokenInfo(
-        walletClient,
-        trigger,
-        paymentTokenInfo
-      )
-      // if arbitrary payment tokens supported,
-      // should return true for the trigger token that supports permit
-      expect(isPermit).to.be.true
-    })
-
-    test("Payment token not specified + arbitrary payment tokens not supported", async () => {
-      const paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: "0x00000000000000000000000000000000000a11ce",
-        chainId: chain.id
-      })
-
-      paymentTokenInfo.isArbitraryPaymentTokensSupported = false
-      expect(paymentTokenInfo.paymentToken).to.be.undefined
-
-      const trigger = {
-        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
-        chainId: chain.id,
-        amount: 1n
-      }
-
-      const isPermit = await isPermitTokenInfo(
-        walletClient,
-        trigger,
-        paymentTokenInfo
-      )
-      // if arbitrary payment tokens not supported,
-      // should return false for the trigger token that supports permit
-      expect(isPermit).to.be.false
-    })
-
-    test("Payment token specified + payment token different from the trigger token", async () => {
-      const paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
-        chainId: chain.id
-      })
-
-      const trigger = {
-        // not permittable token
-        tokenAddress: testnetMcTestUSDC.addressOn(chain.id),
-        chainId: chain.id,
-        amount: 1n
-      }
-
-      const isPermit = await isPermitTokenInfo(
-        walletClient,
-        trigger,
-        paymentTokenInfo
-      )
-      // should be based on trigger token in this case and trigger token does not support permit
-      expect(isPermit).to.be.false
-    })
-
-    test("Payment token specified + payment token same as the trigger token + permit enabled", async () => {
-      const paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
-        chainId: chain.id
-      })
+    test("Trigger token is permit enabled", async () => {
       const trigger = {
         tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
         chainId: chain.id,
         amount: 1n
       }
       const isPermit = await isPermitTokenInfo(
-        walletClient,
+        meeClient,
         trigger,
-        paymentTokenInfo
       )
       expect(isPermit).to.be.true
     })
 
     test("Payment token specified + payment token same as the trigger token + permit not enabled", async () => {
-      const paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: testnetMcTestUSDC.addressOn(chain.id), // not permittable token
-        chainId: chain.id
-      })
-
       const trigger = {
         tokenAddress: testnetMcTestUSDC.addressOn(chain.id), // not permittable token
         chainId: chain.id,
         amount: 1n
       }
       const isPermit = await isPermitTokenInfo(
-        walletClient,
+        meeClient,
         trigger,
-        paymentTokenInfo
       )
       expect(isPermit).to.be.false
     })

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -8,7 +8,10 @@ import {
 import { beforeAll, describe, expect, test } from "vitest"
 import type { GetFusionQuoteParams, GetQuoteParams } from "."
 import { toNetwork } from "../../../../test/testSetup"
-import { testnetMcTestUSDC, testnetMcTestUSDCP } from "../../../../test/testTokens"
+import {
+  testnetMcTestUSDC,
+  testnetMcTestUSDCP
+} from "../../../../test/testTokens"
 import type { NetworkConfig } from "../../../../test/testUtils"
 import {
   type MultichainSmartAccount,
@@ -274,7 +277,7 @@ describe("mee.getQuoteType", () => {
         tokenAddress: "0x00000000000000000000000000000000000a11ce",
         chainId: chain.id
       })
-    
+
       paymentTokenInfo.isArbitraryPaymentTokensSupported = false
       expect(paymentTokenInfo.paymentToken).to.be.undefined
 
@@ -296,14 +299,18 @@ describe("mee.getQuoteType", () => {
 
       const trigger = {
         // not permittable token
-        tokenAddress: testnetMcTestUSDC.addressOn(chain.id), 
+        tokenAddress: testnetMcTestUSDC.addressOn(chain.id),
         chainId: chain.id,
         amount: 1n
       }
-      
-      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, trigger)
+
+      const isPermit = await isPermitTokenInfo(
+        walletClient,
+        paymentTokenInfo,
+        trigger
+      )
       // should be based on trigger token in this case and trigger token does not support permit
-      expect(isPermit).to.be.false 
+      expect(isPermit).to.be.false
     })
 
     test("Payment token specified + payment token same as the trigger token + permit enabled", async () => {
@@ -316,7 +323,11 @@ describe("mee.getQuoteType", () => {
         chainId: chain.id,
         amount: 1n
       }
-      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, trigger)
+      const isPermit = await isPermitTokenInfo(
+        walletClient,
+        paymentTokenInfo,
+        trigger
+      )
       expect(isPermit).to.be.true
     })
 
@@ -325,13 +336,17 @@ describe("mee.getQuoteType", () => {
         tokenAddress: testnetMcTestUSDC.addressOn(chain.id), // not permittable token
         chainId: chain.id
       })
-      
+
       const trigger = {
         tokenAddress: testnetMcTestUSDC.addressOn(chain.id), // not permittable token
         chainId: chain.id,
         amount: 1n
       }
-      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, trigger)
+      const isPermit = await isPermitTokenInfo(
+        walletClient,
+        paymentTokenInfo,
+        trigger
+      )
       expect(isPermit).to.be.false
     })
   })

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -20,8 +20,10 @@ import {
 import { DEFAULT_MEE_VERSION } from "../../../constants"
 import { getMEEVersion } from "../../../modules"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
-import getPaymentToken, { type GetPaymentTokenPayload } from "./getPaymentToken"
 import { getQuoteType, isPermitTokenInfo } from "./getQuoteType"
+import getSupportedFeeToken, {
+  type GetSupportedFeeTokenPayload
+} from "./getSupportedFeeToken"
 
 describe("mee.getQuoteType", () => {
   let network: NetworkConfig

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -262,11 +262,17 @@ describe("mee.getQuoteType", () => {
       paymentTokenInfo.isArbitraryPaymentTokensSupported = true
       expect(paymentTokenInfo.paymentToken).to.be.undefined
 
-      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, {
+      const trigger = {
         tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
         chainId: chain.id,
         amount: 1n
-      })
+      }
+
+      const isPermit = await isPermitTokenInfo(
+        walletClient,
+        trigger,
+        paymentTokenInfo
+      )
       // if arbitrary payment tokens supported,
       // should return true for the trigger token that supports permit
       expect(isPermit).to.be.true
@@ -281,11 +287,17 @@ describe("mee.getQuoteType", () => {
       paymentTokenInfo.isArbitraryPaymentTokensSupported = false
       expect(paymentTokenInfo.paymentToken).to.be.undefined
 
-      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, {
+      const trigger = {
         tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
         chainId: chain.id,
         amount: 1n
-      })
+      }
+
+      const isPermit = await isPermitTokenInfo(
+        walletClient,
+        trigger,
+        paymentTokenInfo
+      )
       // if arbitrary payment tokens not supported,
       // should return false for the trigger token that supports permit
       expect(isPermit).to.be.false
@@ -306,8 +318,8 @@ describe("mee.getQuoteType", () => {
 
       const isPermit = await isPermitTokenInfo(
         walletClient,
-        paymentTokenInfo,
-        trigger
+        trigger,
+        paymentTokenInfo
       )
       // should be based on trigger token in this case and trigger token does not support permit
       expect(isPermit).to.be.false
@@ -325,8 +337,8 @@ describe("mee.getQuoteType", () => {
       }
       const isPermit = await isPermitTokenInfo(
         walletClient,
-        paymentTokenInfo,
-        trigger
+        trigger,
+        paymentTokenInfo
       )
       expect(isPermit).to.be.true
     })
@@ -344,8 +356,8 @@ describe("mee.getQuoteType", () => {
       }
       const isPermit = await isPermitTokenInfo(
         walletClient,
-        paymentTokenInfo,
-        trigger
+        trigger,
+        paymentTokenInfo
       )
       expect(isPermit).to.be.false
     })

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -127,9 +127,7 @@ describe("mee.getQuoteType", () => {
       }
     }
 
-    expect(
-      await getQuoteType(meeClient, quoteParams)
-    ).to.eq("permit")
+    expect(await getQuoteType(meeClient, quoteParams)).to.eq("permit")
   })
 
   test("Should get quote type for permit quote payload", async () => {
@@ -156,9 +154,7 @@ describe("mee.getQuoteType", () => {
       }
     })
 
-    expect(await getQuoteType(meeClient, quote)).to.eq(
-      "permit"
-    )
+    expect(await getQuoteType(meeClient, quote)).to.eq("permit")
   })
 
   test("Should get quote type for onchain quote param", async () => {
@@ -185,9 +181,7 @@ describe("mee.getQuoteType", () => {
       }
     }
 
-    expect(
-      await getQuoteType(meeClient, quoteParam)
-    ).to.eq("onchain")
+    expect(await getQuoteType(meeClient, quoteParam)).to.eq("onchain")
   })
 
   test("Should get quote type for onchain quote payload", async () => {
@@ -214,9 +208,7 @@ describe("mee.getQuoteType", () => {
       }
     })
 
-    expect(await getQuoteType(meeClient, quote)).to.eq(
-      "onchain"
-    )
+    expect(await getQuoteType(meeClient, quote)).to.eq("onchain")
   })
 
   describe("isPermitTokenInfo", () => {
@@ -226,10 +218,7 @@ describe("mee.getQuoteType", () => {
         chainId: chain.id,
         amount: 1n
       }
-      const isPermit = await isPermitTokenInfo(
-        meeClient,
-        trigger,
-      )
+      const isPermit = await isPermitTokenInfo(meeClient, trigger)
       expect(isPermit).to.be.true
     })
 
@@ -239,10 +228,7 @@ describe("mee.getQuoteType", () => {
         chainId: chain.id,
         amount: 1n
       }
-      const isPermit = await isPermitTokenInfo(
-        meeClient,
-        trigger,
-      )
+      const isPermit = await isPermitTokenInfo(meeClient, trigger)
       expect(isPermit).to.be.false
     })
   })

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -1,4 +1,4 @@
-import { http, type Chain, type LocalAccount, createWalletClient } from "viem"
+import { http, type Chain, type LocalAccount, createWalletClient, type WalletClient } from "viem"
 import { beforeAll, describe, expect, test } from "vitest"
 import type { GetFusionQuoteParams, GetQuoteParams } from "."
 import { toNetwork } from "../../../../test/testSetup"
@@ -12,7 +12,7 @@ import { DEFAULT_MEE_VERSION } from "../../../constants"
 import { getMEEVersion } from "../../../modules"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import getPaymentToken, { type GetPaymentTokenPayload } from "./getPaymentToken"
-import { getQuoteType } from "./getQuoteType"
+import { getQuoteType, isPermitTokenInfo } from "./getQuoteType"
 
 describe("mee.getQuoteType", () => {
   let network: NetworkConfig
@@ -20,6 +20,7 @@ describe("mee.getQuoteType", () => {
   let mcNexus: MultichainSmartAccount
   let meeClient: MeeClient
   let chain: Chain
+  let walletClient: WalletClient
 
   beforeAll(async () => {
     network = await toNetwork("TESTNET_FROM_ENV_VARS")
@@ -40,6 +41,12 @@ describe("mee.getQuoteType", () => {
     meeClient = await createMeeClient({
       account: mcNexus,
       apiKey: "mee_3ZhZhHx3hmKrBQxacr283dHt"
+    })
+
+    walletClient = createWalletClient({
+      account: eoaAccount,
+      chain,
+      transport: http(network.rpcUrl)
     })
   })
 
@@ -62,12 +69,6 @@ describe("mee.getQuoteType", () => {
       }
     }
 
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain,
-      transport: http(network.rpcUrl)
-    })
-
     expect(await getQuoteType(walletClient, quoteParam)).to.eq("simple")
   })
 
@@ -88,12 +89,6 @@ describe("mee.getQuoteType", () => {
         chainId: chain.id,
         address: testnetMcTestUSDCP.addressOn(chain.id)
       }
-    })
-
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain,
-      transport: http(network.rpcUrl)
     })
 
     expect(await getQuoteType(walletClient, quote)).to.eq("simple")
@@ -122,12 +117,6 @@ describe("mee.getQuoteType", () => {
         address: testnetMcTestUSDCP.addressOn(chain.id)
       }
     }
-
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain,
-      transport: http(network.rpcUrl)
-    })
 
     let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
 
@@ -165,12 +154,6 @@ describe("mee.getQuoteType", () => {
         chainId: chain.id,
         address: testnetMcTestUSDCP.addressOn(chain.id)
       }
-    })
-
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain,
-      transport: http(network.rpcUrl)
     })
 
     let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
@@ -211,12 +194,6 @@ describe("mee.getQuoteType", () => {
       }
     }
 
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain,
-      transport: http(network.rpcUrl)
-    })
-
     let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
 
     if (quoteParam.trigger.tokenAddress) {
@@ -254,12 +231,6 @@ describe("mee.getQuoteType", () => {
       }
     })
 
-    const walletClient = createWalletClient({
-      account: eoaAccount,
-      chain,
-      transport: http(network.rpcUrl)
-    })
-
     let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
 
     if (quote.trigger.tokenAddress) {
@@ -272,4 +243,33 @@ describe("mee.getQuoteType", () => {
       "onchain"
     )
   })
+
+   // Add the tests for isPermitTokenInfo function => all the logic branches
+  // 1. payment token not specified + arbitrary payment tokens supported
+  // 2. payment token not specified + arbitrary payment tokens not supported
+  // 3. payment token specified + payment token different from the trigger token
+  // 4. payment token specified + payment token same as the trigger token + permit enabled
+  // 5. payment token specified + payment token same as the trigger token + permit not enabled
+  describe("isPermitTokenInfo", () => {
+    test("Payment token not specified + arbitrary payment tokens supported", async () => {
+      const paymentTokenInfo = await getPaymentToken(meeClient, {
+        tokenAddress: "0x00000000000000000000000000000000000a11ce",
+        chainId: chain.id
+      })
+      paymentTokenInfo.isArbitraryPaymentTokensSupported = true
+      expect(paymentTokenInfo.paymentToken).to.be.undefined
+
+      const isPermit = await isPermitTokenInfo(walletClient, paymentTokenInfo, 
+        {
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        chainId: chain.id,
+        amount: 1n
+        } 
+      )
+      // if arbitrary payment tokens supported, 
+      // should return true for the trigger token that supports permit
+      expect(isPermit).to.be.true
+    })
+  })
+
 })

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -5,7 +5,7 @@ import type { GetOnChainQuotePayload } from "./getOnChainQuote"
 import type { GetPaymentTokenPayload } from "./getPaymentToken"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { GetQuoteParams, GetQuotePayload } from "./getQuote"
-import type { Trigger, TokenTrigger } from "./signPermitQuote"
+import type { TokenTrigger, Trigger } from "./signPermitQuote"
 
 export type QuoteType = "simple" | "onchain" | "permit"
 
@@ -20,8 +20,11 @@ export const isPermitTokenInfo = async (
     // if payment token is not specified, it means the trigger token can be used as payment token
     // but only if we support arbitrary payment tokens for this quote
     if (paymentTokenInfo.isArbitraryPaymentTokensSupported) {
-      permitEnabled = await isPermitSupported(walletClient, trigger.tokenAddress)
-    } 
+      permitEnabled = await isPermitSupported(
+        walletClient,
+        trigger.tokenAddress
+      )
+    }
   } else if (paymentTokenInfo.paymentToken.address !== trigger.tokenAddress) {
     // if payment token is defined and different from the trigger token, it means
     // 'to permit' or 'not to permit' is decided by the trigger token, not the payment token
@@ -30,8 +33,8 @@ export const isPermitTokenInfo = async (
     // so only trigger token is transferred via fusion
     permitEnabled = await isPermitSupported(walletClient, trigger.tokenAddress)
   } else {
-  // at this point, payment token is defined and is the same as the trigger token
-    permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false 
+    // at this point, payment token is defined and is the same as the trigger token
+    permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false
   }
   return permitEnabled
 }
@@ -64,9 +67,7 @@ const isPermitQuote = async (
   // For non normal quote, if the payment info is not available ?
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
-    throw new Error(
-      `isPermitQuote: Payment token not specified`
-    )
+    throw new Error(`isPermitQuote: Payment token not specified`)
   }
 
   const permitEnabled = await isPermitTokenInfo(
@@ -98,9 +99,7 @@ const isOnChainQuote = async (
   // For non normal quote, if the payment info is not available ?
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
-    throw new Error(
-      `isOnChainQuote: Payment token not specified`
-    )
+    throw new Error(`isOnChainQuote: Payment token not specified`)
   }
 
   const permitEnabled = await isPermitTokenInfo(

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -2,53 +2,43 @@ import type { WalletClient } from "viem"
 import { type AnyData, isPermitSupported } from "../../../modules"
 import type { GetFusionQuoteParams } from "./getFusionQuote"
 import type { GetOnChainQuotePayload } from "./getOnChainQuote"
-import type { GetPaymentTokenPayload } from "./getPaymentToken"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { GetQuoteParams, GetQuotePayload } from "./getQuote"
 import type { TokenTrigger, Trigger } from "./signPermitQuote"
+import { getPaymentToken } from "./getPaymentToken"
+import type { BaseMeeClient } from "../../createMeeClient"
 
 export type QuoteType = "simple" | "onchain" | "permit"
 
 export const isPermitTokenInfo = async (
-  triggerWalletClient: WalletClient,
-  trigger: TokenTrigger,
-  paymentTokenInfo?: GetPaymentTokenPayload
+  client: BaseMeeClient,
+  trigger: TokenTrigger
 ): Promise<boolean> => {
   let permitEnabled = false
 
-  if (!paymentTokenInfo) {
-    // if payment token is not specified at this point,
-    // it means the trigger token is used to choose b/w:
-    // `to permit` or `not to permit`
-    permitEnabled = await isPermitSupported(
-      triggerWalletClient,
-      trigger.tokenAddress
-    )
-  } else if (!paymentTokenInfo.paymentToken) {
-    // if payment token is not specified, it means the trigger token can be used as payment token
-    // but only if we support arbitrary payment tokens for this quote
-    if (paymentTokenInfo.isArbitraryPaymentTokensSupported) {
-      permitEnabled = await isPermitSupported(
-        triggerWalletClient,
-        trigger.tokenAddress
-      )
-    }
-  } else if (paymentTokenInfo.paymentToken.address !== trigger.tokenAddress) {
-    // if payment token is defined and different from the trigger token, it means
-    // 'to permit' or 'not to permit' is decided by the trigger token, not the payment token
-    // because in this case, fee is paid directly from the orchestrator account,
-    // without transferring the fee token to the orchestrator account via fusion.
-    // So only trigger token is transferred via fusion to the orchestrator account
-    permitEnabled = await isPermitSupported(
-      triggerWalletClient,
-      trigger.tokenAddress
-    )
-  } else {
-    // at this point, payment token is defined and is the same as the trigger token
+  const paymentTokenInfo = await getPaymentToken(client, {
+    tokenAddress: trigger.tokenAddress,
+    chainId: trigger.chainId
+  })
+
+  if (paymentTokenInfo.paymentToken) {
+    // detect w/o extra RPCcall
     permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false
+  } else {
+    const { walletClient } = client.account.deploymentOn(
+      trigger.chainId,
+      true
+    )
+    // detect via RPCcall
+    permitEnabled = await isPermitSupported(
+      walletClient,
+      trigger.tokenAddress
+    )
   }
+
   return permitEnabled
 }
+  
 
 const isNormalQuote = (
   payload: AnyData
@@ -58,90 +48,76 @@ const isNormalQuote = (
 }
 
 const isPermitQuote = async (
-  triggerWalletClient: WalletClient,
-  payload: AnyData,
-  paymentTokenInfo?: GetPaymentTokenPayload
+  client: BaseMeeClient,
+  payload: AnyData
 ): Promise<boolean> => {
   const isTriggerAvailable = "trigger" in payload
 
-  // If trigger is not available ? It is not considered as permit quote
+  // If trigger is not available, it is not considered as permit quote
   if (!isTriggerAvailable) return false
 
   const trigger = payload.trigger as Trigger
 
-  // If trigger call is available ? It is not permit quote
+  // If trigger call is available, it is not permit quote
   if ("call" in trigger) {
     return false
   }
   // after this point, trigger can only be of type TokenTrigger
-
   const permitEnabled = await isPermitTokenInfo(
-    triggerWalletClient,
+    client,
     trigger as TokenTrigger, // trigger can only be of type TokenTrigger at this point
-    paymentTokenInfo
   )
 
-  return !!permitEnabled
+  // If permit is enabled, it is a permit quote
+  return permitEnabled
 }
 
 const isOnChainQuote = async (
-  triggerWalletClient: WalletClient,
+  client: BaseMeeClient,
   payload: AnyData,
-  paymentTokenInfo?: GetPaymentTokenPayload
 ): Promise<boolean> => {
   const isTriggerAvailable = "trigger" in payload
 
-  // If trigger is not available ? It is not considered as on chain quote
+  // If trigger is not available, it is not considered as on chain quote
   if (!isTriggerAvailable) return false
 
   const trigger = payload.trigger as Trigger
 
-  // If triggger has a call ? It is considered as on chain quote
+  // If triggger has a call, it is considered as on chain quote
   if ("call" in trigger) {
     return true
   }
 
   const permitEnabled = await isPermitTokenInfo(
-    triggerWalletClient,
+    client,
     trigger as TokenTrigger, // trigger can only be of type TokenTrigger at this point
-    paymentTokenInfo
   )
 
-  // If permit is enabled ? It is not an on chain quote
+  // If permit is enabled, it is not an on chain quote
   return !permitEnabled
 }
 
 // NOTE: MM DTK is not supported for now - It is experimental and need to support once it is mainstream
 export const getQuoteType = async (
-  triggerWalletClient: WalletClient,
+  client: BaseMeeClient,
   quoteParams:
     | GetQuotePayload
     | GetQuoteParams
     | GetPermitQuotePayload
     | GetOnChainQuotePayload
     | GetFusionQuoteParams,
-  paymentTokenInfo?: GetPaymentTokenPayload
 ): Promise<QuoteType> => {
   // If the quote payload doesn't have trigger ? It is considered as normal quote
   if (isNormalQuote(quoteParams)) {
     return "simple"
   }
-
-  if (!paymentTokenInfo && !("sponsorship" in quoteParams)) {
-    throw new Error(
-      "Detecting quote type: Payment token info not specified in a non-sponsored flow"
-    )
-  }
-
-  if (await isPermitQuote(triggerWalletClient, quoteParams, paymentTokenInfo)) {
+  if (await isPermitQuote(client, quoteParams)) {
     return "permit"
   }
-
   if (
-    await isOnChainQuote(triggerWalletClient, quoteParams, paymentTokenInfo)
+    await isOnChainQuote(client, quoteParams)
   ) {
     return "onchain"
   }
-
   throw new Error("Invalid quote, can't determine signature type")
 }

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -1,12 +1,11 @@
-import type { WalletClient } from "viem"
 import { type AnyData, isPermitSupported } from "../../../modules"
+import type { BaseMeeClient } from "../../createMeeClient"
 import type { GetFusionQuoteParams } from "./getFusionQuote"
 import type { GetOnChainQuotePayload } from "./getOnChainQuote"
+import { getPaymentToken } from "./getPaymentToken"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { GetQuoteParams, GetQuotePayload } from "./getQuote"
 import type { TokenTrigger, Trigger } from "./signPermitQuote"
-import { getPaymentToken } from "./getPaymentToken"
-import type { BaseMeeClient } from "../../createMeeClient"
 
 export type QuoteType = "simple" | "onchain" | "permit"
 
@@ -25,20 +24,13 @@ export const isPermitTokenInfo = async (
     // detect w/o extra RPCcall
     permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false
   } else {
-    const { walletClient } = client.account.deploymentOn(
-      trigger.chainId,
-      true
-    )
+    const { walletClient } = client.account.deploymentOn(trigger.chainId, true)
     // detect via RPCcall
-    permitEnabled = await isPermitSupported(
-      walletClient,
-      trigger.tokenAddress
-    )
+    permitEnabled = await isPermitSupported(walletClient, trigger.tokenAddress)
   }
 
   return permitEnabled
 }
-  
 
 const isNormalQuote = (
   payload: AnyData
@@ -65,7 +57,7 @@ const isPermitQuote = async (
   // after this point, trigger can only be of type TokenTrigger
   const permitEnabled = await isPermitTokenInfo(
     client,
-    trigger as TokenTrigger, // trigger can only be of type TokenTrigger at this point
+    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
   )
 
   // If permit is enabled, it is a permit quote
@@ -74,7 +66,7 @@ const isPermitQuote = async (
 
 const isOnChainQuote = async (
   client: BaseMeeClient,
-  payload: AnyData,
+  payload: AnyData
 ): Promise<boolean> => {
   const isTriggerAvailable = "trigger" in payload
 
@@ -90,7 +82,7 @@ const isOnChainQuote = async (
 
   const permitEnabled = await isPermitTokenInfo(
     client,
-    trigger as TokenTrigger, // trigger can only be of type TokenTrigger at this point
+    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
   )
 
   // If permit is enabled, it is not an on chain quote
@@ -105,7 +97,7 @@ export const getQuoteType = async (
     | GetQuoteParams
     | GetPermitQuotePayload
     | GetOnChainQuotePayload
-    | GetFusionQuoteParams,
+    | GetFusionQuoteParams
 ): Promise<QuoteType> => {
   // If the quote payload doesn't have trigger ? It is considered as normal quote
   if (isNormalQuote(quoteParams)) {
@@ -114,9 +106,7 @@ export const getQuoteType = async (
   if (await isPermitQuote(client, quoteParams)) {
     return "permit"
   }
-  if (
-    await isOnChainQuote(client, quoteParams)
-  ) {
+  if (await isOnChainQuote(client, quoteParams)) {
     return "onchain"
   }
   throw new Error("Invalid quote, can't determine signature type")

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -23,7 +23,7 @@ export const isPermitTokenInfo = async (
     permitEnabled = await isPermitSupported(walletClient, tokenAddress)
   } else {
     throw new Error(
-      `Payment token (${tokenAddress}) not supported for chain ${chainId}`
+      `(${tokenAddress}) not supported for chain ${chainId} as a payment token for permit mode`
     )
   }
 
@@ -58,7 +58,7 @@ const isPermitQuote = async (
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
     throw new Error(
-      `Payment token (${trigger.tokenAddress}) not supported for chain ${trigger.chainId}`
+      `isPermitQuote: Payment token not specified, or trigger token (${trigger.tokenAddress}) not supported for chain ${trigger.chainId} as a payment token`
     )
   }
 
@@ -93,7 +93,7 @@ const isOnChainQuote = async (
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
     throw new Error(
-      `Payment token (${trigger.tokenAddress}) not supported for chain ${trigger.chainId}`
+      `isOnChainQuote: Payment token not specified, or trigger token (${trigger.tokenAddress}) not supported for chain ${trigger.chainId} as a payment token`
     )
   }
 

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -2,9 +2,9 @@ import { type AnyData, isPermitSupported } from "../../../modules"
 import type { BaseMeeClient } from "../../createMeeClient"
 import type { GetFusionQuoteParams } from "./getFusionQuote"
 import type { GetOnChainQuotePayload } from "./getOnChainQuote"
-import { getPaymentToken } from "./getPaymentToken"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { GetQuoteParams, GetQuotePayload } from "./getQuote"
+import { getSupportedFeeToken } from "./getSupportedFeeToken"
 import type { TokenTrigger, Trigger } from "./signPermitQuote"
 
 export type QuoteType = "simple" | "onchain" | "permit"
@@ -15,14 +15,15 @@ export const isPermitTokenInfo = async (
 ): Promise<boolean> => {
   let permitEnabled = false
 
-  const paymentTokenInfo = await getPaymentToken(client, {
+  const supportedFeeTokenInfo = await getSupportedFeeToken(client, {
     tokenAddress: trigger.tokenAddress,
     chainId: trigger.chainId
   })
 
-  if (paymentTokenInfo.paymentToken) {
+  if (supportedFeeTokenInfo.supportedFeeToken) {
     // detect w/o extra RPCcall
-    permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false
+    permitEnabled =
+      supportedFeeTokenInfo.supportedFeeToken.permitEnabled || false
   } else {
     const { walletClient } = client.account.deploymentOn(trigger.chainId, true)
     // detect via RPCcall

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -5,28 +5,34 @@ import type { GetOnChainQuotePayload } from "./getOnChainQuote"
 import type { GetPaymentTokenPayload } from "./getPaymentToken"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { GetQuoteParams, GetQuotePayload } from "./getQuote"
-import type { Trigger } from "./signPermitQuote"
+import type { Trigger, TokenTrigger } from "./signPermitQuote"
 
 export type QuoteType = "simple" | "onchain" | "permit"
 
 export const isPermitTokenInfo = async (
   walletClient: WalletClient,
   paymentTokenInfo: GetPaymentTokenPayload,
-  tokenAddress: Address,
-  chainId: number
+  trigger: TokenTrigger
 ): Promise<boolean> => {
   let permitEnabled = false
 
-  if (paymentTokenInfo.paymentToken) {
-    permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false
-  } else if (paymentTokenInfo.isArbitraryPaymentTokensSupported) {
-    permitEnabled = await isPermitSupported(walletClient, tokenAddress)
+  if (!paymentTokenInfo.paymentToken) {
+    // if payment token is not specified, it means the trigger token can be used as payment token
+    // but only if we support arbitrary payment tokens for this quote
+    if (paymentTokenInfo.isArbitraryPaymentTokensSupported) {
+      permitEnabled = await isPermitSupported(walletClient, trigger.tokenAddress)
+    } 
+  } else if (paymentTokenInfo.paymentToken.address !== trigger.tokenAddress) {
+    // if payment token is defined and different from the trigger token, it means
+    // 'to permit' or 'not to permit' is decided by the trigger token, not the payment token
+    // coz in this case, fee is paid directly from the orchestrator account, w/o
+    // transferring the fee token to the orchestrator account via fusion
+    // so only trigger token is transferred via fusion
+    permitEnabled = await isPermitSupported(walletClient, trigger.tokenAddress)
   } else {
-    throw new Error(
-      `(${tokenAddress}) not supported for chain ${chainId} as a payment token for permit mode`
-    )
+  // at this point, payment token is defined and is the same as the trigger token
+    permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false 
   }
-
   return permitEnabled
 }
 
@@ -53,20 +59,20 @@ const isPermitQuote = async (
   if ("call" in trigger) {
     return false
   }
+  // after this point, trigger can only be of type TokenTrigger
 
   // For non normal quote, if the payment info is not available ?
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
     throw new Error(
-      `isPermitQuote: Payment token not specified, or trigger token (${trigger.tokenAddress}) not supported for chain ${trigger.chainId} as a payment token`
+      `isPermitQuote: Payment token not specified`
     )
   }
 
   const permitEnabled = await isPermitTokenInfo(
     walletClient,
     paymentTokenInfo,
-    trigger.tokenAddress,
-    trigger.chainId
+    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
   )
 
   return !!permitEnabled
@@ -93,15 +99,14 @@ const isOnChainQuote = async (
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
     throw new Error(
-      `isOnChainQuote: Payment token not specified, or trigger token (${trigger.tokenAddress}) not supported for chain ${trigger.chainId} as a payment token`
+      `isOnChainQuote: Payment token not specified`
     )
   }
 
   const permitEnabled = await isPermitTokenInfo(
     walletClient,
     paymentTokenInfo,
-    trigger.tokenAddress,
-    trigger.chainId
+    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
   )
 
   // If permit is enabled ? It is not an on chain quote

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -67,7 +67,7 @@ const isPermitQuote = async (
   // For non normal quote, if the payment info is not available ?
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
-    throw new Error(`isPermitQuote: Payment token not specified`)
+    throw new Error("isPermitQuote: Payment token not specified")
   }
 
   const permitEnabled = await isPermitTokenInfo(
@@ -99,7 +99,7 @@ const isOnChainQuote = async (
   // For non normal quote, if the payment info is not available ?
   // It means the token is not supported by the network and also swap routers
   if (!paymentTokenInfo) {
-    throw new Error(`isOnChainQuote: Payment token not specified`)
+    throw new Error("isOnChainQuote: Payment token not specified")
   }
 
   const permitEnabled = await isPermitTokenInfo(

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -10,18 +10,26 @@ import type { TokenTrigger, Trigger } from "./signPermitQuote"
 export type QuoteType = "simple" | "onchain" | "permit"
 
 export const isPermitTokenInfo = async (
-  walletClient: WalletClient,
-  paymentTokenInfo: GetPaymentTokenPayload,
-  trigger: TokenTrigger
+  triggerWalletClient: WalletClient,
+  trigger: TokenTrigger,
+  paymentTokenInfo?: GetPaymentTokenPayload
 ): Promise<boolean> => {
   let permitEnabled = false
 
-  if (!paymentTokenInfo.paymentToken) {
+  if (!paymentTokenInfo) {
+    // if payment token is not specified at this point,
+    // it means the trigger token is used to choose b/w:
+    // `to permit` or `not to permit`
+    permitEnabled = await isPermitSupported(
+      triggerWalletClient,
+      trigger.tokenAddress
+    )
+  } else if (!paymentTokenInfo.paymentToken) {
     // if payment token is not specified, it means the trigger token can be used as payment token
     // but only if we support arbitrary payment tokens for this quote
     if (paymentTokenInfo.isArbitraryPaymentTokensSupported) {
       permitEnabled = await isPermitSupported(
-        walletClient,
+        triggerWalletClient,
         trigger.tokenAddress
       )
     }
@@ -31,7 +39,10 @@ export const isPermitTokenInfo = async (
     // coz in this case, fee is paid directly from the orchestrator account, w/o
     // transferring the fee token to the orchestrator account via fusion
     // so only trigger token is transferred via fusion
-    permitEnabled = await isPermitSupported(walletClient, trigger.tokenAddress)
+    permitEnabled = await isPermitSupported(
+      triggerWalletClient,
+      trigger.tokenAddress
+    )
   } else {
     // at this point, payment token is defined and is the same as the trigger token
     permitEnabled = paymentTokenInfo.paymentToken.permitEnabled || false
@@ -47,7 +58,7 @@ const isNormalQuote = (
 }
 
 const isPermitQuote = async (
-  walletClient: WalletClient,
+  triggerWalletClient: WalletClient,
   payload: AnyData,
   paymentTokenInfo?: GetPaymentTokenPayload
 ): Promise<boolean> => {
@@ -64,23 +75,17 @@ const isPermitQuote = async (
   }
   // after this point, trigger can only be of type TokenTrigger
 
-  // For non normal quote, if the payment info is not available ?
-  // It means the token is not supported by the network and also swap routers
-  if (!paymentTokenInfo) {
-    throw new Error("isPermitQuote: Payment token not specified")
-  }
-
   const permitEnabled = await isPermitTokenInfo(
-    walletClient,
-    paymentTokenInfo,
-    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
+    triggerWalletClient,
+    trigger as TokenTrigger, // trigger can only be of type TokenTrigger at this point
+    paymentTokenInfo
   )
 
   return !!permitEnabled
 }
 
 const isOnChainQuote = async (
-  walletClient: WalletClient,
+  triggerWalletClient: WalletClient,
   payload: AnyData,
   paymentTokenInfo?: GetPaymentTokenPayload
 ): Promise<boolean> => {
@@ -96,16 +101,10 @@ const isOnChainQuote = async (
     return true
   }
 
-  // For non normal quote, if the payment info is not available ?
-  // It means the token is not supported by the network and also swap routers
-  if (!paymentTokenInfo) {
-    throw new Error("isOnChainQuote: Payment token not specified")
-  }
-
   const permitEnabled = await isPermitTokenInfo(
-    walletClient,
-    paymentTokenInfo,
-    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
+    triggerWalletClient,
+    trigger as TokenTrigger, // trigger can only be of type TokenTrigger at this point
+    paymentTokenInfo
   )
 
   // If permit is enabled ? It is not an on chain quote
@@ -114,7 +113,7 @@ const isOnChainQuote = async (
 
 // NOTE: MM DTK is not supported for now - It is experimental and need to support once it is mainstream
 export const getQuoteType = async (
-  walletClient: WalletClient,
+  triggerWalletClient: WalletClient,
   quoteParams:
     | GetQuotePayload
     | GetQuoteParams
@@ -128,11 +127,19 @@ export const getQuoteType = async (
     return "simple"
   }
 
-  if (await isPermitQuote(walletClient, quoteParams, paymentTokenInfo)) {
+  if (!paymentTokenInfo && !("sponsorship" in quoteParams)) {
+    throw new Error(
+      "Detecting quote type: Payment token info not specified in a non-sponsored flow"
+    )
+  }
+
+  if (await isPermitQuote(triggerWalletClient, quoteParams, paymentTokenInfo)) {
     return "permit"
   }
 
-  if (await isOnChainQuote(walletClient, quoteParams, paymentTokenInfo)) {
+  if (
+    await isOnChainQuote(triggerWalletClient, quoteParams, paymentTokenInfo)
+  ) {
     return "onchain"
   }
 

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -36,9 +36,9 @@ export const isPermitTokenInfo = async (
   } else if (paymentTokenInfo.paymentToken.address !== trigger.tokenAddress) {
     // if payment token is defined and different from the trigger token, it means
     // 'to permit' or 'not to permit' is decided by the trigger token, not the payment token
-    // coz in this case, fee is paid directly from the orchestrator account, w/o
-    // transferring the fee token to the orchestrator account via fusion
-    // so only trigger token is transferred via fusion
+    // because in this case, fee is paid directly from the orchestrator account,
+    // without transferring the fee token to the orchestrator account via fusion.
+    // So only trigger token is transferred via fusion to the orchestrator account
     permitEnabled = await isPermitSupported(
       triggerWalletClient,
       trigger.tokenAddress

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -1,4 +1,4 @@
-import type { Address, WalletClient } from "viem"
+import type { WalletClient } from "viem"
 import { type AnyData, isPermitSupported } from "../../../modules"
 import type { GetFusionQuoteParams } from "./getFusionQuote"
 import type { GetOnChainQuotePayload } from "./getOnChainQuote"

--- a/src/sdk/clients/decorators/mee/getSupportedFeeToken.test.ts
+++ b/src/sdk/clients/decorators/mee/getSupportedFeeToken.test.ts
@@ -65,7 +65,8 @@ describe("mee.getSupportedFeeToken", () => {
     )
 
     const tokenSymbols = info.supportedGasTokens.flatMap(
-      ({ supportedFeeTokens }) => supportedFeeTokens.map(({ symbol }) => symbol)
+      ({ paymentTokens: supportedFeeTokens }) =>
+        supportedFeeTokens.map(({ symbol }) => symbol)
     )
 
     expect(supportedChains.length).toBeGreaterThan(0)

--- a/src/sdk/clients/decorators/mee/getSupportedFeeToken.test.ts
+++ b/src/sdk/clients/decorators/mee/getSupportedFeeToken.test.ts
@@ -12,7 +12,7 @@ import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import { getInfo } from "./getInfo"
 import type { FeeTokenInfo } from "./getQuote"
 
-describe("mee.getPaymentToken", () => {
+describe("mee.getSupportedFeeToken", () => {
   let network: NetworkConfig
   let eoaAccount: LocalAccount
 
@@ -64,8 +64,8 @@ describe("mee.getPaymentToken", () => {
       Number(chainId)
     )
 
-    const tokenSymbols = info.supportedGasTokens.flatMap(({ paymentTokens }) =>
-      paymentTokens.map(({ symbol }) => symbol)
+    const tokenSymbols = info.supportedGasTokens.flatMap(
+      ({ supportedFeeTokens }) => supportedFeeTokens.map(({ symbol }) => symbol)
     )
 
     expect(supportedChains.length).toBeGreaterThan(0)
@@ -78,25 +78,28 @@ describe("mee.getPaymentToken", () => {
   })
 
   test("should return payment token and arbitrary token payment info for valid chain id and address", async () => {
-    const paymentTokenInfo = await meeClient.getPaymentToken({
+    const supportedFeeTokenInfo = await meeClient.getSupportedFeeToken({
       chainId: 1,
       tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
     })
 
-    expect(paymentTokenInfo.isArbitraryPaymentTokensSupported).to.be.oneOf([
+    expect(supportedFeeTokenInfo.isArbitraryFeeTokensSupported).to.be.oneOf([
       true,
       false,
       null,
       undefined
     ])
 
-    expect(paymentTokenInfo.paymentToken).not.to.be.oneOf([undefined, null])
+    expect(supportedFeeTokenInfo.supportedFeeToken).not.to.be.oneOf([
+      undefined,
+      null
+    ])
 
-    if (paymentTokenInfo.paymentToken) {
-      expect(paymentTokenInfo.paymentToken.symbol).toBe("USDC")
+    if (supportedFeeTokenInfo.supportedFeeToken) {
+      expect(supportedFeeTokenInfo.supportedFeeToken.symbol).toBe("USDC")
       expect(
         addressEquals(
-          paymentTokenInfo.paymentToken.address,
+          supportedFeeTokenInfo.supportedFeeToken.address,
           "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
         )
       ).toBe(true)

--- a/src/sdk/clients/decorators/mee/getSupportedFeeToken.ts
+++ b/src/sdk/clients/decorators/mee/getSupportedFeeToken.ts
@@ -7,7 +7,7 @@ import { getGasToken } from "./getGasToken"
  * Represents a payment token configuration with its properties and capabilities.
  * This interface defines the structure of tokens that can be used for gas payments.
  */
-export interface PaymentToken {
+export interface SupportedFeeToken {
   /**
    * Human-readable name of the token
    * @example "USD Coin"
@@ -39,7 +39,7 @@ export interface PaymentToken {
 /**
  * Parameters for retrieving payment token information
  */
-export type GetPaymentTokenParams = {
+export type GetSupportedFeeTokenParams = {
   /**
    * The blockchain chain ID to query
    * @example 1 // Ethereum Mainnet
@@ -56,9 +56,9 @@ export type GetPaymentTokenParams = {
 /**
  * Response payload containing payment token information and arbitrary token support info
  */
-export type GetPaymentTokenPayload = {
-  isArbitraryPaymentTokensSupported: boolean
-  paymentToken?: PaymentToken
+export type GetSupportedFeeTokenPayload = {
+  isArbitraryFeeTokensSupported: boolean
+  supportedFeeToken?: SupportedFeeToken
 }
 
 /**
@@ -74,14 +74,14 @@ export type GetPaymentTokenPayload = {
  *
  * @example
  * ```typescript
- * const tokenInfo = await getPaymentToken(client, {
+ * const tokenInfo = await getSupportedFeeToken(client, {
  *   chainId: 1,
  *   tokenAddress: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48" // USDC
  * });
  * // Returns:
  * // {
- * //   isArbitraryPaymentTokensSupported: true,
- * //   paymentToken: {
+ * //   isArbitraryFeeTokensSupported: true,
+ * //   supportedFeeToken: {
  * //     name: "USD Coin",
  * //     address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
  * //     symbol: "USDC",
@@ -95,22 +95,22 @@ export type GetPaymentTokenPayload = {
  * - The token is not supported on the specified chain
  * - The chain ID is not supported
  */
-export const getPaymentToken = async (
+export const getSupportedFeeToken = async (
   client: BaseMeeClient,
-  parameters: GetPaymentTokenParams
-): Promise<GetPaymentTokenPayload> => {
+  parameters: GetSupportedFeeTokenParams
+): Promise<GetSupportedFeeTokenPayload> => {
   const gasToken = await getGasToken(client, {
     chainId: parameters.chainId,
     address: parameters.tokenAddress
   })
-  const paymentToken = gasToken.paymentTokens.find((paymentToken) =>
-    addressEquals(paymentToken.address, parameters.tokenAddress)
+  const supportedFeeToken = gasToken.supportedFeeTokens.find(
+    (supportedFeeToken) =>
+      addressEquals(supportedFeeToken.address, parameters.tokenAddress)
   )
   return {
-    isArbitraryPaymentTokensSupported:
-      gasToken.isArbitraryPaymentTokensSupported,
-    paymentToken
+    isArbitraryFeeTokensSupported: gasToken.isArbitraryFeeTokensSupported,
+    supportedFeeToken
   }
 }
 
-export default getPaymentToken
+export default getSupportedFeeToken

--- a/src/sdk/clients/decorators/mee/getSupportedFeeToken.ts
+++ b/src/sdk/clients/decorators/mee/getSupportedFeeToken.ts
@@ -103,9 +103,8 @@ export const getSupportedFeeToken = async (
     chainId: parameters.chainId,
     address: parameters.tokenAddress
   })
-  const supportedFeeToken = gasToken.supportedFeeTokens.find(
-    (supportedFeeToken) =>
-      addressEquals(supportedFeeToken.address, parameters.tokenAddress)
+  const supportedFeeToken = gasToken.paymentTokens.find((supportedFeeToken) =>
+    addressEquals(supportedFeeToken.address, parameters.tokenAddress)
   )
   return {
     isArbitraryFeeTokensSupported: gasToken.isArbitraryFeeTokensSupported,

--- a/src/sdk/clients/decorators/mee/index.ts
+++ b/src/sdk/clients/decorators/mee/index.ts
@@ -23,11 +23,6 @@ import getOnChainQuote, {
   type GetOnChainQuoteParams,
   type GetOnChainQuotePayload
 } from "./getOnChainQuote.js"
-import {
-  type GetPaymentTokenParams,
-  type GetPaymentTokenPayload,
-  getPaymentToken
-} from "./getPaymentToken"
 import getPermitQuote, {
   type GetPermitQuoteParams,
   type GetPermitQuotePayload
@@ -37,6 +32,11 @@ import getSupertransactionReceipt, {
   type GetSupertransactionReceiptParams,
   type GetSupertransactionReceiptPayload
 } from "./getSupertransactionReceipt"
+import {
+  type GetSupportedFeeTokenParams,
+  type GetSupportedFeeTokenPayload,
+  getSupportedFeeToken
+} from "./getSupportedFeeToken"
 import signFusionQuote, {
   type SignFusionQuotePayload,
   type SignFusionQuoteParameters
@@ -211,9 +211,9 @@ export type MeeActions = {
    * @param params - Parameters for retrieving payment token info
    * @returns Promise resolving to payment token data
    */
-  getPaymentToken: <EParams extends GetPaymentTokenParams>(
+  getSupportedFeeToken: <EParams extends GetSupportedFeeTokenParams>(
     params: EParams
-  ) => Promise<GetPaymentTokenPayload>
+  ) => Promise<GetSupportedFeeTokenPayload>
 
   /**
    * Get an on-chain quote for standard transactions
@@ -269,8 +269,8 @@ export type MeeActions = {
 export const meeActions = (meeClient: BaseMeeClient): MeeActions => {
   return {
     getGasToken: (params: GetGasTokenParams) => getGasToken(meeClient, params),
-    getPaymentToken: (params: GetPaymentTokenParams) =>
-      getPaymentToken(meeClient, params),
+    getSupportedFeeToken: (params: GetSupportedFeeTokenParams) =>
+      getSupportedFeeToken(meeClient, params),
     getOnChainQuote: (params: GetOnChainQuoteParams) =>
       getOnChainQuote(meeClient, params),
     getQuote: (params: GetQuoteParams) => getQuote(meeClient, params),
@@ -316,4 +316,4 @@ export * from "./getPermitQuote"
 export * from "./executeFusionQuote"
 export * from "./getSupertransactionReceipt"
 export * from "./getQuoteType"
-export * from "./getPaymentToken"
+export * from "./getSupportedFeeToken"

--- a/src/sdk/clients/decorators/mee/signFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.ts
@@ -68,21 +68,22 @@ export const signFusionQuote = async (
   }
   // if it is not mm-dtk, then it is permit or on-chain
 
-  const trigger = parameters.fusionQuote.trigger
+  const paymentInfo = parameters.fusionQuote.quote.paymentInfo
 
   let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
+  paymentTokenInfo = await getPaymentToken(client, {
+    tokenAddress: paymentInfo.token,
+    chainId: Number(paymentInfo.chainId)
+  })
 
-  if (trigger.tokenAddress) {
-    paymentTokenInfo = await getPaymentToken(client, {
-      tokenAddress: trigger.tokenAddress,
-      chainId: trigger.chainId
-    })
-  }
-
-  const { walletClient } = client.account.deploymentOn(trigger.chainId, true)
+  const trigger = parameters.fusionQuote.trigger
+  const { walletClient: triggerWalletClient } = client.account.deploymentOn(
+    trigger.chainId,
+    true
+  )
 
   const signatureType = await getQuoteType(
-    walletClient,
+    triggerWalletClient,
     parameters.fusionQuote,
     paymentTokenInfo
   )

--- a/src/sdk/clients/decorators/mee/signFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.ts
@@ -67,10 +67,7 @@ export const signFusionQuote = async (
   }
   // if it is not mm-dtk, then it is permit or on-chain
 
-  const signatureType = await getQuoteType(
-    client,
-    parameters.fusionQuote,
-  )
+  const signatureType = await getQuoteType(client, parameters.fusionQuote)
 
   switch (signatureType) {
     case "permit":

--- a/src/sdk/clients/decorators/mee/signFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.ts
@@ -1,5 +1,4 @@
 import type { BaseMeeClient } from "../../createMeeClient"
-import { type GetPaymentTokenPayload, getPaymentToken } from "./getPaymentToken"
 import { getQuoteType } from "./getQuoteType"
 import { type SignMmDtkQuoteParams, signMMDtkQuote } from "./signMmDtkQuote"
 import signOnChainQuote, {
@@ -68,24 +67,9 @@ export const signFusionQuote = async (
   }
   // if it is not mm-dtk, then it is permit or on-chain
 
-  const paymentInfo = parameters.fusionQuote.quote.paymentInfo
-
-  let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
-  paymentTokenInfo = await getPaymentToken(client, {
-    tokenAddress: paymentInfo.token,
-    chainId: Number(paymentInfo.chainId)
-  })
-
-  const trigger = parameters.fusionQuote.trigger
-  const { walletClient: triggerWalletClient } = client.account.deploymentOn(
-    trigger.chainId,
-    true
-  )
-
   const signatureType = await getQuoteType(
-    triggerWalletClient,
+    client,
     parameters.fusionQuote,
-    paymentTokenInfo
   )
 
   switch (signatureType) {

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -724,9 +724,6 @@ describe.runIf(runLifecycleTests)("mee.signOnChainQuote - testnet", () => {
     expect(signedOnChainQuote.signature).toBeDefined()
     expect(isHex(signedOnChainQuote.signature)).toEqual(true)
 
-    const supportedFeeTokenInfo: GetSupportedFeeTokenPayload | undefined =
-      undefined
-
     const quoteType = await getQuoteType(meeClient, fusionQuote)
 
     expect(quoteType).toEqual("onchain")

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -44,9 +44,11 @@ import {
 import executeSignedQuote from "./executeSignedQuote"
 import getFusionQuote from "./getFusionQuote"
 import getOnChainQuote from "./getOnChainQuote"
-import getPaymentToken, { type GetPaymentTokenPayload } from "./getPaymentToken"
 import { type FeeTokenInfo, getQuote } from "./getQuote"
 import { getQuoteType } from "./getQuoteType"
+import getSupportedFeeToken, {
+  type GetSupportedFeeTokenPayload
+} from "./getSupportedFeeToken"
 import {
   ON_CHAIN_PREFIX,
   formatSignedOnChainQuotePayload,
@@ -722,20 +724,10 @@ describe.runIf(runLifecycleTests)("mee.signOnChainQuote - testnet", () => {
     expect(signedOnChainQuote.signature).toBeDefined()
     expect(isHex(signedOnChainQuote.signature)).toEqual(true)
 
-    let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
+    const supportedFeeTokenInfo: GetSupportedFeeTokenPayload | undefined =
+      undefined
 
-    if (fusionQuote.trigger.tokenAddress) {
-      paymentTokenInfo = await getPaymentToken(meeClient, {
-        tokenAddress: fusionQuote.trigger.tokenAddress,
-        chainId: fusionQuote.trigger.chainId
-      })
-    }
-
-    const quoteType = await getQuoteType(
-      walletClient,
-      fusionQuote,
-      paymentTokenInfo
-    )
+    const quoteType = await getQuoteType(meeClient, fusionQuote)
 
     expect(quoteType).toEqual("onchain")
 

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -42,9 +42,11 @@ import { getMEEVersion } from "../../../modules"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import { executeSignedQuote } from "./executeSignedQuote"
 import getFusionQuote from "./getFusionQuote"
-import getPaymentToken, { type GetPaymentTokenPayload } from "./getPaymentToken"
 import { type FeeTokenInfo, getQuote } from "./getQuote"
 import { getQuoteType } from "./getQuoteType"
+import getSupportedFeeToken, {
+  type GetSupportedFeeTokenPayload
+} from "./getSupportedFeeToken"
 import {
   type Trigger,
   formatSignedPermitQuotePayload,
@@ -418,10 +420,11 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     expect(signedPermitQuote.signature).toBeDefined()
     expect(isHex(signedPermitQuote.signature)).toEqual(true)
 
-    let paymentTokenInfo: GetPaymentTokenPayload | undefined = undefined
+    let supportedFeeTokenInfo: GetSupportedFeeTokenPayload | undefined =
+      undefined
 
     if (fusionQuote.trigger.tokenAddress) {
-      paymentTokenInfo = await getPaymentToken(meeClient, {
+      supportedFeeTokenInfo = await getSupportedFeeToken(meeClient, {
         tokenAddress: fusionQuote.trigger.tokenAddress,
         chainId: fusionQuote.trigger.chainId
       })
@@ -430,7 +433,7 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     const quoteType = await getQuoteType(
       walletClient,
       fusionQuote,
-      paymentTokenInfo
+      supportedFeeTokenInfo
     )
 
     expect(quoteType).toEqual("permit")

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -430,11 +430,7 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
       })
     }
 
-    const quoteType = await getQuoteType(
-      walletClient,
-      fusionQuote,
-      supportedFeeTokenInfo
-    )
+    const quoteType = await getQuoteType(meeClient, fusionQuote)
 
     expect(quoteType).toEqual("permit")
 

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -423,13 +423,6 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     let supportedFeeTokenInfo: GetSupportedFeeTokenPayload | undefined =
       undefined
 
-    if (fusionQuote.trigger.tokenAddress) {
-      supportedFeeTokenInfo = await getSupportedFeeToken(meeClient, {
-        tokenAddress: fusionQuote.trigger.tokenAddress,
-        chainId: fusionQuote.trigger.chainId
-      })
-    }
-
     const quoteType = await getQuoteType(meeClient, fusionQuote)
 
     expect(quoteType).toEqual("permit")


### PR DESCRIPTION
- Refactor `isPaymentToken` info for better support of the case when feeToken (payment token) and trigger token (fundingTokens[0]) are different
- More congruent error messages

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on renaming and refactoring the handling of payment tokens to support a new structure for fee tokens in the codebase. It updates variable names, types, and function signatures to reflect these changes, improving clarity and consistency.

### Detailed summary
- Renamed `paymentToken` to `tokenAddress` in `getOnChainQuote.ts` and `getPermitQuote.ts`.
- Introduced `SupportedFeeToken` type and related functions in `getSupportedFeeToken.ts`.
- Updated `GetPaymentTokenPayload` to `GetSupportedFeeTokenPayload`.
- Refactored functions to use the new `getSupportedFeeToken` instead of `getPaymentToken`.
- Adjusted tests to reflect changes in naming and functionality.
- Modified `getQuoteType` to work with new fee token structures.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->