### PR TITLE
test: ss with universal policy

### DIFF
--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -1,5 +1,5 @@
 import type { Address, Prettify, PublicClient } from "viem"
-import { erc20Abi, parseUnits } from "viem"
+import { erc20Abi, getAbiItem, parseUnits, toFunctionSelector } from "viem"
 import type { BaseMeeClient } from "../../../../../clients/createMeeClient"
 import type { FeeTokenInfo } from "../../../../../clients/decorators/mee"
 import {
@@ -118,17 +118,22 @@ export const grantMeePermission = async <
       deployment?.version.validatorAddress ||
       defaultVersionConfig.validatorAddress
 
-    const paymentActionPolicy =
-      feeToken && feeToken.chainId === chainId
-        ? {
-            actionTarget: feeToken.address,
-            actionTargetSelector: "0xa9059cbb" as Address, // transfer
-            actionPolicies: [
-              getPolicyForPayment(maxPaymentAmount!, feeToken.address)
-            ]
-          }
-        : undefined
-
+    let paymentActionPolicy: ActionData | undefined = undefined;
+    // if the fee token is involved in the permissions, try adding the payment action policy
+    if (feeToken && feeToken.chainId === chainId) {
+      // if some permission is already defining the policy for the feeToken.transfer, do not add the payment action policy
+      // as they can conflict with each other
+      if (!actions.some((action) => action.actionTargetSelector === toFunctionSelector(getAbiItem({ abi: erc20Abi, name: "transfer" })) && action.actionTarget === feeToken.address)) {
+        paymentActionPolicy = {
+          actionTarget: feeToken.address,
+          actionTargetSelector: "0xa9059cbb" as Address, // transfer
+          actionPolicies: [
+            getPolicyForPayment(maxPaymentAmount!, feeToken.address)
+          ]
+        }
+      }
+    }
+      
     return {
       account: deployment,
       redeemer,

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -121,10 +121,9 @@ export const grantMeePermission = async <
     let paymentActionPolicy: ActionData | undefined = undefined
     // if the fee token is involved in the permissions, try adding the payment action policy
     if (feeToken && feeToken.chainId === chainId) {
-      // if some permission is already defining the policy for the feeToken.transfer, do not add the payment action policy
-      // as they can conflict with each other
+      // if some permission is already defining the policy for the feeToken.transfer, throw an error
       if (
-        !actions.some(
+        actions.some(
           (action) =>
             action.actionTargetSelector ===
               toFunctionSelector(
@@ -132,13 +131,20 @@ export const grantMeePermission = async <
               ) && action.actionTarget === feeToken.address
         )
       ) {
-        paymentActionPolicy = {
-          actionTarget: feeToken.address,
-          actionTargetSelector: "0xa9059cbb" as Address, // transfer
-          actionPolicies: [
-            getPolicyForPayment(maxPaymentAmount!, feeToken.address)
-          ]
-        }
+        throw new Error(`You are defining the policy that prevents using ${feeToken.address} on chain ${chainId} as the fee token. 
+                         Possible solutions:
+                         1. Remove the 'transfer' method of ${feeToken.address} from the actions array.
+                         2. Use a different fee token.
+                         3. Use sponsored mode.`)
+      }
+
+      // else add the payment action policy
+      paymentActionPolicy = {
+        actionTarget: feeToken.address,
+        actionTargetSelector: "0xa9059cbb" as Address, // transfer
+        actionPolicies: [
+          getPolicyForPayment(maxPaymentAmount!, feeToken.address)
+        ]
       }
     }
 

--- a/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/grantMeePermission.ts
@@ -118,12 +118,20 @@ export const grantMeePermission = async <
       deployment?.version.validatorAddress ||
       defaultVersionConfig.validatorAddress
 
-    let paymentActionPolicy: ActionData | undefined = undefined;
+    let paymentActionPolicy: ActionData | undefined = undefined
     // if the fee token is involved in the permissions, try adding the payment action policy
     if (feeToken && feeToken.chainId === chainId) {
       // if some permission is already defining the policy for the feeToken.transfer, do not add the payment action policy
       // as they can conflict with each other
-      if (!actions.some((action) => action.actionTargetSelector === toFunctionSelector(getAbiItem({ abi: erc20Abi, name: "transfer" })) && action.actionTarget === feeToken.address)) {
+      if (
+        !actions.some(
+          (action) =>
+            action.actionTargetSelector ===
+              toFunctionSelector(
+                getAbiItem({ abi: erc20Abi, name: "transfer" })
+              ) && action.actionTarget === feeToken.address
+        )
+      ) {
         paymentActionPolicy = {
           actionTarget: feeToken.address,
           actionTargetSelector: "0xa9059cbb" as Address, // transfer
@@ -133,7 +141,7 @@ export const grantMeePermission = async <
         }
       }
     }
-      
+
     return {
       account: deployment,
       redeemer,

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -3,15 +3,15 @@ import type { Address, Chain, LocalAccount, Transport } from "viem"
 import {
   http,
   createPublicClient,
+  encodeFunctionData,
   erc20Abi,
   getAbiItem,
-  parseUnits,
-  toFunctionSelector,
   maxUint256,
   pad,
+  parseUnits,
+  toFunctionSelector,
   toHex,
-  zeroAddress,
-  encodeFunctionData
+  zeroAddress
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { beforeAll, describe, expect, inject, test } from "vitest"
@@ -40,7 +40,6 @@ import type { Validator } from "../toValidator"
 import { meeSessionActions } from "./decorators/mee"
 import { toSmartSessionsModule } from "./toSmartSessionsModule"
 
-
 // @ts-ignore
 const { runPaidTests } = inject("settings")
 const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
@@ -55,7 +54,7 @@ enum ParamCondition {
   GREATER_THAN_OR_EQUAL = 3,
   LESS_THAN_OR_EQUAL = 4,
   NOT_EQUAL = 5,
-  IN_RANGE = 6,
+  IN_RANGE = 6
 }
 
 describe("mee.multichainSmartSessions", () => {
@@ -223,9 +222,9 @@ describe("mee.multichainSmartSessions", () => {
     }
   )
 
-  test.runIf(runPaidTests).skip(
-    "should grant and use multichain permissions for the account that is already deployed on all chains",
-    async () => {
+  test
+    .runIf(runPaidTests)
+    .skip("should grant and use multichain permissions for the account that is already deployed on all chains", async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       // ======== At this point the Nexus SA is already deployed and SS is installed ==============
@@ -328,13 +327,11 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
-    }
-  )
+    })
 
   test.runIf(runPaidTests)(
     "should grant and use permission with custom verification gas limit and universal action policy",
     async () => {
-      
       const publicClient = createPublicClient({
         chain: targetChain,
         transport: targetChainTransport
@@ -345,15 +342,15 @@ describe("mee.multichainSmartSessions", () => {
         functionName: "balanceOf",
         args: [redeemerAddress]
       })
-      
+
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       const EMPTY_RAW_RULE = {
         condition: ParamCondition.EQUAL,
         offset: 0n,
         isLimited: false,
-        ref: '0x0000000000000000000000000000000000000000000000000000000000000000' as `0x${string}`,
-        usage: { limit: 0n, used: 0n },
+        ref: "0x0000000000000000000000000000000000000000000000000000000000000000" as `0x${string}`,
+        usage: { limit: 0n, used: 0n }
       }
 
       const uniActionPolicyInfo = getUniversalActionPolicy({
@@ -366,14 +363,14 @@ describe("mee.multichainSmartSessions", () => {
               isLimited: false,
               offset: 0n,
               ref: pad(redeemerAddress),
-              usage: { limit: 0n, used: 0n },
+              usage: { limit: 0n, used: 0n }
             },
             {
               condition: ParamCondition.LESS_THAN_OR_EQUAL,
               isLimited: true,
               offset: 32n,
               ref: pad(toHex(parseUnits("3", 6))),
-              usage: { limit: parseUnits("100", 6), used: 0n },
+              usage: { limit: parseUnits("100", 6), used: 0n }
             },
             EMPTY_RAW_RULE,
             EMPTY_RAW_RULE,
@@ -388,10 +385,10 @@ describe("mee.multichainSmartSessions", () => {
             EMPTY_RAW_RULE,
             EMPTY_RAW_RULE,
             EMPTY_RAW_RULE,
-            EMPTY_RAW_RULE,
-          ],
-        },
-      });
+            EMPTY_RAW_RULE
+          ]
+        }
+      })
 
       const sessionDetails =
         await sessionMeeClient.grantPermissionTypedDataSign({
@@ -433,7 +430,9 @@ describe("mee.multichainSmartSessions", () => {
               actionTarget: COUNTER_ON_OPTIMISM
             },
             {
-              actionTargetSelector: toFunctionSelector(getAbiItem({ abi: erc20Abi, name: "transfer" })),
+              actionTargetSelector: toFunctionSelector(
+                getAbiItem({ abi: erc20Abi, name: "transfer" })
+              ),
               actionPolicies: [uniActionPolicyInfo],
               chainId: targetChain.id,
               actionTarget: mcUSDC.addressOn(targetChain.id)
@@ -526,13 +525,15 @@ describe("mee.multichainSmartSessions", () => {
         functionName: "balanceOf",
         args: [redeemerAddress]
       })
-      expect(redeemerUSDCBalanceAfter).toBe(redeemerUSDCBalanceBefore + parseUnits("0.01", 6))
+      expect(redeemerUSDCBalanceAfter).toBe(
+        redeemerUSDCBalanceBefore + parseUnits("0.01", 6)
+      )
     }
   )
 
-  test.runIf(runPaidTests).skip(
-    "should grant and use multichain permissions with sponsorship",
-    async () => {
+  test
+    .runIf(runPaidTests)
+    .skip("should grant and use multichain permissions with sponsorship", async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       const prepareForPermissionsPayload =
@@ -625,6 +626,5 @@ describe("mee.multichainSmartSessions", () => {
       })
 
       expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
-    }
-  )
+    })
 })

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -1,4 +1,4 @@
-import { getSudoPolicy } from "@rhinestone/module-sdk"
+import { getSudoPolicy, getUniversalActionPolicy } from "@rhinestone/module-sdk"
 import type { Address, Chain, LocalAccount, Transport } from "viem"
 import {
   http,
@@ -6,7 +6,12 @@ import {
   erc20Abi,
   getAbiItem,
   parseUnits,
-  toFunctionSelector
+  toFunctionSelector,
+  maxUint256,
+  pad,
+  toHex,
+  zeroAddress,
+  encodeFunctionData
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { beforeAll, describe, expect, inject, test } from "vitest"
@@ -35,12 +40,23 @@ import type { Validator } from "../toValidator"
 import { meeSessionActions } from "./decorators/mee"
 import { toSmartSessionsModule } from "./toSmartSessionsModule"
 
+
 // @ts-ignore
 const { runPaidTests } = inject("settings")
 const COUNTER_ON_OPTIMISM = "0x167a039E79E4E90550333c7D97a12ebf5f6f116A"
 const COUNTER_ON_BASE = "0x3D9aEd944CC8cD91a89aa318efd6CDCD870241e8"
 const COUNTER_ON_BASE_SEPOLIA = "0xcaf661eeD95DE905Fcf5234040A7d6A70c6F5C85"
 const COUNTER_ON_OPTIMISM_SEPOLIA = "0x111EB1afF13be64d81485E7d45E70A6A0283dedE"
+
+enum ParamCondition {
+  EQUAL = 0,
+  GREATER_THAN = 1,
+  LESS_THAN = 2,
+  GREATER_THAN_OR_EQUAL = 3,
+  LESS_THAN_OR_EQUAL = 4,
+  NOT_EQUAL = 5,
+  IN_RANGE = 6,
+}
 
 describe("mee.multichainSmartSessions", () => {
   let network: NetworkConfig
@@ -207,7 +223,7 @@ describe("mee.multichainSmartSessions", () => {
     }
   )
 
-  test.runIf(runPaidTests)(
+  test.runIf(runPaidTests).skip(
     "should grant and use multichain permissions for the account that is already deployed on all chains",
     async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
@@ -316,9 +332,66 @@ describe("mee.multichainSmartSessions", () => {
   )
 
   test.runIf(runPaidTests)(
-    "should grant and use permission with custom verification gas limit",
+    "should grant and use permission with custom verification gas limit and universal action policy",
     async () => {
+      
+      const publicClient = createPublicClient({
+        chain: targetChain,
+        transport: targetChainTransport
+      })
+      const redeemerUSDCBalanceBefore = await publicClient.readContract({
+        address: mcUSDC.addressOn(targetChain.id),
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [redeemerAddress]
+      })
+      
       const sessionMeeClient = meeClient.extend(meeSessionActions)
+
+      const EMPTY_RAW_RULE = {
+        condition: ParamCondition.EQUAL,
+        offset: 0n,
+        isLimited: false,
+        ref: '0x0000000000000000000000000000000000000000000000000000000000000000' as `0x${string}`,
+        usage: { limit: 0n, used: 0n },
+      }
+
+      const uniActionPolicyInfo = getUniversalActionPolicy({
+        valueLimitPerUse: maxUint256,
+        paramRules: {
+          length: 2n,
+          rules: [
+            {
+              condition: ParamCondition.EQUAL,
+              isLimited: false,
+              offset: 0n,
+              ref: pad(redeemerAddress),
+              usage: { limit: 0n, used: 0n },
+            },
+            {
+              condition: ParamCondition.LESS_THAN_OR_EQUAL,
+              isLimited: true,
+              offset: 32n,
+              ref: pad(toHex(parseUnits("3", 6))),
+              usage: { limit: parseUnits("100", 6), used: 0n },
+            },
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+            EMPTY_RAW_RULE,
+          ],
+        },
+      });
 
       const sessionDetails =
         await sessionMeeClient.grantPermissionTypedDataSign({
@@ -358,6 +431,12 @@ describe("mee.multichainSmartSessions", () => {
               actionPolicies: [getSudoPolicy()],
               chainId: paymentChain.id,
               actionTarget: COUNTER_ON_OPTIMISM
+            },
+            {
+              actionTargetSelector: toFunctionSelector(getAbiItem({ abi: erc20Abi, name: "transfer" })),
+              actionPolicies: [uniActionPolicyInfo],
+              chainId: targetChain.id,
+              actionTarget: mcUSDC.addressOn(targetChain.id)
             }
           ],
           maxPaymentAmount: parseUnits("3", 6)
@@ -410,6 +489,19 @@ describe("mee.multichainSmartSessions", () => {
               }
             ],
             chainId: paymentChain.id
+          },
+          {
+            calls: [
+              {
+                to: mcUSDC.addressOn(targetChain.id),
+                data: encodeFunctionData({
+                  abi: erc20Abi,
+                  functionName: "transfer",
+                  args: [redeemerAddress, parseUnits("0.01", 6)]
+                })
+              }
+            ],
+            chainId: targetChain.id
           }
         ],
         feeToken,
@@ -425,10 +517,20 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
+
+      console.log(receipt.explorerLinks)
+
+      const redeemerUSDCBalanceAfter = await publicClient.readContract({
+        address: mcUSDC.addressOn(targetChain.id),
+        abi: erc20Abi,
+        functionName: "balanceOf",
+        args: [redeemerAddress]
+      })
+      expect(redeemerUSDCBalanceAfter).toBe(redeemerUSDCBalanceBefore + parseUnits("0.01", 6))
     }
   )
 
-  test.runIf(runPaidTests)(
+  test.runIf(runPaidTests).skip(
     "should grant and use multichain permissions with sponsorship",
     async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -3,6 +3,7 @@ import type { Address, Chain, LocalAccount, Transport } from "viem"
 import {
   http,
   createPublicClient,
+  createWalletClient,
   encodeFunctionData,
   erc20Abi,
   getAbiItem,
@@ -114,6 +115,19 @@ describe("mee.multichainSmartSessions", () => {
       apiKey: "mee_3Zmc7H6Pbd5wUfUGu27aGzdf"
     })
     smartSessionsValidator = toSmartSessionsModule({ signer: mcNexus.signer })
+
+    // send some USDC from eoaAccount to mcNexus on target chain
+    const eoaWalletClient = createWalletClient({
+      chain: targetChain,
+      transport: targetChainTransport,
+      account: eoaAccount
+    })
+    await eoaWalletClient.writeContract({
+      address: mcUSDC.addressOn(targetChain.id),
+      abi: erc20Abi,
+      functionName: "transfer",
+      args: [mcNexus.addressOn(targetChain.id, true), parseUnits("0.011", 6)]
+    })
   })
 
   test.runIf(runPaidTests)(
@@ -124,7 +138,7 @@ describe("mee.multichainSmartSessions", () => {
       // if tests fail, increase the amount
       const transferToNexusTrigger = {
         tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Optimism chain
-        amount: parseUnits("0.3", 6), // so Nexus is able to pay for the next SuperTxns
+        amount: parseUnits("0.5", 6), // so Nexus is able to pay for the next SuperTxns
         chainId: paymentChain.id // Which chain this trigger executes on
       }
 
@@ -222,9 +236,9 @@ describe("mee.multichainSmartSessions", () => {
     }
   )
 
-  test
-    .runIf(runPaidTests)
-    .skip("should grant and use multichain permissions for the account that is already deployed on all chains", async () => {
+  test.runIf(runPaidTests)(
+    "should grant and use multichain permissions for the account that is already deployed on all chains",
+    async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       // ======== At this point the Nexus SA is already deployed and SS is installed ==============
@@ -327,7 +341,8 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
-    })
+    }
+  )
 
   test.runIf(runPaidTests)(
     "should grant and use permission with custom verification gas limit and universal action policy",
@@ -353,7 +368,7 @@ describe("mee.multichainSmartSessions", () => {
         usage: { limit: 0n, used: 0n }
       }
 
-      const uniActionPolicyInfo = getUniversalActionPolicy({
+      const uniActionPolicyInfoUSDC = getUniversalActionPolicy({
         valueLimitPerUse: maxUint256,
         paramRules: {
           length: 2n,
@@ -433,7 +448,7 @@ describe("mee.multichainSmartSessions", () => {
               actionTargetSelector: toFunctionSelector(
                 getAbiItem({ abi: erc20Abi, name: "transfer" })
               ),
-              actionPolicies: [uniActionPolicyInfo],
+              actionPolicies: [uniActionPolicyInfoUSDC],
               chainId: targetChain.id,
               actionTarget: mcUSDC.addressOn(targetChain.id)
             }
@@ -489,6 +504,9 @@ describe("mee.multichainSmartSessions", () => {
             ],
             chainId: paymentChain.id
           },
+          // transfer USDC from from orchestrator to redeemer on target chain
+          // this is to test that the action policy via universal action policy
+          // is created successfully
           {
             calls: [
               {
@@ -517,23 +535,22 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.logs).toBeDefined()
       }
 
-      console.log(receipt.explorerLinks)
-
       const redeemerUSDCBalanceAfter = await publicClient.readContract({
         address: mcUSDC.addressOn(targetChain.id),
         abi: erc20Abi,
         functionName: "balanceOf",
         args: [redeemerAddress]
       })
+
       expect(redeemerUSDCBalanceAfter).toBe(
         redeemerUSDCBalanceBefore + parseUnits("0.01", 6)
       )
     }
   )
 
-  test
-    .runIf(runPaidTests)
-    .skip("should grant and use multichain permissions with sponsorship", async () => {
+  test.runIf(runPaidTests)(
+    "should grant and use multichain permissions with sponsorship",
+    async () => {
       const sessionMeeClient = meeClient.extend(meeSessionActions)
 
       const prepareForPermissionsPayload =
@@ -626,5 +643,6 @@ describe("mee.multichainSmartSessions", () => {
       })
 
       expect(receipt.transactionStatus).toBe("MINED_SUCCESS")
-    })
+    }
+  )
 })

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     testTimeout: 500_000,
     hookTimeout: 250_000,
     fileParallelism: false,
-    retry: 2
+    retry: 0
   }
 })

--- a/src/test/vitest.config.ts
+++ b/src/test/vitest.config.ts
@@ -29,6 +29,6 @@ export default defineConfig({
     testTimeout: 500_000,
     hookTimeout: 250_000,
     fileParallelism: false,
-    retry: 0
+    retry: 2
   }
 })


### PR DESCRIPTION
- add tests to showcase using Universal Action Policy
- throw when a permission defines an action policy for the feeToken.transfer => causes conflicts

<!-- start pr-codex -->

---

## PR-Codex overview
This PR enhances the `grantMeePermission` function and related tests to improve error handling and introduce a new `ParamCondition` enum for better parameter management. It also refines user operation handling in the `useMeePermission` logic.

### Detailed summary
- Added `getAbiItem` and `toFunctionSelector` imports in `grantMeePermission.ts`.
- Refactored payment action policy creation with error handling for duplicate fee token actions.
- Enhanced user operation processing logic in `useMeePermission.ts` to prevent multiple ENABLE modes for the same chain.
- Introduced `ParamCondition` enum in `toMultichainSmartSessions.test.ts` for clearer parameter conditions.
- Updated tests to include a new universal action policy and validate USDC transfers correctly.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->