### PR TITLE
fix: ss fix mode distribution sponsored

### DIFF
--- a/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
@@ -66,41 +66,42 @@ export const useMeePermission = async (
 
   const signedQuote = await meeClient.signQuote({ quote })
 
-  const modeMap = signedQuote.userOps.reduce(
-    (acc, userOpEntry) => {
-      acc[String(userOpEntry.chainId)] = false
-      return acc
-    },
-    {} as Record<string, boolean>
-  )
+  // Assign the correct mode for each userOp
+  // This is required to avoid using ENABLE mode for the same chain more than once
+  const processedChains = new Set<string>()
+  const startIndex = signedQuote.paymentInfo.sponsored ? 1 : 0
 
-  // Then focus on the other user ops
   for (const [index, userOpEntry] of signedQuote.userOps.entries()) {
-    // If payment is sponsored, skip the first userOp (index 0) as it's the payment userOp
-    if (signedQuote.paymentInfo.sponsored && index === 0) {
-      continue
-    }
+    // Skip payment userOp if sponsored
+    if (index < startIndex) continue
 
-    // If we've iterated over this chainId before, it will never require enable mode again.
-    const alreadyUsed = !!modeMap[userOpEntry.chainId]
+    const chainId = String(userOpEntry.chainId)
+    const isFirstTimeForChain = !processedChains.has(chainId)
 
+    // Find session details for this chain
     const relevantIndex = sessionDetailsArray.findIndex(
       ({ enableSessionData }) =>
         enableSessionData?.enableSession?.sessionToEnable?.chainId ===
         BigInt(userOpEntry.chainId)
     )
 
-    // Mark the session as used or unused
-    const dynamicMode = alreadyUsed ? SmartSessionMode.USE : mode
+    if (relevantIndex === -1) {
+      throw new Error(
+        `No session details found for chainId ${userOpEntry.chainId}`
+      )
+    }
 
-    // Set the session details for the user op
+    // Determine mode: first time gets original mode (enable and use most likely), subsequent times get USE
+    const dynamicMode = isFirstTimeForChain ? mode : SmartSessionMode.USE
+
+    // Apply mode to session details
     userOpEntry.sessionDetails = {
       ...sessionDetailsArray[relevantIndex],
       mode: dynamicMode
     }
 
-    // Remember that the mode has now been catered for
-    modeMap[userOpEntry.chainId] = true
+    // Mark chain as processed
+    processedChains.add(chainId)
   }
 
   return await meeClient.executeSignedQuote({ signedQuote })

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/useMeePermission.ts
@@ -75,7 +75,12 @@ export const useMeePermission = async (
   )
 
   // Then focus on the other user ops
-  for (const [_, userOpEntry] of signedQuote.userOps.entries()) {
+  for (const [index, userOpEntry] of signedQuote.userOps.entries()) {
+    // If payment is sponsored, skip the first userOp (index 0) as it's the payment userOp
+    if (signedQuote.paymentInfo.sponsored && index === 0) {
+      continue
+    }
+
     // If we've iterated over this chainId before, it will never require enable mode again.
     const alreadyUsed = !!modeMap[userOpEntry.chainId]
 

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -207,9 +207,9 @@ describe("mee.multichainSmartSessions", () => {
     }
   )
 
-  test.runIf(runPaidTests)(
-    "should grant and use multichain permissions for the account that is already deployed on all chains",
-    async () => {
+  test
+    .runIf(runPaidTests)
+    .skip("should grant and use multichain permissions for the account that is already deployed on all chains", async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       // ======== At this point the Nexus SA is already deployed and SS is installed ==============
@@ -312,12 +312,11 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
-    }
-  )
+    })
 
-  test.runIf(runPaidTests)(
-    "should grant and use permission with custom verification gas limit",
-    async () => {
+  test
+    .runIf(runPaidTests)
+    .skip("should grant and use permission with custom verification gas limit", async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       const sessionDetails =
@@ -425,8 +424,7 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
-    }
-  )
+    })
 
   test.runIf(runPaidTests)(
     "should grant and use multichain permissions with sponsorship",
@@ -495,6 +493,17 @@ describe("mee.multichainSmartSessions", () => {
           {
             calls: [
               {
+                to: COUNTER_ON_BASE,
+                data: toFunctionSelector(
+                  getAbiItem({ abi: CounterAbi, name: "incrementNumber" })
+                )
+              }
+            ],
+            chainId: targetChain.id
+          },
+          {
+            calls: [
+              {
                 to: COUNTER_ON_OPTIMISM,
                 data: toFunctionSelector(
                   getAbiItem({ abi: CounterAbi, name: "incrementNumber" })
@@ -503,8 +512,7 @@ describe("mee.multichainSmartSessions", () => {
             ],
             chainId: paymentChain.id
           }
-        ],
-        verificationGasLimit: 3_000_111n
+        ]
       })
 
       const receipt = await meeClient.waitForSupertransactionReceipt({

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -1,12 +1,18 @@
-import { getSudoPolicy } from "@rhinestone/module-sdk"
+import { getSudoPolicy, getUniversalActionPolicy } from "@rhinestone/module-sdk"
 import type { Address, Chain, LocalAccount, Transport } from "viem"
 import {
   http,
   createPublicClient,
+  createWalletClient,
+  encodeFunctionData,
   erc20Abi,
   getAbiItem,
+  maxUint256,
+  pad,
   parseUnits,
-  toFunctionSelector
+  toFunctionSelector,
+  toHex,
+  zeroAddress
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { beforeAll, describe, expect, inject, test } from "vitest"
@@ -41,6 +47,16 @@ const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
 const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
 const COUNTER_ON_BASE_SEPOLIA = "0xcaf661eeD95DE905Fcf5234040A7d6A70c6F5C85"
 const COUNTER_ON_OPTIMISM_SEPOLIA = "0x111EB1afF13be64d81485E7d45E70A6A0283dedE"
+
+enum ParamCondition {
+  EQUAL = 0,
+  GREATER_THAN = 1,
+  LESS_THAN = 2,
+  GREATER_THAN_OR_EQUAL = 3,
+  LESS_THAN_OR_EQUAL = 4,
+  NOT_EQUAL = 5,
+  IN_RANGE = 6
+}
 
 describe("mee.multichainSmartSessions", () => {
   let network: NetworkConfig
@@ -99,6 +115,19 @@ describe("mee.multichainSmartSessions", () => {
       apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
     })
     smartSessionsValidator = toSmartSessionsModule({ signer: mcNexus.signer })
+
+    // send some USDC from eoaAccount to mcNexus on target chain
+    const eoaWalletClient = createWalletClient({
+      chain: targetChain,
+      transport: targetChainTransport,
+      account: eoaAccount
+    })
+    await eoaWalletClient.writeContract({
+      address: mcUSDC.addressOn(targetChain.id),
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [mcNexus.addressOn(targetChain.id, true), parseUnits("0.011", 6)]
+    })
   })
 
   test.runIf(runPaidTests)(
@@ -109,7 +138,7 @@ describe("mee.multichainSmartSessions", () => {
       // if tests fail, increase the amount
       const transferToNexusTrigger = {
         tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Optimism chain
-        amount: parseUnits("0.3", 6), // so Nexus is able to pay for the next SuperTxns
+        amount: parseUnits("0.5", 6), // so Nexus is able to pay for the next SuperTxns
         chainId: paymentChain.id // Which chain this trigger executes on
       }
 
@@ -316,9 +345,65 @@ describe("mee.multichainSmartSessions", () => {
   )
 
   test.runIf(runPaidTests)(
-    "should grant and use permission with custom verification gas limit",
+    "should grant and use permission with custom verification gas limit and universal action policy",
     async () => {
+      const publicClient = createPublicClient({
+        chain: targetChain,
+        transport: targetChainTransport
+      })
+      const redeemerUSDCBalanceBefore = await publicClient.readContract({
+        address: mcUSDC.addressOn(targetChain.id),
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [redeemerAddress]
+      })
+
       const sessionMeeClient = meeClient.extend(meeSessionActions)
+
+      const EMPTY_RAW_RULE = {
+        condition: ParamCondition.EQUAL,
+        offset: 0n,
+        isLimited: false,
+        ref: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+        usage: { limit: 0n, used: 0n }
+      }
+
+      const uniActionPolicyInfoUSDC = getUniversalActionPolicy({
+        valueLimitPerUse: maxUint256,
+        paramRules: {
+          length: 2n,
+          rules: [
+            {
+              condition: ParamCondition.EQUAL,
+              isLimited: false,
+              offset: 0n,
+              ref: pad(redeemerAddress),
+              usage: { limit: 0n, used: 0n }
+            },
+            {
+              condition: ParamCondition.LESS_THAN_OR_EQUAL,
+              isLimited: true,
+              offset: 32n,
+              ref: pad(toHex(parseUnits("3", 6))),
+              usage: { limit: parseUnits("100", 6), used: 0n }
+            },
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE
+          ]
+        }
+      })
 
       const sessionDetails =
         await sessionMeeClient.grantPermissionTypedDataSign({
@@ -358,6 +443,14 @@ describe("mee.multichainSmartSessions", () => {
               actionPolicies: [getSudoPolicy()],
               chainId: paymentChain.id,
               actionTarget: COUNTER_ON_OPTIMISM
+            },
+            {
+              actionTargetSelector: toFunctionSelector(
+                getAbiItem({ abi: erc20Abi, name: "transfer" })
+              ),
+              actionPolicies: [uniActionPolicyInfoUSDC],
+              chainId: targetChain.id,
+              actionTarget: mcUSDC.addressOn(targetChain.id)
             }
           ],
           maxPaymentAmount: parseUnits("3", 6)
@@ -410,6 +503,22 @@ describe("mee.multichainSmartSessions", () => {
               }
             ],
             chainId: paymentChain.id
+          },
+          // transfer USDC from from orchestrator to redeemer on target chain
+          // this is to test that the action policy via universal action policy
+          // is created successfully
+          {
+            calls: [
+              {
+                to: mcUSDC.addressOn(targetChain.id),
+                data: encodeFunctionData({
+                  abi: erc20Abi,
+                  functionName: "transfer",
+                  args: [redeemerAddress, parseUnits("0.01", 6)]
+                })
+              }
+            ],
+            chainId: targetChain.id
           }
         ],
         feeToken,
@@ -425,6 +534,17 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
+
+      const redeemerUSDCBalanceAfter = await publicClient.readContract({
+        address: mcUSDC.addressOn(targetChain.id),
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [redeemerAddress]
+      })
+
+      expect(redeemerUSDCBalanceAfter).toBe(
+        redeemerUSDCBalanceBefore + parseUnits("0.01", 6)
+      )
     }
   )
 

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -207,9 +207,9 @@ describe("mee.multichainSmartSessions", () => {
     }
   )
 
-  test
-    .runIf(runPaidTests)
-    .skip("should grant and use multichain permissions for the account that is already deployed on all chains", async () => {
+  test.runIf(runPaidTests)(
+    "should grant and use multichain permissions for the account that is already deployed on all chains",
+    async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       // ======== At this point the Nexus SA is already deployed and SS is installed ==============
@@ -312,11 +312,12 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
-    })
+    }
+  )
 
-  test
-    .runIf(runPaidTests)
-    .skip("should grant and use permission with custom verification gas limit", async () => {
+  test.runIf(runPaidTests)(
+    "should grant and use permission with custom verification gas limit",
+    async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       const sessionDetails =
@@ -424,7 +425,8 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
-    })
+    }
+  )
 
   test.runIf(runPaidTests)(
     "should grant and use multichain permissions with sponsorship",

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     testTimeout: 500_000,
     hookTimeout: 250_000,
     fileParallelism: false,
-    retry: 2
+    retry: 0
   }
 })

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     testTimeout: 500_000,
     hookTimeout: 250_000,
     fileParallelism: false,
-    retry: 0
+    retry: 2
   }
 })


### PR DESCRIPTION
Fix the issue detected when debugging dexodus case. 
Existing algorithm was assigning the mode (ENABLE_AND_USE / USE) _incorrectly_ for sponsored superTxns

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `grantMeePermission` functionality and improving the handling of user operations for multichain smart sessions. It introduces new policies and validation checks to ensure correct fee token usage and action policies for ERC20 transfers.

### Detailed summary
- Added `getAbiItem` and `toFunctionSelector` imports to `grantMeePermission.ts`.
- Introduced validation for fee token usage in `grantMeePermission`.
- Updated user operation processing to avoid duplicate chain mode settings in `useMeePermission.ts`.
- Added a new `ParamCondition` enum in `toMultichainSmartSessions.test.ts`.
- Enhanced test cases with additional action policies and checks for ERC20 transfers.
- Updated the transfer amount for `transferToNexusTrigger` in tests.
- Improved error handling for missing session details in user operations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->