### PR TITLE
feat: relayer fee check change

### DIFF
--- a/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
@@ -240,7 +240,7 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
       data: {
         recipient: eoaAccount.address,
         tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
-        amount: parseUnits("100", 6),
+        amount: 0n,
         chainId: chain.id
       }
     })
@@ -248,9 +248,12 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
     await expect(
       meeClient.getQuote({
         instructions: [...transferInstruction],
+        simulation: {
+          simulate: true,
+        },
         feeToken
       })
-    ).rejects.toThrow("Insufficient funds for relayer fees")
+    ).rejects.toThrowError(/^Insufficient funds for relayer fees/);
   })
 
   test("should throw an error if there are insufficient funds for the trigger amount in fusion mode", async () => {

--- a/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
@@ -253,7 +253,9 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
         },
         feeToken
       })
-    ).rejects.toThrowError(/^Insufficient funds for relayer fees/)
+    ).rejects.toThrowError(
+      /^Insufficient balance to pay for the gas & orchestration fees/
+    )
   })
 
   test("should throw an error if there are insufficient funds for the trigger amount in fusion mode", async () => {

--- a/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
@@ -249,11 +249,11 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
       meeClient.getQuote({
         instructions: [...transferInstruction],
         simulation: {
-          simulate: true,
+          simulate: true
         },
         feeToken
       })
-    ).rejects.toThrowError(/^Insufficient funds for relayer fees/);
+    ).rejects.toThrowError(/^Insufficient funds for relayer fees/)
   })
 
   test("should throw an error if there are insufficient funds for the trigger amount in fusion mode", async () => {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on updating the `getQuoteSimulations` test to handle a simulation scenario and improve error messaging related to insufficient funds.

### Detailed summary
- Changed `amount` from `parseUnits("100", 6)` to `0n`.
- Added a `simulation` object with `simulate: true` to the `getQuote` call.
- Updated the error message expectation from "Insufficient funds for relayer fees" to a regex for "Insufficient balance to pay for the gas & orchestration fees".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->