### PR TITLE
feat: add functions to check for enabled permissions

### DIFF
--- a/src/sdk/modules/validators/smartSessions/decorators/mee/index.ts
+++ b/src/sdk/modules/validators/smartSessions/decorators/mee/index.ts
@@ -1,4 +1,6 @@
+import type { PublicClient } from "viem"
 import type { BaseMeeClient } from "../../../../../clients/createMeeClient"
+import { SMART_SESSIONS_ADDRESS } from "../../../../../constants"
 import type { ModularSmartAccount } from "../../../../utils/Types"
 import {
   type GrantMeePermissionParams,
@@ -37,6 +39,10 @@ export type MeeSessionActions = {
   usePermission: (
     params: UseMeePermissionParams
   ) => Promise<UseMeePermissionPayload>
+  isPermissionEnabled: (params: IsPermissionEnabledParams) => Promise<boolean>
+  checkEnabledPermissions: (
+    params: GrantMeePermissionPayload
+  ) => Promise<CheckEnabledPermissionsPayload>
 }
 
 /**
@@ -57,7 +63,11 @@ export const meeSessionActions = (
       params: GrantMeePermissionParams<ModularSmartAccount>
     ) => grantMeePermissionTypedDataSign(meeClient, params),
     usePermission: (params: UseMeePermissionParams) =>
-      useMeePermission(meeClient, params)
+      useMeePermission(meeClient, params),
+    isPermissionEnabled: (params: IsPermissionEnabledParams) =>
+      isPermissionEnabled(meeClient, params),
+    checkEnabledPermissions: (params: GrantMeePermissionPayload) =>
+      checkEnabledPermissions(meeClient, params)
   }
 }
 
@@ -67,3 +77,97 @@ export {
 } from "./grantMeePermission"
 export { useMeePermission } from "./useMeePermission"
 export { prepareForPermissions } from "./prepareForPermissions"
+
+/**
+ * Input parameters for the isPermissionEnabled function
+ * @param permissionId - The permission ID to check
+ * @param chainId - The chain ID to check the permission on
+ */
+export type IsPermissionEnabledParams = {
+  permissionId: `0x${string}`
+  chainId: number
+}
+
+/**
+ * Checks if a permission is enabled for a given chain for this MEE client
+ * assumes the PermissionId is known
+ * @param meeClient - The MEE client
+ * @param params - The parameters for the isPermissionEnabled function
+ * @returns The result of the call to SmartSessions.isPermissionEnabled function
+ */
+export const isPermissionEnabled = async (
+  meeClient: BaseMeeClient,
+  params: IsPermissionEnabledParams
+): Promise<boolean> => {
+  const deployment = meeClient.account.deploymentOn(params.chainId, true)
+  const chainClient = deployment.client as PublicClient
+  return await chainClient.readContract({
+    address: SMART_SESSIONS_ADDRESS,
+    abi: [
+      {
+        inputs: [
+          {
+            name: "permissionId",
+            type: "bytes32",
+            internalType: "PermissionId"
+          },
+          { name: "account", type: "address", internalType: "address" }
+        ],
+        name: "isPermissionEnabled",
+        outputs: [{ name: "", type: "bool", internalType: "bool" }],
+        stateMutability: "view",
+        type: "function"
+      }
+    ],
+    functionName: "isPermissionEnabled",
+    args: [params.permissionId, deployment.address]
+  })
+}
+
+/**
+ * Output payload for the checkEnabledPermission function
+ * It is a mapping of permissionId => chainId => isEnabled
+ */
+export type CheckEnabledPermissionsPayload = {
+  [permissionId: `0x${string}`]: {
+    [chainId: number]: boolean
+  }
+}
+
+/**
+ * For all the permissions from the grantMeePermissionPayload,
+ * checks if they are enabled or not.
+ * Facilitates checking the whole return object of the grantMeePermission function.
+ * So the developer doesn't need to parse and know permissionId(s) for each chain.
+ * Detects the permissions that were expected to be enabled on each chain
+ * and checks if they are enabled or not.
+ * @param meeClient - The MEE client
+ * @param params - The return data of the grantMeePermission function
+ * @returns A mapping of permissionId => chainId => isEnabled
+ */
+export const checkEnabledPermissions = async (
+  meeClient: BaseMeeClient,
+  params: GrantMeePermissionPayload
+): Promise<CheckEnabledPermissionsPayload> => {
+  const enabledPermissions = await Promise.all(
+    params.map(async (permission) => {
+      const chainId = Number(
+        permission.enableSessionData.enableSession.sessionToEnable.chainId
+      )
+      return {
+        permissionId: permission.permissionId,
+        chainId,
+        enabled: await isPermissionEnabled(meeClient, {
+          permissionId: permission.permissionId,
+          chainId
+        })
+      }
+    })
+  )
+  return enabledPermissions.reduce((acc, permission) => {
+    acc[permission.permissionId] = {
+      [permission.chainId]: permission.enabled
+    }
+    return acc
+  }, {} as CheckEnabledPermissionsPayload)
+}

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -141,7 +141,7 @@ describe("mee.multichainSmartSessions", () => {
       // if tests fail, increase the amount
       const transferToNexusTrigger = {
         tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Optimism chain
-        amount: parseUnits("0.2", 6), // so Nexus is able to pay for the next SuperTxns
+        amount: parseUnits("0.5", 6), // so Nexus is able to pay for the next SuperTxns
         chainId: paymentChain.id // Which chain this trigger executes on
       }
 

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -39,6 +39,7 @@ import { getMEEVersion } from "../../utils"
 import type { AnyData } from "../../utils/Types"
 import type { Validator } from "../toValidator"
 import { meeSessionActions } from "./decorators/mee"
+import type { GrantMeePermissionPayload } from "./decorators/mee/grantMeePermission"
 import { toSmartSessionsModule } from "./toSmartSessionsModule"
 
 // @ts-ignore
@@ -76,6 +77,8 @@ describe("mee.multichainSmartSessions", () => {
   let smartSessionsValidator: Validator
 
   let feeToken: FeeTokenInfo
+
+  let grantMeePermissionPayload: GrantMeePermissionPayload
 
   beforeAll(async () => {
     network = await toNetwork("MAINNET_FROM_ENV_VARS")
@@ -138,7 +141,7 @@ describe("mee.multichainSmartSessions", () => {
       // if tests fail, increase the amount
       const transferToNexusTrigger = {
         tokenAddress: mcUSDC.addressOn(paymentChain.id), // The USDC token address on Optimism chain
-        amount: parseUnits("0.5", 6), // so Nexus is able to pay for the next SuperTxns
+        amount: parseUnits("0.2", 6), // so Nexus is able to pay for the next SuperTxns
         chainId: paymentChain.id // Which chain this trigger executes on
       }
 
@@ -341,6 +344,67 @@ describe("mee.multichainSmartSessions", () => {
         expect(receipt_.status).toBe("success")
         expect(receipt_.logs).toBeDefined()
       }
+
+      grantMeePermissionPayload = sessionDetails
+    }
+  )
+
+  test.runIf(runPaidTests)(
+    "should check if the permissions are enabled",
+    async () => {
+      const sessionMeeClient = meeClient.extend(meeSessionActions)
+
+      const expectedEnabledPermissionsOnChains = grantMeePermissionPayload.map(
+        (permission) => {
+          return {
+            permissionId: permission.permissionId,
+            chainId: Number(
+              permission.enableSessionData.enableSession.sessionToEnable.chainId
+            )
+          }
+        }
+      )
+
+      for (const permissionOnChain of expectedEnabledPermissionsOnChains) {
+        const isEnabled = await sessionMeeClient.isPermissionEnabled({
+          permissionId: permissionOnChain.permissionId,
+          chainId: permissionOnChain.chainId
+        })
+        expect(isEnabled).toBe(true)
+      }
+
+      const enabledPermissionsReturn =
+        await sessionMeeClient.checkEnabledPermissions(
+          grantMeePermissionPayload
+        )
+
+      for (const permissionOnChain of expectedEnabledPermissionsOnChains) {
+        expect(
+          enabledPermissionsReturn[permissionOnChain.permissionId][
+            permissionOnChain.chainId
+          ]
+        ).toBe(true)
+      }
+
+      const invalidChainId = expectedEnabledPermissionsOnChains[1].chainId
+      expect(invalidChainId).not.toBe(
+        expectedEnabledPermissionsOnChains[0].chainId
+      )
+      expect(
+        sessionMeeClient.account.deploymentOn(invalidChainId, false)
+      ).toBeDefined()
+      let isEnabled = await sessionMeeClient.isPermissionEnabled({
+        permissionId: expectedEnabledPermissionsOnChains[0].permissionId,
+        chainId: invalidChainId
+      })
+      expect(isEnabled).toBe(false)
+
+      const invalidPermissionId = `0x${(BigInt(expectedEnabledPermissionsOnChains[0].permissionId) + 1n).toString(16).padStart(64, "0")}`
+      isEnabled = await sessionMeeClient.isPermissionEnabled({
+        permissionId: invalidPermissionId as `0x${string}`,
+        chainId: expectedEnabledPermissionsOnChains[0].chainId
+      })
+      expect(isEnabled).toBe(false)
     }
   )
 


### PR DESCRIPTION
- meeClient.isPermissionEnabled : checks for a given permission
- meeClient.checkEnabledPermissions : checks the whole grantMeePermission payload

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces functionality to check permission statuses for smart sessions in a multichain context. It adds new methods to validate if permissions are enabled and to check enabled permissions based on a payload.

### Detailed summary
- Added `GrantMeePermissionPayload` type to the test file.
- Introduced `isPermissionEnabled` and `checkEnabledPermissions` methods in `meeSessionActions`.
- Implemented logic to verify permissions in the test suite for smart sessions.
- Enhanced the `isPermissionEnabled` function to interact with the smart contract.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->