### PR TITLE
chore: custom verification gas limit for Smart Sessions

### DIFF
--- a/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
+++ b/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
@@ -67,7 +67,7 @@ export const getMmDtkQuote = async (
     cleanUps,
     instructions,
     gasLimit,
-    verificationGasLimit,
+    customVerificationGasLimit,
     delegatorSmartAccount,
     ...rest
   } = parameters
@@ -99,8 +99,8 @@ export const getMmDtkQuote = async (
     eoa: sender, // it is not an EOA, but a smart account in this case, however param is named `eoa` for backward compatibility, see `GetQuoteParams` type for more details
     instructions: batchedInstructions,
     gasLimit: gasLimit || triggerGasLimit,
-    verificationGasLimit:
-      verificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT_FOR_MM_DTK,
+    customVerificationGasLimit:
+      customVerificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT_FOR_MM_DTK,
     ...(cleanUps ? { cleanUps } : {}),
     ...rest
   })

--- a/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
+++ b/src/sdk/clients/decorators/mee/getMmDtkQuote.ts
@@ -67,7 +67,7 @@ export const getMmDtkQuote = async (
     cleanUps,
     instructions,
     gasLimit,
-    customVerificationGasLimit,
+    verificationGasLimit,
     delegatorSmartAccount,
     ...rest
   } = parameters
@@ -99,8 +99,8 @@ export const getMmDtkQuote = async (
     eoa: sender, // it is not an EOA, but a smart account in this case, however param is named `eoa` for backward compatibility, see `GetQuoteParams` type for more details
     instructions: batchedInstructions,
     gasLimit: gasLimit || triggerGasLimit,
-    customVerificationGasLimit:
-      customVerificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT_FOR_MM_DTK,
+    verificationGasLimit:
+      verificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT_FOR_MM_DTK,
     ...(cleanUps ? { cleanUps } : {}),
     ...rest
   })

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -977,8 +977,7 @@ const preparePaymentInfo = async (
       token,
       nonce,
       callGasLimit: gasLimit || DEFAULT_GAS_LIMIT,
-      verificationGasLimit:
-        customVerificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT, // when sponsored, it is whether the custom one or the default one
+      verificationGasLimit: DEFAULT_VERIFICATION_GAS_LIMIT, // when sponsored, this will be set by the node
       chainId: chainId.toString(),
       sponsorshipUrl,
       ...(eoaOrFeePayer ? { eoa: eoaOrFeePayer } : {}),

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -261,7 +261,7 @@ export type GetQuoteParams = SupertransactionLike & {
    * The verification gas limit for the active module
    * @example 150000n
    */
-  customVerificationGasLimit?: bigint
+  verificationGasLimit?: bigint
   /**
    * Short encoding flag for fusion isValidsignatureWithSender/validateSignatureWithData functions
    * This flag is set true when the whole superTxn with all entries require short encoding
@@ -554,7 +554,7 @@ export const getQuote = async (
     authorizations = [],
     multichain7702Auth = false,
     moduleAddress,
-    customVerificationGasLimit,
+    verificationGasLimit,
     shortEncodingSuperTxn = false,
     sponsorship = false,
     sponsorshipOptions,
@@ -858,9 +858,9 @@ export const getQuote = async (
           }
         }
 
-        const verificationGasLimit = resolveVerificationGasLimit({
+        const resolvedVerificationGasLimit = resolveVerificationGasLimit({
           moduleAddress,
-          customVerificationGasLimit,
+          verificationGasLimit,
           sponsorship,
           index: indexPerChainId.get(chainId)!,
           paymentChainId: paymentInfo.chainId,
@@ -882,7 +882,7 @@ export const getQuote = async (
           chainId,
           isCleanUpUserOp,
           ...initDataOrUndefined,
-          ...verificationGasLimit,
+          ...resolvedVerificationGasLimit,
           shortEncoding: shortEncodingSuperTxn || shortEncoding
         }
       }
@@ -936,7 +936,7 @@ const preparePaymentInfo = async (
     sponsorshipOptions,
     shortEncodingSuperTxn,
     moduleAddress,
-    customVerificationGasLimit
+    verificationGasLimit
   } = parameters
 
   let paymentInfo: PaymentInfo | undefined = undefined
@@ -1049,7 +1049,7 @@ const preparePaymentInfo = async (
     const paymentVerificationGasLimit =
       resolvePaymentUserOpVerificationGasLimitNonSponsored(
         moduleAddress,
-        customVerificationGasLimit
+        verificationGasLimit
       )
 
     paymentInfo = {
@@ -1325,13 +1325,13 @@ const prepareCleanUpUserOps = async (
 /**
  * Parameters for the resolveVerificationGasLimit function
  * @param moduleAddress - The active module address
- * @param customVerificationGasLimit - The custom verification gas limit
+ * @param verificationGasLimit - The custom verification gas limit
  * @param index - The index of the userOp during the userOps completion process
  * @param sponsorship - Whether the superTxn is sponsored
  */
 export type resolveVerificationGasLimitParams = {
   moduleAddress?: Address
-  customVerificationGasLimit?: bigint
+  verificationGasLimit?: bigint
   sponsorship: boolean
   index: number
 }
@@ -1358,7 +1358,7 @@ const resolveVerificationGasLimit = (
 ): verificationGasLimitPayload | undefined => {
   const {
     moduleAddress,
-    customVerificationGasLimit,
+    verificationGasLimit,
     sponsorship,
     index,
     paymentChainId,
@@ -1367,14 +1367,14 @@ const resolveVerificationGasLimit = (
   if (currentChainId === paymentChainId) {
     return resolveVerificationGasLimitForPaymentChain({
       moduleAddress,
-      customVerificationGasLimit,
+      verificationGasLimit,
       sponsorship,
       index
     })
   }
   return resolveVerificationGasLimitForNonPaymentChain({
     moduleAddress,
-    customVerificationGasLimit,
+    verificationGasLimit,
     index
   })
 }
@@ -1389,16 +1389,16 @@ const resolveVerificationGasLimit = (
 const resolveVerificationGasLimitForPaymentChain = (
   parameters: resolveVerificationGasLimitParams
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, customVerificationGasLimit, sponsorship, index } =
+  const { moduleAddress, verificationGasLimit, sponsorship, index } =
     parameters
 
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied
-  if (!moduleAddress && !customVerificationGasLimit) {
+  if (!moduleAddress && !verificationGasLimit) {
     return undefined
   }
-  if (!moduleAddress && customVerificationGasLimit) {
-    return { verificationGasLimit: customVerificationGasLimit }
+  if (!moduleAddress && verificationGasLimit) {
+    return { verificationGasLimit }
   }
   // at this stage moduleAddress is definitely provided
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
@@ -1412,7 +1412,7 @@ const resolveVerificationGasLimitForPaymentChain = (
         // return increased verification gas limit for the first userOp
         // as it this userOp will be enabling the permission => requires more gas
         return {
-          verificationGasLimit: customVerificationGasLimit || 1_000_000n
+          verificationGasLimit: verificationGasLimit || 1_000_000n
         }
       }
     }
@@ -1423,8 +1423,8 @@ const resolveVerificationGasLimitForPaymentChain = (
   // if module is defined, however it is not SMART_SESSIONS_ADDRESS,
   // return the custom verification gas limit
   // more manual handling for other modules can be added here if needed
-  if (customVerificationGasLimit) {
-    return { verificationGasLimit: customVerificationGasLimit }
+  if (verificationGasLimit) {
+    return { verificationGasLimit }
   }
   // if module is provided but no custom verification gas limit is provided,
   // return undefined == default verification gas limit
@@ -1441,14 +1441,14 @@ const resolveVerificationGasLimitForPaymentChain = (
 const resolveVerificationGasLimitForNonPaymentChain = (
   parameters: Omit<resolveVerificationGasLimitParams, "sponsorship">
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, customVerificationGasLimit, index } = parameters
+  const { moduleAddress, verificationGasLimit, index } = parameters
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied
-  if (!moduleAddress && !customVerificationGasLimit) {
+  if (!moduleAddress && !verificationGasLimit) {
     return undefined
   }
-  if (!moduleAddress && customVerificationGasLimit) {
-    return { verificationGasLimit: customVerificationGasLimit }
+  if (!moduleAddress && verificationGasLimit) {
+    return { verificationGasLimit }
   }
   // at this stage moduleAddress is definitely provided
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
@@ -1456,13 +1456,13 @@ const resolveVerificationGasLimitForNonPaymentChain = (
     if (index === 0) {
       // return increased verification gas limit for payment userOp
       // in a non-sponsored superTxn
-      return { verificationGasLimit: customVerificationGasLimit || 1_000_000n }
+      return { verificationGasLimit: verificationGasLimit || 1_000_000n }
     }
     // for all other userOps, return USE session verification gas limit
     return { verificationGasLimit: 250_000n }
   }
-  if (customVerificationGasLimit) {
-    return { verificationGasLimit: customVerificationGasLimit }
+  if (verificationGasLimit) {
+    return { verificationGasLimit }
   }
   // if module is provided but no custom verification gas limit is provided, return undefined == default verification gas limit
   return undefined
@@ -1477,27 +1477,27 @@ const resolveVerificationGasLimitForNonPaymentChain = (
  */
 const resolvePaymentUserOpVerificationGasLimitNonSponsored = (
   moduleAddress?: Address,
-  customVerificationGasLimit?: bigint
+  verificationGasLimit?: bigint
 ): verificationGasLimitPayload | undefined => {
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied
-  if (!moduleAddress && !customVerificationGasLimit) {
+  if (!moduleAddress && !verificationGasLimit) {
     return undefined
   }
-  if (!moduleAddress && customVerificationGasLimit) {
-    return { verificationGasLimit: customVerificationGasLimit }
+  if (!moduleAddress && verificationGasLimit) {
+    return { verificationGasLimit }
   }
   // at this stage moduleAddress is definitely provided
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
     // return increased verification gas limit for payment userOp
     // in a non-sponsored superTxn
-    return { verificationGasLimit: customVerificationGasLimit || 1_000_000n }
+    return { verificationGasLimit: verificationGasLimit || 1_000_000n }
     // if it is sponsorship, the payment userOp won't even use Smart Sessions Module
     // so doesn't need any custom verification gas limit
     // also payment userOp never utilizes USE mode of Smart Sessions Module
   }
-  if (customVerificationGasLimit) {
-    return { verificationGasLimit: customVerificationGasLimit }
+  if (verificationGasLimit) {
+    return { verificationGasLimit }
   }
   // if module is provided but no custom verification gas limit is provided, return undefined == default verification gas limit
   return undefined

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -209,6 +209,20 @@ export type SponsorshipOptionsParams = {
   }
 }
 
+export type ActiveModuleParams = {
+  /**
+   * The address of the active module
+   * @example "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
+   */
+  moduleAddress: Address
+
+  /**
+   * The verification gas limit for the active module
+   * @example 150000n
+   */
+  customVerificationGasLimit?: bigint
+}
+
 /**
  * Parameters required for requesting a quote from the MEE service
  */
@@ -250,17 +264,13 @@ export type GetQuoteParams = SupertransactionLike & {
    */
   gasLimit?: bigint
   /**
-   * verificationGasLimit option to override the default payment verification gas limit
-   */
-  verificationGasLimit?: bigint
-  /**
    * token cleanup option to pull the funds on failure or dust cleanup
    */
   cleanUps?: CleanUp[]
   /**
-   * Active module address. Used to fetch the nonce for the active module
+   * Active module params. Used to fetch the nonce for the active module and resolve verification gas limit
    */
-  moduleAddress?: Address
+  activeModuleParams?: ActiveModuleParams
   /**
    * Short encoding flag for fusion isValidsignatureWithSender/validateSignatureWithData functions
    * This flag is set true when the whole superTxn with all entries require short encoding
@@ -552,12 +562,14 @@ export const getQuote = async (
     delegate = false,
     authorizations = [],
     multichain7702Auth = false,
-    moduleAddress,
+    activeModuleParams,
     shortEncodingSuperTxn = false,
     sponsorship = false,
     sponsorshipOptions,
     feeToken
   } = parameters
+
+  const { moduleAddress } = activeModuleParams || {}
 
   const resolvedInstructions = await resolveInstructions(instructions)
 
@@ -584,11 +596,6 @@ export const getQuote = async (
   }
 
   const hasProcessedInitData: number[] = []
-
-  const paymentVerificationGasLimit = resolvePaymentUserOpVerificationGasLimit({
-    moduleAddress,
-    sponsorship
-  })
 
   const initDataTypeByChainId = new Map<number, INIT_DATA_TYPE>()
 
@@ -750,7 +757,6 @@ export const getQuote = async (
     client,
     {
       ...parameters,
-      paymentVerificationGasLimit,
       initDataTypeByChainId
     }
   )
@@ -863,7 +869,7 @@ export const getQuote = async (
         }
 
         const verificationGasLimit = resolveVerificationGasLimit({
-          moduleAddress,
+          activeModuleParams,
           sponsorship,
           index: indexPerChainId.get(chainId)!,
           paymentChainId: paymentInfo.chainId,
@@ -925,7 +931,6 @@ export const getQuote = async (
 const preparePaymentInfo = async (
   client: BaseMeeClient,
   parameters: GetQuoteParams & {
-    paymentVerificationGasLimit?: { verificationGasLimit: bigint }
     initDataTypeByChainId: Map<number, INIT_DATA_TYPE>
   }
 ) => {
@@ -935,14 +940,13 @@ const preparePaymentInfo = async (
     feeToken,
     feePayer,
     gasLimit,
-    verificationGasLimit,
     authorizations = [],
     sponsorship,
     sponsorshipOptions,
     shortEncodingSuperTxn,
-    moduleAddress: validatorAddress,
-    paymentVerificationGasLimit
+    activeModuleParams
   } = parameters
+  const { moduleAddress, customVerificationGasLimit } = activeModuleParams || {}
 
   let paymentInfo: PaymentInfo | undefined = undefined
   let isInitDataProcessed = false
@@ -983,7 +987,7 @@ const preparePaymentInfo = async (
       nonce,
       callGasLimit: gasLimit || DEFAULT_GAS_LIMIT,
       verificationGasLimit:
-        verificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT,
+        customVerificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT, // when sponsored, it is whether the custom one or the default one
       chainId: chainId.toString(),
       sponsorshipUrl,
       ...(eoaOrFeePayer ? { eoa: eoaOrFeePayer } : {}),
@@ -997,6 +1001,7 @@ const preparePaymentInfo = async (
     // first developer defined userOp. To make this happen, this field should be false
     isInitDataProcessed = false
   } else {
+    // No sponsorship
     if (!feeToken) throw Error("Fee token should be configured")
 
     const validPaymentAccount = account_.deploymentOn(feeToken.chainId)
@@ -1022,7 +1027,7 @@ const preparePaymentInfo = async (
 
     const [nonce, isAccountDeployed, initCode] = await Promise.all([
       validPaymentAccount.getNonceWithKey(validPaymentAccount.address, {
-        moduleAddress: validatorAddress
+        moduleAddress
       }),
       validPaymentAccount.isDeployed(),
       validPaymentAccount.getInitCode()
@@ -1050,6 +1055,10 @@ const preparePaymentInfo = async (
       }
     }
 
+    // for non-sponsored superTxn, the verification gas limit is resolved here
+    const paymentVerificationGasLimit =
+      resolvePaymentUserOpVerificationGasLimitNonSponsored(activeModuleParams)
+
     paymentInfo = {
       sponsored: false,
       sender: validPaymentAccount.address,
@@ -1057,15 +1066,15 @@ const preparePaymentInfo = async (
       nonce: nonce.nonce.toString(),
       callGasLimit: gasLimit || DEFAULT_GAS_LIMIT,
       verificationGasLimit:
-        verificationGasLimit || DEFAULT_VERIFICATION_GAS_LIMIT,
+        paymentVerificationGasLimit?.verificationGasLimit ||
+        DEFAULT_VERIFICATION_GAS_LIMIT,
       chainId: feeToken.chainId.toString(),
       ...(feeToken.gasRefundAddress
         ? { gasRefundAddress: feeToken.gasRefundAddress }
         : {}),
       ...(eoaOrFeePayer ? { eoa: eoaOrFeePayer } : {}),
       ...initData,
-      shortEncoding: shortEncodingSuperTxn,
-      ...paymentVerificationGasLimit
+      shortEncoding: shortEncodingSuperTxn
     }
 
     // Init code / authorization list will added to payment userOp. To prevent adding the init code / authList
@@ -1322,12 +1331,12 @@ const prepareCleanUpUserOps = async (
 // ============ resolve verification gas limit functions ============
 /**
  * Parameters for the resolveVerificationGasLimit function
- * @param moduleAddress - The address of the module
+ * @param activeModuleParams - The active module params
  * @param index - The index of the userOp during the userOps completion process
  * @param sponsorship - Whether the superTxn is sponsored
  */
 export type resolveVerificationGasLimitParams = {
-  moduleAddress?: Address
+  activeModuleParams?: ActiveModuleParams
   sponsorship: boolean
   index: number
 }
@@ -1352,17 +1361,22 @@ const resolveVerificationGasLimit = (
     currentChainId: string
   }
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, sponsorship, index, paymentChainId, currentChainId } =
-    parameters
+  const {
+    activeModuleParams,
+    sponsorship,
+    index,
+    paymentChainId,
+    currentChainId
+  } = parameters
   if (currentChainId === paymentChainId) {
     return resolveVerificationGasLimitForPaymentChain({
-      moduleAddress,
+      activeModuleParams,
       sponsorship,
       index
     })
   }
   return resolveVerificationGasLimitForNonPaymentChain({
-    moduleAddress,
+    activeModuleParams,
     index
   })
 }
@@ -1377,23 +1391,45 @@ const resolveVerificationGasLimit = (
 const resolveVerificationGasLimitForPaymentChain = (
   parameters: resolveVerificationGasLimitParams
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, sponsorship, index } = parameters
-  // if module address is not provided, the default verification gas limit will be applied
-  if (!moduleAddress) {
+  const { activeModuleParams, sponsorship, index } = parameters
+  const { moduleAddress, customVerificationGasLimit } = activeModuleParams || {}
+
+  // if neither module address nor custom verification gas limit is provided,
+  // the default verification gas limit will be applied
+  if (!moduleAddress && !customVerificationGasLimit) {
     return undefined
+  } 
+  if (!moduleAddress && customVerificationGasLimit) {
+    return { verificationGasLimit: customVerificationGasLimit }
   }
+  // at this stage moduleAddress is definitely provided
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
     if (sponsorship) {
+      // handling this only for sponsored superTxn. (payment userOp
+      // is signed by the node and can not enable the permission) =>
+      // => the permission is enabled in the first meaningful userOp
+      // for non-sponsored superTxn, enabling the permission happens
+      // in the payment userOp see resolvePaymentUserOpVerificationGasLimit(...) below
       if (index === 0) {
         // return increased verification gas limit for the first userOp
         // as it this userOp will be enabling the permission => requires more gas
-        return { verificationGasLimit: 1_000_000n }
+        return {
+          verificationGasLimit: customVerificationGasLimit || 1_000_000n
+        }
       }
     }
     // return slighly increased verification gas limit
     // for USE session userOps
     return { verificationGasLimit: 250_000n }
   }
+  // if module is defined, however it is not SMART_SESSIONS_ADDRESS,
+  // return the custom verification gas limit
+  // more manual handling for other modules can be added here if needed
+  if (customVerificationGasLimit) {
+    return { verificationGasLimit: customVerificationGasLimit }
+  }
+  // if module is provided but no custom verification gas limit is provided,
+  // return undefined == default verification gas limit
   return undefined
 }
 
@@ -1407,20 +1443,31 @@ const resolveVerificationGasLimitForPaymentChain = (
 const resolveVerificationGasLimitForNonPaymentChain = (
   parameters: Omit<resolveVerificationGasLimitParams, "sponsorship">
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, index } = parameters
-  // if module address is not provided, the default verification gas limit will be applied
-  if (!moduleAddress) {
+  const { activeModuleParams, index } = parameters
+  const { moduleAddress, customVerificationGasLimit } = activeModuleParams || {}
+  // if neither module address nor custom verification gas limit is provided,
+  // the default verification gas limit will be applied
+  if (!moduleAddress && !customVerificationGasLimit) {
     return undefined
+  } 
+  if (!moduleAddress && customVerificationGasLimit) {
+    return { verificationGasLimit: customVerificationGasLimit }
   }
+  // at this stage moduleAddress is definitely provided
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
+    // on the non-payment chain, the permission is always enabled in the first meaningful userOp
     if (index === 0) {
       // return increased verification gas limit for payment userOp
       // in a non-sponsored superTxn
-      return { verificationGasLimit: 1_000_000n }
+      return { verificationGasLimit: customVerificationGasLimit || 1_000_000n }
     }
     // for all other userOps, return USE session verification gas limit
     return { verificationGasLimit: 250_000n }
   }
+  if (customVerificationGasLimit) {
+    return { verificationGasLimit: customVerificationGasLimit }
+  }
+  // if module is provided but no custom verification gas limit is provided, return undefined == default verification gas limit
   return undefined
 }
 
@@ -1431,23 +1478,31 @@ const resolveVerificationGasLimitForNonPaymentChain = (
  * returns undefined if there's no special gas limit required for a given case
  * 'undefined' means the node will apply the default verification gas limit
  */
-const resolvePaymentUserOpVerificationGasLimit = (
-  parameters: Omit<resolveVerificationGasLimitParams, "index">
+const resolvePaymentUserOpVerificationGasLimitNonSponsored = (
+  parameters?: ActiveModuleParams
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, sponsorship } = parameters
-  // if module address is not provided, the default verification gas limit will be applied
-  if (!moduleAddress) {
+  const { moduleAddress, customVerificationGasLimit } = parameters || {}
+  // if neither module address nor custom verification gas limit is provided,
+  // the default verification gas limit will be applied
+  if (!moduleAddress && !customVerificationGasLimit) {
     return undefined
   }
+  if (!moduleAddress && customVerificationGasLimit) {
+    return { verificationGasLimit: customVerificationGasLimit }
+  }
+  // at this stage moduleAddress is definitely provided
   if (addressEquals(moduleAddress, SMART_SESSIONS_ADDRESS)) {
-    if (!sponsorship) {
-      // return increased verification gas limit for payment userOp
-      // in a non-sponsored superTxn
-      return { verificationGasLimit: 1_000_000n }
-    }
+    // return increased verification gas limit for payment userOp
+    // in a non-sponsored superTxn
+    return { verificationGasLimit: customVerificationGasLimit || 1_000_000n }
     // if it is sponsorship, the payment userOp won't even use Smart Sessions Module
     // so doesn't need any custom verification gas limit
+    // also payment userOp never utilizes USE mode of Smart Sessions Module
   }
+  if (customVerificationGasLimit) {
+    return { verificationGasLimit: customVerificationGasLimit }
+  }
+  // if module is provided but no custom verification gas limit is provided, return undefined == default verification gas limit
   return undefined
 }
 

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -209,20 +209,6 @@ export type SponsorshipOptionsParams = {
   }
 }
 
-export type ActiveModuleParams = {
-  /**
-   * The address of the active module
-   * @example "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
-   */
-  moduleAddress: Address
-
-  /**
-   * The verification gas limit for the active module
-   * @example 150000n
-   */
-  customVerificationGasLimit?: bigint
-}
-
 /**
  * Parameters required for requesting a quote from the MEE service
  */
@@ -268,9 +254,14 @@ export type GetQuoteParams = SupertransactionLike & {
    */
   cleanUps?: CleanUp[]
   /**
-   * Active module params. Used to fetch the nonce for the active module and resolve verification gas limit
+   * Active module address. Used to fetch the nonce for the active module and resolve verification gas limit
    */
-  activeModuleParams?: ActiveModuleParams
+  moduleAddress?: Address
+  /**
+   * The verification gas limit for the active module
+   * @example 150000n
+   */
+  customVerificationGasLimit?: bigint
   /**
    * Short encoding flag for fusion isValidsignatureWithSender/validateSignatureWithData functions
    * This flag is set true when the whole superTxn with all entries require short encoding
@@ -562,14 +553,13 @@ export const getQuote = async (
     delegate = false,
     authorizations = [],
     multichain7702Auth = false,
-    activeModuleParams,
+    moduleAddress,
+    customVerificationGasLimit,
     shortEncodingSuperTxn = false,
     sponsorship = false,
     sponsorshipOptions,
     feeToken
   } = parameters
-
-  const { moduleAddress } = activeModuleParams || {}
 
   const resolvedInstructions = await resolveInstructions(instructions)
 
@@ -869,7 +859,8 @@ export const getQuote = async (
         }
 
         const verificationGasLimit = resolveVerificationGasLimit({
-          activeModuleParams,
+          moduleAddress,
+          customVerificationGasLimit,
           sponsorship,
           index: indexPerChainId.get(chainId)!,
           paymentChainId: paymentInfo.chainId,
@@ -944,9 +935,9 @@ const preparePaymentInfo = async (
     sponsorship,
     sponsorshipOptions,
     shortEncodingSuperTxn,
-    activeModuleParams
+    moduleAddress,
+    customVerificationGasLimit,
   } = parameters
-  const { moduleAddress, customVerificationGasLimit } = activeModuleParams || {}
 
   let paymentInfo: PaymentInfo | undefined = undefined
   let isInitDataProcessed = false
@@ -1057,7 +1048,7 @@ const preparePaymentInfo = async (
 
     // for non-sponsored superTxn, the verification gas limit is resolved here
     const paymentVerificationGasLimit =
-      resolvePaymentUserOpVerificationGasLimitNonSponsored(activeModuleParams)
+      resolvePaymentUserOpVerificationGasLimitNonSponsored(moduleAddress, customVerificationGasLimit)
 
     paymentInfo = {
       sponsored: false,
@@ -1331,12 +1322,14 @@ const prepareCleanUpUserOps = async (
 // ============ resolve verification gas limit functions ============
 /**
  * Parameters for the resolveVerificationGasLimit function
- * @param activeModuleParams - The active module params
+ * @param moduleAddress - The active module address
+ * @param customVerificationGasLimit - The custom verification gas limit
  * @param index - The index of the userOp during the userOps completion process
  * @param sponsorship - Whether the superTxn is sponsored
  */
 export type resolveVerificationGasLimitParams = {
-  activeModuleParams?: ActiveModuleParams
+  moduleAddress?: Address
+  customVerificationGasLimit?: bigint
   sponsorship: boolean
   index: number
 }
@@ -1362,7 +1355,8 @@ const resolveVerificationGasLimit = (
   }
 ): verificationGasLimitPayload | undefined => {
   const {
-    activeModuleParams,
+    moduleAddress,
+    customVerificationGasLimit,
     sponsorship,
     index,
     paymentChainId,
@@ -1370,13 +1364,15 @@ const resolveVerificationGasLimit = (
   } = parameters
   if (currentChainId === paymentChainId) {
     return resolveVerificationGasLimitForPaymentChain({
-      activeModuleParams,
+      moduleAddress,
+      customVerificationGasLimit,
       sponsorship,
       index
     })
   }
   return resolveVerificationGasLimitForNonPaymentChain({
-    activeModuleParams,
+    moduleAddress,
+    customVerificationGasLimit,
     index
   })
 }
@@ -1391,14 +1387,13 @@ const resolveVerificationGasLimit = (
 const resolveVerificationGasLimitForPaymentChain = (
   parameters: resolveVerificationGasLimitParams
 ): verificationGasLimitPayload | undefined => {
-  const { activeModuleParams, sponsorship, index } = parameters
-  const { moduleAddress, customVerificationGasLimit } = activeModuleParams || {}
+  const { moduleAddress, customVerificationGasLimit, sponsorship, index } = parameters
 
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied
   if (!moduleAddress && !customVerificationGasLimit) {
     return undefined
-  } 
+  }
   if (!moduleAddress && customVerificationGasLimit) {
     return { verificationGasLimit: customVerificationGasLimit }
   }
@@ -1443,13 +1438,12 @@ const resolveVerificationGasLimitForPaymentChain = (
 const resolveVerificationGasLimitForNonPaymentChain = (
   parameters: Omit<resolveVerificationGasLimitParams, "sponsorship">
 ): verificationGasLimitPayload | undefined => {
-  const { activeModuleParams, index } = parameters
-  const { moduleAddress, customVerificationGasLimit } = activeModuleParams || {}
+  const { moduleAddress, customVerificationGasLimit, index } = parameters
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied
   if (!moduleAddress && !customVerificationGasLimit) {
     return undefined
-  } 
+  }
   if (!moduleAddress && customVerificationGasLimit) {
     return { verificationGasLimit: customVerificationGasLimit }
   }
@@ -1479,9 +1473,9 @@ const resolveVerificationGasLimitForNonPaymentChain = (
  * 'undefined' means the node will apply the default verification gas limit
  */
 const resolvePaymentUserOpVerificationGasLimitNonSponsored = (
-  parameters?: ActiveModuleParams
+    moduleAddress?: Address,
+    customVerificationGasLimit?: bigint
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, customVerificationGasLimit } = parameters || {}
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied
   if (!moduleAddress && !customVerificationGasLimit) {

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -1389,8 +1389,7 @@ const resolveVerificationGasLimit = (
 const resolveVerificationGasLimitForPaymentChain = (
   parameters: resolveVerificationGasLimitParams
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, verificationGasLimit, sponsorship, index } =
-    parameters
+  const { moduleAddress, verificationGasLimit, sponsorship, index } = parameters
 
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -936,7 +936,7 @@ const preparePaymentInfo = async (
     sponsorshipOptions,
     shortEncodingSuperTxn,
     moduleAddress,
-    customVerificationGasLimit,
+    customVerificationGasLimit
   } = parameters
 
   let paymentInfo: PaymentInfo | undefined = undefined
@@ -1048,7 +1048,10 @@ const preparePaymentInfo = async (
 
     // for non-sponsored superTxn, the verification gas limit is resolved here
     const paymentVerificationGasLimit =
-      resolvePaymentUserOpVerificationGasLimitNonSponsored(moduleAddress, customVerificationGasLimit)
+      resolvePaymentUserOpVerificationGasLimitNonSponsored(
+        moduleAddress,
+        customVerificationGasLimit
+      )
 
     paymentInfo = {
       sponsored: false,
@@ -1387,7 +1390,8 @@ const resolveVerificationGasLimit = (
 const resolveVerificationGasLimitForPaymentChain = (
   parameters: resolveVerificationGasLimitParams
 ): verificationGasLimitPayload | undefined => {
-  const { moduleAddress, customVerificationGasLimit, sponsorship, index } = parameters
+  const { moduleAddress, customVerificationGasLimit, sponsorship, index } =
+    parameters
 
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied
@@ -1473,8 +1477,8 @@ const resolveVerificationGasLimitForNonPaymentChain = (
  * 'undefined' means the node will apply the default verification gas limit
  */
 const resolvePaymentUserOpVerificationGasLimitNonSponsored = (
-    moduleAddress?: Address,
-    customVerificationGasLimit?: bigint
+  moduleAddress?: Address,
+  customVerificationGasLimit?: bigint
 ): verificationGasLimitPayload | undefined => {
   // if neither module address nor custom verification gas limit is provided,
   // the default verification gas limit will be applied


### PR DESCRIPTION
Refactor of using custom verification gas limit parameter in the GetQuote decorator

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `getQuote` function in the `src/sdk/clients/decorators/mee/getQuote.ts` file by introducing and refining the handling of a new `verificationGasLimit` parameter, which allows for more flexible gas limit management during transactions.

### Detailed summary
- Added a new optional parameter `verificationGasLimit` to `getQuote`.
- Updated the `moduleAddress` documentation to include its role in resolving the verification gas limit.
- Removed the previous handling of `paymentVerificationGasLimit`.
- Introduced a new function `resolvePaymentUserOpVerificationGasLimitNonSponsored` for handling non-sponsored transactions.
- Adjusted logic in `resolveVerificationGasLimit` to incorporate `verificationGasLimit`.
- Updated the verification gas limit handling in various parts of the `preparePaymentInfo` function.
- Enhanced comments throughout the code for better clarity on the gas limit resolution process.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->