### PR TITLE
fix: add checks

### DIFF
--- a/src/sdk/account/decorators/instructions/buildComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.ts
@@ -19,6 +19,7 @@ import {
   prepareComposableInputCalldataParams,
   prepareInputParam
 } from "../../../modules/utils/composabilityCalls"
+import { isRuntimeComposableValue } from "../../../modules/utils/composabilityCalls"
 import {
   type RuntimeValue,
   getFunctionContextFromAbi
@@ -143,8 +144,18 @@ export const formatComposableCallWithVersion = (
   let composableCall: ComposableCall
   // Handle different composability versions
   if (composabilityVersion === ComposabilityVersion.V1_0_0) {
+    if (isRuntimeComposableValue(to)) {
+      throw new Error(
+        "Runtime injected target is not supported for Composability v1.0.0"
+      )
+    }
     if (!isAddress(to as Address)) {
       throw new Error("Invalid target contract address")
+    }
+    if (isRuntimeComposableValue(value)) {
+      throw new Error(
+        "Runtime injected value is not supported for Composability v1.0.0"
+      )
     }
     // format composable call for composability version 1.0.0 with to and value
     composableCall = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds checks for runtime composable values in the `formatComposableCallWithVersion` function to ensure compatibility with Composability version 1.0.0, preventing the use of unsupported runtime injected targets and values.

### Detailed summary
- Added an import statement for `isRuntimeComposableValue`.
- Introduced checks to throw errors if `to` or `value` are runtime composable values when `composabilityVersion` is `V1_0_0`.
- Updated error messages for clarity regarding unsupported runtime injected values.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->