### PR TITLE
fix: add custom vgl for usePermission

### DIFF
--- a/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
@@ -18,6 +18,7 @@ export type UseMeePermissionParams = {
   mode: "ENABLE_AND_USE" | "USE"
   instructions: Instruction[]
   sessionDetails: GrantMeePermissionPayload
+  verificationGasLimit?: bigint
 } & OneOf<
   | {
       feeToken: FeeTokenInfo
@@ -40,7 +41,8 @@ export const useMeePermission = async (
   const {
     sessionDetails: sessionDetailsArray,
     mode: mode_,
-    instructions
+    instructions,
+    verificationGasLimit
   } = parameters
   const meeClient = meeClient_ as MeeClient
 
@@ -53,6 +55,7 @@ export const useMeePermission = async (
     instructions,
     moduleAddress: SMART_SESSIONS_ADDRESS,
     shortEncodingSuperTxn: true,
+    verificationGasLimit,
     ...(parameters.sponsorship
       ? {
           sponsorship: parameters.sponsorship,


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces a new optional parameter `verificationGasLimit` in the `useMeePermission` function and updates several tests to accommodate this change. It also modifies the gas limit in specific test cases and updates the MEE version used in the tests.

### Detailed summary
- Added `verificationGasLimit` as an optional parameter in the `useMeePermission` function.
- Updated the destructuring assignment in `useMeePermission` to include `verificationGasLimit`.
- Changed test cases to use `MEEVersion.V2_1_0`.
- Adjusted `amount` in `transferToNexusTrigger` from `0.5` to `0.3`.
- Added a new test for granting and using permission with a custom `verificationGasLimit`.
- Set `verificationGasLimit` to `3_000_000n` in the new test.
- Updated `verificationGasLimit` to `3_000_111n` in an existing test case.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->