### PR TITLE
feat: added multichain account address overrides

### DIFF
--- a/src/sdk/account/decorators/instructions/buildApprove.test.ts
+++ b/src/sdk/account/decorators/instructions/buildApprove.test.ts
@@ -60,7 +60,14 @@ describe("mee.buildApprove", () => {
 
   it("should build an approval instruction", async () => {
     const instructions: Instruction[] = await buildApprove(
-      { accountAddress: mcNexus.signer.address, currentInstructions: [] },
+      {
+        accountAddress: mcNexus.signer.address,
+        currentInstructions: [],
+        meeVersions: mcNexus.deployments.map((dep) => ({
+          version: dep.version,
+          chainId: dep.chain.id
+        }))
+      },
       {
         chainId: targetChain.id,
         tokenAddress,

--- a/src/sdk/account/toNexusAccount.addresses.test.ts
+++ b/src/sdk/account/toNexusAccount.addresses.test.ts
@@ -78,12 +78,12 @@ describe("nexus.account.addresses", async () => {
       "0xf0479e036343bC66dc49dd374aFAF98402D0Ae5f"
 
     const newNexusAccount = await toNexusAccount({
-      accountAddress: someoneElsesNexusAddress,
       signer: eoaAccount,
       chainConfiguration: {
         chain,
         transport: http(network.rpcUrl),
-        version: getMEEVersion(MEEVersion.V1_0_0)
+        version: getMEEVersion(MEEVersion.V1_0_0),
+        accountAddress: someoneElsesNexusAddress
       }
     })
 

--- a/src/sdk/account/toNexusAccount.ts
+++ b/src/sdk/account/toNexusAccount.ts
@@ -133,6 +133,8 @@ export type ChainConfiguration = {
   transport: ClientConfig["transport"]
   /** MEE version config */
   version: MEEVersionConfig
+  /** Optional account address override */
+  accountAddress?: Address
   /**
    * Flag to enable/disable MEE Version check. Defaults to true.
    * Only set this as false if you're very sure about MEE version support on specific chains otherwise SDK will
@@ -156,8 +158,6 @@ export type ToNexusSmartAccountParameters = {
   chainConfiguration: ChainConfiguration
   /** Optional index for the account */
   index?: bigint | undefined
-  /** Optional account address override */
-  accountAddress?: Address
   /** Optional validator modules configuration */
   validators?: Array<Validator>
   /** Optional executor modules configuration */
@@ -469,7 +469,8 @@ export const toNexusAccount = async (
       chain,
       version: meeConfig,
       transport: transportConfig,
-      versionCheck = true
+      versionCheck = true,
+      accountAddress: accountAddress_
     },
     index = 0n,
     validators: customValidators,
@@ -477,7 +478,6 @@ export const toNexusAccount = async (
     hook: customHook,
     fallbacks: customFallbacks,
     prevalidationHooks: customPrevalidationHooks,
-    accountAddress: accountAddress_,
     initData: customInitData
   } = parameters
 

--- a/src/sdk/clients/createMeeClient.test.ts
+++ b/src/sdk/clients/createMeeClient.test.ts
@@ -378,12 +378,12 @@ describe("mee.createMeeClient.delegated", async () => {
   beforeAll(async () => {
     mcNexus = await toMultichainNexusAccount({
       signer: eoaAccount,
-      accountAddress: eoaAccount.address,
       chainConfigurations: [
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(DEFAULT_MEE_VERSION)
+          version: getMEEVersion(DEFAULT_MEE_VERSION),
+          accountAddress: eoaAccount.address
         }
       ]
     })

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -773,12 +773,12 @@ describe("mee.getQuote", () => {
       const mcNexus = await toMultichainNexusAccount({
         signer: eoaAccount,
         index: BigInt(getRandomAccountIndex(1000, 1000000000)),
-        accountAddress: eoaAccount.address,
         chainConfigurations: [
           {
             chain: baseSepolia,
             transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-            version: getMEEVersion(DEFAULT_MEE_VERSION)
+            version: getMEEVersion(DEFAULT_MEE_VERSION),
+            accountAddress: eoaAccount.address
           }
         ]
       })
@@ -1266,15 +1266,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
@@ -1382,15 +1383,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
@@ -1498,15 +1500,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version: baseSepoliaMcNexusVersion } = mcNexus.deploymentOn(
@@ -1587,15 +1590,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
@@ -1680,15 +1684,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: newEoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: newEoaAccount.address
         }
-      ],
-      accountAddress: newEoaAccount.address
+      ]
     })
 
     const { publicClient } = mcNexus.deploymentOn(optimismSepolia.id, true)
@@ -1792,15 +1797,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
@@ -1864,15 +1870,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
@@ -1944,15 +1951,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
@@ -2022,10 +2030,10 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
@@ -2079,15 +2087,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
@@ -2140,15 +2149,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const { version } = mcNexus.deploymentOn(baseSepolia.id, true)
@@ -2208,15 +2218,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     let isDelegated = await mcNexus.isDelegated()
@@ -2318,15 +2329,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     let isDelegated = await mcNexus.isDelegated()
@@ -2416,15 +2428,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     let isDelegated = await mcNexus.isDelegated()
@@ -2506,15 +2519,16 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     let isDelegated = await mcNexus.isDelegated()
@@ -2574,6 +2588,36 @@ describe("mee.getQuote", () => {
     isDelegated = await mcNexus.isDelegated()
 
     expect(isDelegated).toBe(true)
+  })
+
+  test("Multichain accountAddress overrides for EIP 7702 Auth", async () => {
+    const randomAddressOne = privateKeyToAccount(generatePrivateKey())
+    const randomAddressTwo = privateKeyToAccount(generatePrivateKey())
+
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: baseSepolia,
+          transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: randomAddressOne.address
+        },
+        {
+          chain: optimismSepolia,
+          transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: randomAddressTwo.address
+        }
+      ]
+    })
+
+    expect(mcNexus.addressOn(baseSepolia.id, true)).to.eq(
+      randomAddressOne.address
+    )
+    expect(mcNexus.addressOn(optimismSepolia.id, true)).to.eq(
+      randomAddressTwo.address
+    )
   })
 
   test("Should include gasRefundAddress in quote payment info if configured in feeToken", async () => {

--- a/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
@@ -780,11 +780,11 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
         {
           chain: chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          // Overriden with EOA address
+          accountAddress: eoaAccount.address
         }
-      ],
-      // Overriden with EOA address
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const meeClient = await createMeeClient({
@@ -821,10 +821,10 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
         {
           chain: chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          accountAddress: eoaAccount.address
         }
-      ],
-      accountAddress: eoaAccount.address
+      ]
     })
 
     const meeClient = await createMeeClient({
@@ -1237,10 +1237,10 @@ describe.runIf(runLifecycleTests)(
             {
               chain: chain,
               transport: http(network.rpcUrl),
-              version: getMEEVersion(DEFAULT_MEE_VERSION)
+              version: getMEEVersion(DEFAULT_MEE_VERSION),
+              accountAddress: mcNexus.addressOn(chain.id)!
             }
           ],
-          accountAddress: mcNexus.addressOn(chain.id)!,
           signer: sessionSigner
         })
 

--- a/src/sdk/clients/decorators/mee/upgradeSmartAccount.test.ts
+++ b/src/sdk/clients/decorators/mee/upgradeSmartAccount.test.ts
@@ -195,12 +195,12 @@ describe("mee.upgradeSmartAccount", () => {
         {
           chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_0_0)
+          version: getMEEVersion(MEEVersion.V2_0_0),
+          // Old nexus address is overriden here
+          accountAddress: mcNexus1_0_0Address
         }
       ],
-      index: accountIndex,
-      // Old nexus address is overriden here
-      accountAddress: mcNexus1_0_0Address
+      index: accountIndex
     })
 
     const { getNonceWithKey, version: mcNexus2_0_0Version } =
@@ -244,12 +244,12 @@ describe("mee.upgradeSmartAccount", () => {
         {
           chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getMEEVersion(MEEVersion.V2_1_0),
+          // Old nexus address is overriden here
+          accountAddress: mcNexus1_0_0Address
         }
       ],
-      index: accountIndex,
-      // Old nexus address is overriden here
-      accountAddress: mcNexus1_0_0Address
+      index: accountIndex
     })
 
     const { getNonceWithKey, version: mcNexus2_1_0Version } =

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -284,18 +284,19 @@ describe("mee.multichainSmartSessions", () => {
       // with the redeemer account (which is Session Key) as signer
       // this would be a common pattern for signing userOps with a session key
       const dappNexusAccount = await toMultichainNexusAccount({
-        accountAddress: mcNexus.addressOn(paymentChain.id),
         signer: redeemerAccount,
         chainConfigurations: [
           {
             chain: paymentChain,
             transport: paymentChainTransport,
-            version: getMEEVersion(DEFAULT_MEE_VERSION)
+            version: getMEEVersion(DEFAULT_MEE_VERSION),
+            accountAddress: mcNexus.addressOn(paymentChain.id)
           },
           {
             chain: targetChain,
             transport: targetChainTransport,
-            version: getMEEVersion(DEFAULT_MEE_VERSION)
+            version: getMEEVersion(DEFAULT_MEE_VERSION),
+            accountAddress: mcNexus.addressOn(targetChain.id)
           }
         ]
       })
@@ -529,18 +530,19 @@ describe("mee.multichainSmartSessions", () => {
         })
 
       const dappNexusAccount = await toMultichainNexusAccount({
-        accountAddress: mcNexus.addressOn(paymentChain.id),
         signer: redeemerAccount,
         chainConfigurations: [
           {
             chain: paymentChain,
             transport: paymentChainTransport,
-            version: getMEEVersion(DEFAULT_MEE_VERSION)
+            version: getMEEVersion(DEFAULT_MEE_VERSION),
+            accountAddress: mcNexus.addressOn(paymentChain.id)
           },
           {
             chain: targetChain,
             transport: targetChainTransport,
-            version: getMEEVersion(DEFAULT_MEE_VERSION)
+            version: getMEEVersion(DEFAULT_MEE_VERSION),
+            accountAddress: mcNexus.addressOn(targetChain.id)
           }
         ]
       })
@@ -686,17 +688,18 @@ describe("mee.multichainSmartSessions", () => {
       )
 
       const dappNexusAccount = await toMultichainNexusAccount({
-        accountAddress: mcNexus.addressOn(paymentChain.id),
         chainConfigurations: [
           {
             chain: paymentChain,
             transport: paymentChainTransport,
-            version: getMEEVersion(DEFAULT_MEE_VERSION)
+            version: getMEEVersion(DEFAULT_MEE_VERSION),
+            accountAddress: mcNexus.addressOn(paymentChain.id)
           },
           {
             chain: targetChain,
             transport: targetChainTransport,
-            version: getMEEVersion(DEFAULT_MEE_VERSION)
+            version: getMEEVersion(DEFAULT_MEE_VERSION),
+            accountAddress: mcNexus.addressOn(targetChain.id)
           }
         ],
         signer: redeemerAccount

--- a/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toSmartSessionsModule.test.ts
@@ -197,12 +197,12 @@ describe("modules.toSmartSessionsModule", () => {
     })
 
     const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
       signer: redeemerAccount,
       chainConfiguration: {
         chain,
         transport: http(infra.network.rpcUrl),
-        version: getMEEVersion(DEFAULT_MEE_VERSION)
+        version: getMEEVersion(DEFAULT_MEE_VERSION),
+        accountAddress: nexusAccount.address
       }
     })
 
@@ -251,12 +251,12 @@ describe("modules.toSmartSessionsModule", () => {
     })
 
     const emulatedAccount = await toNexusAccount({
-      accountAddress: secondChainNexusAccount.address,
       signer: redeemerAccount,
       chainConfiguration: {
         chain: secondChain,
         transport: http(secondInfra.network.rpcUrl),
-        version: getMEEVersion(DEFAULT_MEE_VERSION)
+        version: getMEEVersion(DEFAULT_MEE_VERSION),
+        accountAddress: secondChainNexusAccount.address
       }
     })
 
@@ -298,12 +298,12 @@ describe("modules.toSmartSessionsModule", () => {
 
   test("use a permission with typed data sign a second time", async () => {
     const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
       signer: redeemerAccount,
       chainConfiguration: {
         chain,
         transport: http(infra.network.rpcUrl),
-        version: getMEEVersion(DEFAULT_MEE_VERSION)
+        version: getMEEVersion(DEFAULT_MEE_VERSION),
+        accountAddress: nexusAccount.address
       }
     })
 
@@ -368,12 +368,12 @@ describe("modules.toSmartSessionsModule", () => {
 
   test("use a permission", async () => {
     const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
       signer: redeemerAccount,
       chainConfiguration: {
         chain,
         transport: http(infra.network.rpcUrl),
-        version: getMEEVersion(DEFAULT_MEE_VERSION)
+        version: getMEEVersion(DEFAULT_MEE_VERSION),
+        accountAddress: nexusAccount.address
       }
     })
 
@@ -407,12 +407,12 @@ describe("modules.toSmartSessionsModule", () => {
 
   test("use a second permission on the same chain should work with index", async () => {
     const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
       signer: redeemerAccount,
       chainConfiguration: {
         chain,
         transport: http(infra.network.rpcUrl),
-        version: getMEEVersion(DEFAULT_MEE_VERSION)
+        version: getMEEVersion(DEFAULT_MEE_VERSION),
+        accountAddress: nexusAccount.address
       }
     })
 
@@ -447,12 +447,12 @@ describe("modules.toSmartSessionsModule", () => {
 
   test("use a permission a second time", async () => {
     const emulatedAccount = await toNexusAccount({
-      accountAddress: nexusAccount.address,
       signer: redeemerAccount,
       chainConfiguration: {
         chain,
         transport: http(infra.network.rpcUrl),
-        version: getMEEVersion(DEFAULT_MEE_VERSION)
+        version: getMEEVersion(DEFAULT_MEE_VERSION),
+        accountAddress: nexusAccount.address
       }
     })
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing the `accountAddress` handling across various functions in the SDK, allowing for optional overrides and ensuring consistency in how account addresses are passed to different methods.

### Detailed summary
- Added `accountAddress` parameter in multiple function calls across tests.
- Updated `toNexusAccount` and `toMultichainNexusAccount` to accept optional `accountAddress` overrides.
- Modified test cases to utilize the new `accountAddress` parameter.
- Ensured consistency in handling `accountAddress` across different chain configurations.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->