### PR TITLE
feat: enhanced Permit flow with onchain mode fallback

### DIFF
--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -383,7 +383,7 @@ describe.runIf(runLifecycleTests)("mee.getPermitQuote", () => {
 
     if (fallbackToOnchainMode) {
       // This always fails here. This is being coded like this to avoid type issues
-      expect(fallbackToOnchainMode).to.be.eq(false)
+      expect(fallbackToOnchainMode).toBe(false)
       return
     }
 

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -378,7 +378,15 @@ describe.runIf(runLifecycleTests)("mee.getPermitQuote", () => {
     // The final amount should be the total balance
     expect(fusionQuote.trigger.amount).toBe(maxAvailableBalance)
 
-    const signedQuote = await signPermitQuote(meeClient, { fusionQuote }) // Permit with 20k
+    const { fallbackToOnchainMode, signedPermitQuotePayload: signedQuote } =
+      await signPermitQuote(meeClient, { fusionQuote }) // Permit with 20k
+
+    if (fallbackToOnchainMode) {
+      // This always fails here. This is being coded like this to avoid type issues
+      expect(fallbackToOnchainMode).to.be.eq(false)
+      return
+    }
+
     const { hash } = await executeSignedQuote(meeClient, { signedQuote })
 
     const receipt = await waitForSupertransactionReceipt(meeClient, {
@@ -419,7 +427,15 @@ describe.runIf(runLifecycleTests)("mee.getPermitQuote", () => {
       feeToken
     })
 
-    const signedQuote = await signPermitQuote(meeClient, { fusionQuote }) // Permit with 20k
+    const { fallbackToOnchainMode, signedPermitQuotePayload: signedQuote } =
+      await signPermitQuote(meeClient, { fusionQuote }) // Permit with 20k
+
+    if (fallbackToOnchainMode) {
+      // This always fails here. This is being coded like this to avoid type issues
+      expect(fallbackToOnchainMode).to.be.eq(false)
+      return
+    }
+
     const { hash } = await executeSignedQuote(meeClient, { signedQuote })
 
     const receipt = await waitForSupertransactionReceipt(meeClient, { hash })

--- a/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
@@ -29,7 +29,6 @@ import {
   zeroAddress
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
-import { getStorageAt } from "viem/actions"
 import { baseSepolia, optimismSepolia } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import type { FeeTokenInfo, Instruction } from "."

--- a/src/sdk/clients/decorators/mee/getQuoteType.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.test.ts
@@ -3,7 +3,8 @@ import {
   type Chain,
   type LocalAccount,
   type WalletClient,
-  createWalletClient
+  createWalletClient,
+  zeroAddress
 } from "viem"
 import { beforeAll, describe, expect, test } from "vitest"
 import type { GetFusionQuoteParams, GetQuoteParams } from "."
@@ -233,5 +234,32 @@ describe("mee.getQuoteType", () => {
       const isPermit = await isPermitTokenInfo(meeClient, trigger)
       expect(isPermit).to.be.false
     })
+  })
+
+  test("Should get a fallback onchain mode quote type for invalid permit quote payload", async () => {
+    const transferInstruction = await mcNexus.buildComposable({
+      type: "transfer",
+      data: {
+        recipient: eoaAccount.address,
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        amount: 1n,
+        chainId: chain.id
+      }
+    })
+
+    const quote = await meeClient.getFusionQuote({
+      trigger: {
+        tokenAddress: zeroAddress,
+        chainId: chain.id,
+        amount: 1n
+      },
+      instructions: [...transferInstruction],
+      feeToken: {
+        chainId: chain.id,
+        address: testnetMcTestUSDCP.addressOn(chain.id)
+      }
+    })
+
+    expect(await getQuoteType(meeClient, quote)).to.eq("onchain")
   })
 })

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -6,9 +6,9 @@ import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { GetQuoteParams, GetQuotePayload } from "./getQuote"
 import { getSupportedFeeToken } from "./getSupportedFeeToken"
 import {
-  prepareSignablePermitQuotePayload,
   type TokenTrigger,
-  type Trigger
+  type Trigger,
+  prepareSignablePermitQuotePayload
 } from "./signPermitQuote"
 
 export type QuoteType = "simple" | "onchain" | "permit" | "mm-dtk"

--- a/src/sdk/clients/decorators/mee/getQuoteType.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteType.ts
@@ -5,7 +5,11 @@ import type { GetOnChainQuotePayload } from "./getOnChainQuote"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { GetQuoteParams, GetQuotePayload } from "./getQuote"
 import { getSupportedFeeToken } from "./getSupportedFeeToken"
-import type { TokenTrigger, Trigger } from "./signPermitQuote"
+import {
+  prepareSignablePermitQuotePayload,
+  type TokenTrigger,
+  type Trigger
+} from "./signPermitQuote"
 
 export type QuoteType = "simple" | "onchain" | "permit" | "mm-dtk"
 
@@ -55,20 +59,48 @@ const isPermitQuote = async (
   if ("call" in trigger) {
     return false
   }
-  // after this point, trigger can only be of type TokenTrigger
-  const permitEnabled = await isPermitTokenInfo(
-    client,
-    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
-  )
 
-  // If permit is enabled, it is a permit quote
-  return permitEnabled
+  const { walletClient, address: spender } = client.account.deploymentOn(
+    trigger.chainId,
+    true
+  )
+  const owner = client.account.signer.address
+
+  // This is a dummy quote payload to get the permit token fallback to onchain mode state.
+  const dummyQuotePayload = {
+    ...payload,
+    quote: {
+      hash: "0xffff" // Dummy sprtxHash
+    }
+  } as GetPermitQuotePayload
+
+  // after this point, trigger can only be of type TokenTrigger
+  try {
+    const [permitEnabled, { fallbackToOnchainMode }] = await Promise.all([
+      isPermitTokenInfo(
+        client,
+        trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
+      ),
+      prepareSignablePermitQuotePayload(
+        dummyQuotePayload,
+        owner,
+        spender,
+        walletClient
+      )
+    ])
+
+    // If fallbackToOnchainMode is true, then permit flow has some issues and we avoid using permit mode.
+    if (fallbackToOnchainMode) return false
+
+    // If permit is enabled, it is a permit quote
+    return permitEnabled
+  } catch {
+    // If there is any error in detecting the permit support, the flow will fallback to onchain mode
+    return false
+  }
 }
 
-const isOnChainQuote = async (
-  client: BaseMeeClient,
-  payload: AnyData
-): Promise<boolean> => {
+const isOnChainQuote = async (payload: AnyData): Promise<boolean> => {
   const isTriggerAvailable = "trigger" in payload
 
   // If trigger is not available, it is not considered as on chain quote
@@ -81,13 +113,9 @@ const isOnChainQuote = async (
     return true
   }
 
-  const permitEnabled = await isPermitTokenInfo(
-    client,
-    trigger as TokenTrigger // trigger can only be of type TokenTrigger at this point
-  )
-
-  // If permit is enabled, it is not an on chain quote
-  return !permitEnabled
+  // Permit check is done before this function call. If this function is called, it means permit is skipped and it can be executed via onchain mode
+  // Even if the permit flow fallbacks to onchain mode ? This will be always true.
+  return true
 }
 
 // NOTE: MM DTK is not supported for now - It is experimental and need to support once it is mainstream
@@ -107,7 +135,7 @@ export const getQuoteType = async (
   if (await isPermitQuote(client, quoteParams)) {
     return "permit"
   }
-  if (await isOnChainQuote(client, quoteParams)) {
+  if (await isOnChainQuote(quoteParams)) {
     return "onchain"
   }
   throw new Error("Invalid quote, can't determine quote type")

--- a/src/sdk/clients/decorators/mee/index.ts
+++ b/src/sdk/clients/decorators/mee/index.ts
@@ -1,3 +1,4 @@
+import type { OneOf } from "viem"
 import type { BaseMeeClient } from "../../createMeeClient"
 import execute from "./execute"
 import {
@@ -184,11 +185,16 @@ export type MeeActions = {
   /**
    * Sign a permit quote for ERC20Permit-enabled tokens
    * @param params - Parameters for signing the permit quote
-   * @returns Promise resolving to signed permit data
+   * @returns Promise resolving to signed permit data or fallbackToOnchainMode flag
    */
   signPermitQuote: (
     params: SignPermitQuoteParams
-  ) => Promise<SignPermitQuotePayload>
+  ) => Promise<
+    OneOf<
+      | { signedPermitQuotePayload: SignPermitQuotePayload }
+      | { fallbackToOnchainMode: true }
+    >
+  >
 
   /**
    * Get a permit quote for ERC20Permit-enabled tokens

--- a/src/sdk/clients/decorators/mee/signFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.ts
@@ -72,8 +72,18 @@ export const signFusionQuote = async (
     (await getQuoteType(client, parameters.fusionQuote))
 
   switch (signatureType) {
-    case "permit":
-      return signPermitQuote(client, parameters)
+    case "permit": {
+      const { fallbackToOnchainMode, signedPermitQuotePayload } =
+        await signPermitQuote(client, parameters)
+
+      // If there is any issue with permit fuctionality, the quote signing will fallback to onchain mode.
+      // Fallback only happens if RPC issue, problem with permit values such as name, version, domain separator.
+      if (fallbackToOnchainMode) {
+        return signOnChainQuote(client, parameters)
+      }
+
+      return signedPermitQuotePayload
+    }
     case "onchain":
       return signOnChainQuote(client, parameters)
     default:

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -44,10 +44,9 @@ import { executeSignedQuote } from "./executeSignedQuote"
 import getFusionQuote from "./getFusionQuote"
 import { type FeeTokenInfo, getQuote } from "./getQuote"
 import { getQuoteType } from "./getQuoteType"
-import getSupportedFeeToken, {
-  type GetSupportedFeeTokenPayload
-} from "./getSupportedFeeToken"
+import signOnChainQuote from "./signOnChainQuote"
 import {
+  type TokenTrigger,
   type Trigger,
   formatSignedPermitQuotePayload,
   prepareSignablePermitQuotePayload,
@@ -158,7 +157,17 @@ describe("mee.signPermitQuote", () => {
       feeToken
     })
 
-    const signedPermitQuote = await signPermitQuote(meeClient, { fusionQuote })
+    const {
+      fallbackToOnchainMode,
+      signedPermitQuotePayload: signedPermitQuote
+    } = await signPermitQuote(meeClient, { fusionQuote })
+
+    if (fallbackToOnchainMode) {
+      // This always fails here. This is being coded like this to avoid type issues
+      expect(fallbackToOnchainMode).to.be.eq(false)
+      return
+    }
+
     expect(signedPermitQuote).toBeDefined()
   })
 
@@ -207,7 +216,15 @@ describe("mee.signPermitQuote", () => {
       }
 
       console.timeEnd("signPermitQuote:getQuote")
-      const signedQuote = await signPermitQuote(meeClient, { fusionQuote })
+      const { fallbackToOnchainMode, signedPermitQuotePayload: signedQuote } =
+        await signPermitQuote(meeClient, { fusionQuote })
+
+      if (fallbackToOnchainMode) {
+        // This always fails here. This is being coded like this to avoid type issues
+        expect(fallbackToOnchainMode).to.be.eq(false)
+        return
+      }
+
       const { hash } = await executeSignedQuote(meeClient, { signedQuote })
       console.timeEnd("signPermitQuote:getHash")
       const receipt = await waitForSupertransactionReceipt(meeClient, {
@@ -415,25 +432,42 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
       }
     })
 
-    const signedPermitQuote = await signPermitQuote(meeClient, { fusionQuote })
+    const {
+      fallbackToOnchainMode,
+      signedPermitQuotePayload: signedPermitQuote
+    } = await signPermitQuote(meeClient, { fusionQuote })
+
+    if (fallbackToOnchainMode) {
+      // This always fails here. This is being coded like this to avoid type issues
+      expect(fallbackToOnchainMode).to.be.eq(false)
+      return
+    }
+
     expect(signedPermitQuote).toBeDefined()
     expect(signedPermitQuote.signature).toBeDefined()
-    expect(isHex(signedPermitQuote.signature)).toEqual(true)
 
-    const supportedFeeTokenInfo: GetSupportedFeeTokenPayload | undefined =
-      undefined
+    expect(isHex(signedPermitQuote.signature)).toEqual(true)
 
     const quoteType = await getQuoteType(meeClient, fusionQuote)
 
     expect(quoteType).toEqual("permit")
 
-    const { signablePayload, metadata } =
-      await prepareSignablePermitQuotePayload(
-        fusionQuote,
-        eoaAccount.address,
-        mcNexus.addressOn(chain.id, true),
-        walletClient
-      )
+    const {
+      fallbackToOnchainMode: isFallbackNeeded,
+      signablePayload,
+      metadata
+    } = await prepareSignablePermitQuotePayload(
+      fusionQuote,
+      eoaAccount.address,
+      mcNexus.addressOn(chain.id, true),
+      walletClient
+    )
+
+    if (isFallbackNeeded) {
+      // This always fails here. This is being coded like this to avoid type issues
+      expect(isFallbackNeeded).to.be.eq(false)
+      return
+    }
 
     const signature = await walletClient.signTypedData({
       ...signablePayload,
@@ -453,5 +487,117 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     expect(signedPermitQuote.signature).toEqual(
       manuallySignedPermitQuote.signature
     )
+  })
+
+  test("prepareSignablePermitQuotePayload should indicate fallbackToOnchainMode when the permit values are invalid", async () => {
+    const fusionQuote = await getFusionQuote(meeClient, {
+      trigger: {
+        chainId: chain.id,
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        amount: 1n
+      },
+      instructions: [
+        mcNexus.build({
+          type: "default",
+          data: {
+            calls: [
+              {
+                to: zeroAddress,
+                value: 0n
+              }
+            ],
+            chainId: chain.id
+          }
+        })
+      ],
+      feeToken: {
+        chainId: chain.id,
+        address: testnetMcTestUSDCP.addressOn(chain.id)
+      }
+    })
+
+    const modifiedFusionQuote = {
+      ...fusionQuote,
+      trigger: {
+        ...(fusionQuote.trigger as TokenTrigger),
+        tokenAddress: zeroAddress // Forcefully adding a non permit supported address to trigger fallback flow
+      }
+    }
+
+    const { fallbackToOnchainMode, signedPermitQuotePayload } =
+      await signPermitQuote(meeClient, { fusionQuote: modifiedFusionQuote })
+
+    expect(fallbackToOnchainMode).to.be.eq(true)
+    expect(signedPermitQuotePayload).to.be.eq(undefined)
+  })
+
+  test("Permit should fallback to on-chain mode when the permit values are invalid", async () => {
+    const fusionQuote = await getFusionQuote(meeClient, {
+      trigger: {
+        chainId: chain.id,
+        tokenAddress: testnetMcTestUSDCP.addressOn(chain.id),
+        amount: 1n
+      },
+      instructions: [
+        mcNexus.build({
+          type: "default",
+          data: {
+            calls: [
+              {
+                to: zeroAddress,
+                value: 0n
+              }
+            ],
+            chainId: chain.id
+          }
+        })
+      ],
+      feeToken: {
+        chainId: chain.id,
+        address: testnetMcTestUSDCP.addressOn(chain.id)
+      }
+    })
+
+    const modifiedFusionQuote = {
+      ...fusionQuote,
+      trigger: {
+        ...(fusionQuote.trigger as TokenTrigger),
+        tokenAddress: zeroAddress // Forcefully adding a non permit supported address to trigger fallback flow
+      }
+    }
+
+    const { fallbackToOnchainMode, signedPermitQuotePayload } =
+      await signPermitQuote(meeClient, { fusionQuote: modifiedFusionQuote })
+
+    expect(fallbackToOnchainMode).to.be.eq(true)
+    expect(signedPermitQuotePayload).to.be.eq(undefined)
+
+    let trigger: TokenTrigger | undefined = undefined
+
+    // If there is no call ? It is always TokenTrigger
+    if (fusionQuote.trigger && !fusionQuote.trigger.call) {
+      trigger = fusionQuote.trigger
+    }
+
+    const signedQuote = await signOnChainQuote(meeClient, { fusionQuote })
+
+    // Execute the quote
+    const { hash } = await executeSignedQuote(meeClient, {
+      signedQuote: {
+        ...signedQuote,
+        trigger
+      }
+    })
+
+    // Wait for the transaction to complete
+    const executeReceipt = await meeClient.waitForSupertransactionReceipt({
+      hash
+    })
+
+    expect(executeReceipt.transactionStatus).toBe("MINED_SUCCESS")
+    console.log({
+      explorerLinks: executeReceipt.explorerLinks,
+      hash: executeReceipt.hash
+    })
   })
 })

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -17,6 +17,7 @@ import {
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import {
+  MAINNET_RPC_URLS,
   TEST_BLOCK_CONFIRMATIONS,
   getTestChainConfig,
   toNetwork
@@ -39,7 +40,12 @@ import {
 } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
 import { getMEEVersion } from "../../../modules"
-import { type MeeClient, createMeeClient } from "../../createMeeClient"
+import {
+  type MeeClient,
+  createMeeClient,
+  getDefaultMEENetworkApiKey,
+  getDefaultMEENetworkUrl
+} from "../../createMeeClient"
 import { executeSignedQuote } from "./executeSignedQuote"
 import getFusionQuote from "./getFusionQuote"
 import { type FeeTokenInfo, getQuote } from "./getQuote"
@@ -53,6 +59,7 @@ import {
   signPermitQuote
 } from "./signPermitQuote"
 import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
+import { arbitrum, polygon } from "viem/chains"
 
 // @ts-ignore
 const { runPaidTests, runLifecycleTests } = inject("settings")
@@ -487,6 +494,79 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     expect(signedPermitQuote.signature).toEqual(
       manuallySignedPermitQuote.signature
     )
+  })
+
+  test("Should generate a proper valid domain separator for exoitic tokens with different EIP712 domain types", async () => {
+    const mcNexus = await toMultichainNexusAccount({
+      signer: eoaAccount,
+      chainConfigurations: [
+        {
+          chain: arbitrum,
+          transport: http(MAINNET_RPC_URLS[arbitrum.id]),
+          version: getMEEVersion(DEFAULT_MEE_VERSION)
+        },
+        {
+          chain: polygon,
+          transport: http(MAINNET_RPC_URLS[polygon.id]),
+          version: getMEEVersion(DEFAULT_MEE_VERSION)
+        }
+      ]
+    })
+
+    const meeClient = await createMeeClient({
+      account: mcNexus,
+      apiKey: getDefaultMEENetworkApiKey(),
+      url: getDefaultMEENetworkUrl()
+    })
+
+    const tokensWithChainId = [
+      {
+        tokenAddress: "0x09199d9A5F4448D0848e4395D065e1ad9c4a1F74" as Address, // Bonk token
+        chainId: arbitrum.id
+      },
+      {
+        tokenAddress: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174" as Address, // Polygon USDC token
+        chainId: polygon.id
+      }
+    ]
+
+    for (let { tokenAddress, chainId } of tokensWithChainId) {
+      const fusionQuote = await getFusionQuote(meeClient, {
+        trigger: {
+          chainId: chainId,
+          tokenAddress: tokenAddress,
+          amount: 1n
+        },
+        instructions: [
+          mcNexus.build({
+            type: "default",
+            data: {
+              calls: [
+                {
+                  to: zeroAddress,
+                  value: 0n
+                }
+              ],
+              chainId: chainId
+            }
+          })
+        ],
+        feeToken: {
+          chainId: chainId,
+          address: tokenAddress
+        }
+      })
+
+      const { fallbackToOnchainMode } = await prepareSignablePermitQuotePayload(
+        fusionQuote,
+        eoaAccount.address,
+        mcNexus.addressOn(chainId, true),
+        mcNexus.deploymentOn(chainId, true).walletClient
+      )
+
+      // This will be undefined if the permit values are proper
+      expect(fallbackToOnchainMode).to.be.eq(undefined)
+    }
   })
 
   test("prepareSignablePermitQuotePayload should indicate fallbackToOnchainMode when the permit values are invalid", async () => {

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -15,6 +15,7 @@ import {
   zeroAddress
 } from "viem"
 import { generatePrivateKey, privateKeyToAccount } from "viem/accounts"
+import { arbitrum, polygon } from "viem/chains"
 import { beforeAll, describe, expect, inject, test } from "vitest"
 import {
   MAINNET_RPC_URLS,
@@ -59,7 +60,6 @@ import {
   signPermitQuote
 } from "./signPermitQuote"
 import waitForSupertransactionReceipt from "./waitForSupertransactionReceipt"
-import { arbitrum, polygon } from "viem/chains"
 
 // @ts-ignore
 const { runPaidTests, runLifecycleTests } = inject("settings")
@@ -530,7 +530,7 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
       }
     ]
 
-    for (let { tokenAddress, chainId } of tokensWithChainId) {
+    for (const { tokenAddress, chainId } of tokensWithChainId) {
       const fusionQuote = await getFusionQuote(meeClient, {
         trigger: {
           chainId: chainId,

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -547,7 +547,6 @@ export const prepareSignablePermitQuotePayload = async (
             salt: permitValues.salt
           }
         }
-        case "invalid":
         default:
           throw new Error(
             "Permit signing failed: Domain separator mismatch, please double check the token's permit functionality"

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -153,8 +153,8 @@ const PERMIT_PREFIX = "0x177eee02"
 export const isLegacyEIP712Domain = (
   name: string,
   version: string,
-  chainId: number,
   verifyingContract: Address,
+  salt: Hex,
   domainSeparator: Hex
 ) => {
   // Step 1: Hash the EIP712Domain type string
@@ -181,15 +181,9 @@ export const isLegacyEIP712Domain = (
         { type: "bytes32" }, // nameHash
         { type: "bytes32" }, // versionHash
         { type: "address" }, // verifyingContract
-        { type: "bytes32" } // chainId as bytes32
+        { type: "bytes32" } // salt
       ],
-      [
-        DOMAIN_TYPEHASH,
-        nameHash,
-        versionHash,
-        verifyingContract,
-        toHex(chainId, { size: 32 })
-      ]
+      [DOMAIN_TYPEHASH, nameHash, versionHash, verifyingContract, salt]
     )
   )
 
@@ -224,10 +218,10 @@ export const isDefaultEIP712Domain = (
     encodeAbiParameters(
       [
         { type: "bytes32" },
-        { type: "bytes32" },
-        { type: "bytes32" },
-        { type: "uint256" },
-        { type: "address" }
+        { type: "bytes32" }, // nameHash
+        { type: "bytes32" }, // versionHash
+        { type: "uint256" }, // chainId
+        { type: "address" } // verifyingContract
       ],
       [
         DOMAIN_TYPEHASH,
@@ -242,19 +236,69 @@ export const isDefaultEIP712Domain = (
   return domainSeparator.toLowerCase() === DOMAIN_SEPARATOR.toLowerCase()
 }
 
+export const isDefaultEIP712DomainWithSalt = (
+  name: string,
+  version: string,
+  chainId: number,
+  verifyingContract: Address,
+  salt: Hex,
+  domainSeparator: Hex
+) => {
+  // Step 1: Hash the EIP712Domain type string
+  const DOMAIN_TYPEHASH = keccak256(
+    encodePacked(
+      ["string"],
+      [
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)"
+      ]
+    )
+  )
+
+  // Step 2: Hash the name
+  const nameHash = keccak256(encodePacked(["string"], [name]))
+
+  // Step 3: Hash the version
+  const versionHash = keccak256(encodePacked(["string"], [version]))
+
+  // Step 4: Encode and hash all parameters
+  const DOMAIN_SEPARATOR = keccak256(
+    encodeAbiParameters(
+      [
+        { type: "bytes32" }, // EIP712_DOMAIN_TYPEHASH
+        { type: "bytes32" }, // nameHash
+        { type: "bytes32" }, // versionHash
+        { type: "uint256" }, // chainId
+        { type: "address" }, // verifyingContract
+        { type: "bytes32" } // salt
+      ],
+      [
+        DOMAIN_TYPEHASH,
+        nameHash,
+        versionHash,
+        BigInt(chainId),
+        verifyingContract,
+        salt
+      ]
+    )
+  )
+
+  return domainSeparator.toLowerCase() === DOMAIN_SEPARATOR.toLowerCase()
+}
+
 export const getEIP712DomainType = (
   name: string,
   version: string,
   chainId: number,
   verifyingContract: Address,
+  salt: Hex,
   domainSeparator: Hex
 ) => {
   try {
     const isValid = isLegacyEIP712Domain(
       name,
       version,
-      chainId,
       verifyingContract,
+      salt,
       domainSeparator
     )
 
@@ -274,6 +318,21 @@ export const getEIP712DomainType = (
 
     if (isValid) {
       return "default"
+    }
+  } catch {}
+
+  try {
+    const isValid = isDefaultEIP712DomainWithSalt(
+      name,
+      version,
+      chainId,
+      verifyingContract,
+      salt,
+      domainSeparator
+    )
+
+    if (isValid) {
+      return "default-with-salt"
     }
   } catch {}
 
@@ -411,7 +470,8 @@ export const prepareSignablePermitQuotePayload = async (
       }
     ) as [bigint, string, string, Hex, EIP712DomainReturn]
 
-    const [, name_, version_] = eip712Domain
+    const [, name_, version_, chainId_, verifyingContract_, salt_] =
+      eip712Domain
 
     // Default version will be used as fallback
     const defaultVersion = "1"
@@ -436,45 +496,67 @@ export const prepareSignablePermitQuotePayload = async (
       )
     }
 
-    const metadata: PermitMetadata = {
-      nonce,
+    // chainId from eip712Domain is mostly safe and more priority is given
+    const permitChainId =
+      chainId_ !== undefined ? Number(chainId_) : trigger.chainId
+
+    const permitValues = {
       name: name_ ?? name, // name from eip712Domain is mostly safe and more priority is given
       version: version_ ?? version ?? defaultVersion, // version from eip712Domain is mostly safe and more priority is given
-      domainSeparator,
-      owner,
-      spender,
-      amount
+      chainId: permitChainId,
+      verifyingContract: verifyingContract_ ?? trigger.tokenAddress, // verifyingContract from eip712Domain is mostly safe and more priority is given
+      salt: salt_ ?? toHex(permitChainId, { size: 32 }), // salt from eip712Domain is mostly safe and more priority is given
+      domainSeparator
     }
 
     const eip712DomainType = getEIP712DomainType(
-      metadata.name,
-      metadata.version,
-      trigger.chainId,
-      trigger.tokenAddress,
-      domainSeparator
+      permitValues.name,
+      permitValues.version,
+      permitValues.chainId,
+      permitValues.verifyingContract,
+      permitValues.salt,
+      permitValues.domainSeparator
     )
 
-    if (eip712DomainType === "invalid") {
-      throw new Error(
-        "Permit signing failed: Domain separator mismatch, please double check the token's permit functionality"
-      )
+    const getDomain = (
+      eip712DomainType: ReturnType<typeof getEIP712DomainType>
+    ) => {
+      switch (eip712DomainType) {
+        case "default": {
+          return {
+            name: permitValues.name,
+            version: permitValues.version,
+            chainId: permitValues.chainId,
+            verifyingContract: permitValues.verifyingContract
+          }
+        }
+        case "default-with-salt": {
+          return {
+            name: permitValues.name,
+            version: permitValues.version,
+            chainId: permitValues.chainId,
+            verifyingContract: permitValues.verifyingContract,
+            salt: permitValues.salt
+          }
+        }
+        case "legacy": {
+          return {
+            name: permitValues.name,
+            version: permitValues.version,
+            verifyingContract: permitValues.verifyingContract,
+            salt: permitValues.salt
+          }
+        }
+        case "invalid":
+        default:
+          throw new Error(
+            "Permit signing failed: Domain separator mismatch, please double check the token's permit functionality"
+          )
+      }
     }
 
     const signablePermitQuotePayload = {
-      domain:
-        eip712DomainType === "legacy"
-          ? {
-              name: metadata.name,
-              version: metadata.version,
-              verifyingContract: trigger.tokenAddress,
-              salt: toHex(trigger.chainId, { size: 32 })
-            }
-          : {
-              name: metadata.name,
-              version: metadata.version,
-              chainId: trigger.chainId,
-              verifyingContract: trigger.tokenAddress
-            },
+      domain: getDomain(eip712DomainType),
       types: {
         Permit: [
           { name: "owner", type: "address" },
@@ -492,6 +574,16 @@ export const prepareSignablePermitQuotePayload = async (
         nonce,
         deadline: BigInt(quote.hash)
       }
+    }
+
+    const metadata: PermitMetadata = {
+      nonce,
+      name: permitValues.name,
+      version: permitValues.version,
+      domainSeparator: permitValues.domainSeparator,
+      owner,
+      spender,
+      amount
     }
 
     return {

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -7,7 +7,10 @@ import {
   type WalletClient,
   concatHex,
   encodeAbiParameters,
-  parseSignature
+  encodePacked,
+  keccak256,
+  parseSignature,
+  toHex
 } from "viem"
 import { multicall } from "viem/actions"
 import type { EIP712DomainReturn } from "../../../account"
@@ -44,10 +47,15 @@ export interface PermitMetadata {
  * Contains the EIP-712 signable payload and associated metadata
  * needed for formatting and encoding the final permit signature.
  */
-export interface SignablePermitQuotePayload {
-  signablePayload: SignablePermitPayload
-  metadata: PermitMetadata
-}
+export type SignablePermitQuotePayload = OneOf<
+  | {
+      fallbackToOnchainMode: true
+    }
+  | {
+      signablePayload: SignablePermitPayload
+      metadata: PermitMetadata
+    }
+>
 
 /**
  * Custom trigger for arbitrary calls
@@ -142,6 +150,136 @@ export type SignPermitQuotePayload = GetQuotePayload & {
 
 const PERMIT_PREFIX = "0x177eee02"
 
+export const isLegacyEIP712Domain = (
+  name: string,
+  version: string,
+  chainId: number,
+  verifyingContract: Address,
+  domainSeparator: Hex
+) => {
+  // Step 1: Hash the EIP712Domain type string
+  const DOMAIN_TYPEHASH = keccak256(
+    encodePacked(
+      ["string"],
+      [
+        "EIP712Domain(string name,string version,address verifyingContract,bytes32 salt)"
+      ]
+    )
+  )
+
+  // Step 2: Hash the name
+  const nameHash = keccak256(encodePacked(["string"], [name]))
+
+  // Step 3: Hash the version
+  const versionHash = keccak256(encodePacked(["string"], [version]))
+
+  // Step 4: Encode and hash all parameters
+  const DOMAIN_SEPARATOR = keccak256(
+    encodeAbiParameters(
+      [
+        { type: "bytes32" }, // EIP712_DOMAIN_TYPEHASH
+        { type: "bytes32" }, // nameHash
+        { type: "bytes32" }, // versionHash
+        { type: "address" }, // verifyingContract
+        { type: "bytes32" } // chainId as bytes32
+      ],
+      [
+        DOMAIN_TYPEHASH,
+        nameHash,
+        versionHash,
+        verifyingContract,
+        toHex(chainId, { size: 32 })
+      ]
+    )
+  )
+
+  return domainSeparator.toLowerCase() === DOMAIN_SEPARATOR.toLowerCase()
+}
+
+export const isDefaultEIP712Domain = (
+  name: string,
+  version: string,
+  chainId: number,
+  verifyingContract: Address,
+  domainSeparator: Hex
+) => {
+  // Step 1: Hash the EIP712Domain type string
+  const DOMAIN_TYPEHASH = keccak256(
+    encodePacked(
+      ["string"],
+      [
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+      ]
+    )
+  )
+
+  // Step 2: Hash the name
+  const nameHash = keccak256(encodePacked(["string"], [name]))
+
+  // Step 3: Hash the version
+  const versionHash = keccak256(encodePacked(["string"], [version]))
+
+  // Step 4: Encode and hash all parameters
+  const DOMAIN_SEPARATOR = keccak256(
+    encodeAbiParameters(
+      [
+        { type: "bytes32" },
+        { type: "bytes32" },
+        { type: "bytes32" },
+        { type: "uint256" },
+        { type: "address" }
+      ],
+      [
+        DOMAIN_TYPEHASH,
+        nameHash,
+        versionHash,
+        BigInt(chainId),
+        verifyingContract
+      ]
+    )
+  )
+
+  return domainSeparator.toLowerCase() === DOMAIN_SEPARATOR.toLowerCase()
+}
+
+export const getEIP712DomainType = (
+  name: string,
+  version: string,
+  chainId: number,
+  verifyingContract: Address,
+  domainSeparator: Hex
+) => {
+  try {
+    const isValid = isLegacyEIP712Domain(
+      name,
+      version,
+      chainId,
+      verifyingContract,
+      domainSeparator
+    )
+
+    if (isValid) {
+      return "legacy"
+    }
+  } catch {}
+
+  try {
+    const isValid = isDefaultEIP712Domain(
+      name,
+      version,
+      chainId,
+      verifyingContract,
+      domainSeparator
+    )
+
+    if (isValid) {
+      return "default"
+    }
+  } catch {}
+
+  return "invalid"
+}
+
 /**
  * Prepares the payload required for signing a permit quote.
  * This function validates the trigger, fetches necessary token data (nonce, name, version, domain separator),
@@ -195,143 +333,177 @@ export const prepareSignablePermitQuotePayload = async (
 
   const amount = trigger.approvalAmount ?? trigger.amount
 
-  // Fetch required token data for EIP-712 domain and permit using multicall
-  const values = await multicall(publicClient, {
-    contracts: [
-      {
-        address: trigger.tokenAddress,
-        abi: TokenWithPermitAbi,
-        functionName: "nonces",
-        args: [owner]
-      },
-      {
-        address: trigger.tokenAddress,
-        abi: TokenWithPermitAbi,
-        functionName: "name"
-      },
-      {
-        address: trigger.tokenAddress,
-        abi: TokenWithPermitAbi,
-        functionName: "version"
-      },
-      {
-        address: trigger.tokenAddress,
-        abi: TokenWithPermitAbi,
-        functionName: "DOMAIN_SEPARATOR"
-      },
-      {
-        address: trigger.tokenAddress,
-        abi: TokenWithPermitAbi,
-        functionName: "eip712Domain"
+  // If there is any error while prepare permit signature, the flow will fallback to onchain mode.
+  // The fallbacks will happen for these errors such as, invalid permit values, domain separator mismatch, RPC issues and etc...
+  try {
+    // Fetch required token data for EIP-712 domain and permit using multicall
+    const values = await multicall(publicClient, {
+      contracts: [
+        {
+          address: trigger.tokenAddress,
+          abi: TokenWithPermitAbi,
+          functionName: "nonces",
+          args: [owner]
+        },
+        {
+          address: trigger.tokenAddress,
+          abi: TokenWithPermitAbi,
+          functionName: "name"
+        },
+        {
+          address: trigger.tokenAddress,
+          abi: TokenWithPermitAbi,
+          functionName: "version"
+        },
+        {
+          address: trigger.tokenAddress,
+          abi: TokenWithPermitAbi,
+          functionName: "DOMAIN_SEPARATOR"
+        },
+        {
+          address: trigger.tokenAddress,
+          abi: TokenWithPermitAbi,
+          functionName: "eip712Domain"
+        }
+      ]
+    })
+
+    const [nonce, name, version, domainSeparator, eip712Domain] = values.map(
+      (value, i) => {
+        const key = [
+          "nonce",
+          "name",
+          "version",
+          "domainSeparator",
+          "eip712Domain"
+        ][i]
+        if (value.status === "success") {
+          return value.result
+        }
+        if (value.status === "failure") {
+          if (key === "nonce") {
+            // Tokens must implement the nonces function, otherwise we throw a error here
+            throw new Error(
+              "Permit signing failed: Token does not implement nonces(). This function is required for EIP-2612 compliance."
+            )
+          }
+
+          if (key === "domainSeparator") {
+            // Tokens must implement the domainSeparator function, otherwise we throw a error here
+            throw new Error(
+              "Permit signing failed: Token does not implement DOMAIN_SEPARATOR(). This function is required for EIP-712 domain separation."
+            )
+          }
+
+          if (key === "name" || key === "version") {
+            // Some tokens do not implement name and version; defaults to undefined
+            return undefined
+          }
+
+          if (key === "eip712Domain") {
+            // Some tokens do not implement eip712Domain; default to []
+            return []
+          }
+        }
+
+        // Fallback return value instead of throwing error
+        return undefined
       }
-    ]
-  })
+    ) as [bigint, string, string, Hex, EIP712DomainReturn]
 
-  const [nonce, name, version, domainSeparator, eip712Domain] = values.map(
-    (value, i) => {
-      const key = [
-        "nonce",
-        "name",
-        "version",
-        "domainSeparator",
-        "eip712Domain"
-      ][i]
-      if (value.status === "success") {
-        return value.result
-      }
-      if (value.status === "failure") {
-        if (key === "nonce") {
-          // Tokens must implement the nonces function, otherwise we throw a error here
-          throw new Error(
-            "Permit signing failed: Token does not implement nonces(). This function is required for EIP-2612 compliance."
-          )
-        }
+    const [, name_, version_] = eip712Domain
 
-        if (key === "domainSeparator") {
-          // Tokens must implement the domainSeparator function, otherwise we throw a error here
-          throw new Error(
-            "Permit signing failed: Token does not implement DOMAIN_SEPARATOR(). This function is required for EIP-712 domain separation."
-          )
-        }
+    // Default version will be used as fallback
+    const defaultVersion = "1"
 
-        if (key === "name" || key === "version") {
-          // Some tokens do not implement name and version; defaults to undefined
-          return undefined
-        }
-
-        if (key === "eip712Domain") {
-          // Some tokens do not implement eip712Domain; default to []
-          return []
-        }
-      }
-
-      // Fallback return value instead of throwing error
-      return undefined
+    if (version?.length >= 0 && version_?.length >= 0) {
+      if (version !== version_)
+        console.warn(
+          "Warning: Mismatch between token version() and eip712Domain().version. This may cause permit signature verification to fail."
+        )
     }
-  ) as [bigint, string, string, Hex, EIP712DomainReturn]
 
-  const [, name_, version_] = eip712Domain
+    if (name?.length >= 0 && name_?.length >= 0) {
+      if (name !== name_)
+        console.warn(
+          "Warning: Mismatch between token name() and eip712Domain().name. This may cause permit signature verification to fail."
+        )
+    }
 
-  // Default version will be used as fallback
-  const defaultVersion = "1"
-
-  if (version?.length >= 0 && version_?.length >= 0) {
-    if (version !== version_)
-      console.warn(
-        "Warning: Mismatch between token version() and eip712Domain().version. This may cause permit signature verification to fail."
+    if (name === undefined && name_ === undefined) {
+      throw new Error(
+        "Permit signing failed: Token name is missing. Neither name() nor eip712Domain().name is available."
       )
-  }
+    }
 
-  if (name?.length >= 0 && name_?.length >= 0) {
-    if (name !== name_)
-      console.warn(
-        "Warning: Mismatch between token name() and eip712Domain().name. This may cause permit signature verification to fail."
-      )
-  }
-
-  if (name === undefined && name_ === undefined) {
-    throw new Error(
-      "Permit signing failed: Token name is missing. Neither name() nor eip712Domain().name is available."
-    )
-  }
-
-  const signablePermitQuotePayload = {
-    domain: {
+    const metadata: PermitMetadata = {
+      nonce,
       name: name_ ?? name, // name from eip712Domain is mostly safe and more priority is given
       version: version_ ?? version ?? defaultVersion, // version from eip712Domain is mostly safe and more priority is given
-      chainId: trigger.chainId,
-      verifyingContract: trigger.tokenAddress
-    },
-    types: {
-      Permit: [
-        { name: "owner", type: "address" },
-        { name: "spender", type: "address" },
-        { name: "value", type: "uint256" },
-        { name: "nonce", type: "uint256" },
-        { name: "deadline", type: "uint256" }
-      ]
-    },
-    primaryType: "Permit",
-    message: {
-      owner: owner,
-      spender: spender,
-      value: amount,
-      nonce,
-      deadline: BigInt(quote.hash)
-    }
-  }
-
-  return {
-    signablePayload: signablePermitQuotePayload,
-    metadata: {
-      nonce,
-      name: name_ ?? name,
-      version: version_ ?? version ?? defaultVersion,
       domainSeparator,
       owner,
       spender,
       amount
     }
+
+    const eip712DomainType = getEIP712DomainType(
+      metadata.name,
+      metadata.version,
+      trigger.chainId,
+      trigger.tokenAddress,
+      domainSeparator
+    )
+
+    if (eip712DomainType === "invalid") {
+      throw new Error(
+        "Permit signing failed: Domain separator mismatch, please double check the token's permit functionality"
+      )
+    }
+
+    const signablePermitQuotePayload = {
+      domain:
+        eip712DomainType === "legacy"
+          ? {
+              name: metadata.name,
+              version: metadata.version,
+              verifyingContract: trigger.tokenAddress,
+              salt: toHex(trigger.chainId, { size: 32 })
+            }
+          : {
+              name: metadata.name,
+              version: metadata.version,
+              chainId: trigger.chainId,
+              verifyingContract: trigger.tokenAddress
+            },
+      types: {
+        Permit: [
+          { name: "owner", type: "address" },
+          { name: "spender", type: "address" },
+          { name: "value", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+          { name: "deadline", type: "uint256" }
+        ]
+      },
+      primaryType: "Permit",
+      message: {
+        owner: owner,
+        spender: spender,
+        value: amount,
+        nonce,
+        deadline: BigInt(quote.hash)
+      }
+    }
+
+    return {
+      signablePayload: signablePermitQuotePayload,
+      metadata
+    }
+  } catch (error) {
+    const errorMessage = (error as Error).message || "Permit siging failed"
+    console.warn(errorMessage)
+    console.info("Permit signing failed, fallback to onchain mode")
+
+    return { fallbackToOnchainMode: true }
   }
 }
 
@@ -408,7 +580,7 @@ export const formatSignedPermitQuotePayload = (
  *
  * @example
  * ```typescript
- * const signedPermitQuote = await signPermitQuote(meeClient, {
+ * const { fallbackToOnchainMode, signedPermitQuotePayload } = await signPermitQuote(meeClient, {
  *   fusionQuote: {
  *     quote: quotePayload,
  *     trigger: {
@@ -424,7 +596,12 @@ export const formatSignedPermitQuotePayload = (
 export const signPermitQuote = async (
   client: BaseMeeClient,
   parameters: SignPermitQuoteParams
-): Promise<SignPermitQuotePayload> => {
+): Promise<
+  OneOf<
+    | { signedPermitQuotePayload: SignPermitQuotePayload }
+    | { fallbackToOnchainMode: true }
+  >
+> => {
   const {
     companionAccount: account_ = client.account,
     fusionQuote: { trigger }
@@ -439,23 +616,30 @@ export const signPermitQuote = async (
 
   const owner = signer.address
 
-  const { signablePayload, metadata } = await prepareSignablePermitQuotePayload(
-    parameters.fusionQuote,
-    owner,
-    spender,
-    walletClient
-  )
+  const { fallbackToOnchainMode, signablePayload, metadata } =
+    await prepareSignablePermitQuotePayload(
+      parameters.fusionQuote,
+      owner,
+      spender,
+      walletClient
+    )
+
+  if (fallbackToOnchainMode) {
+    return { fallbackToOnchainMode }
+  }
 
   const signature = await walletClient.signTypedData({
     ...signablePayload,
     account: walletClient.account!
   })
 
-  return formatSignedPermitQuotePayload(
+  const signedPermitQuotePayload = formatSignedPermitQuotePayload(
     parameters.fusionQuote,
     metadata,
     signature
   )
+
+  return { signedPermitQuotePayload }
 }
 
 export default signPermitQuote

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -590,7 +590,7 @@ export const prepareSignablePermitQuotePayload = async (
       metadata
     }
   } catch (error) {
-    const errorMessage = (error as Error).message || "Permit siging failed"
+    const errorMessage = (error as Error).message || "Permit signing failed"
     console.warn(errorMessage)
     console.info("Permit signing failed, fallback to onchain mode")
 

--- a/src/test/testSetup.ts
+++ b/src/test/testSetup.ts
@@ -1,6 +1,7 @@
 import { http, type Prettify, type Transport } from "viem"
 import {
   type Chain,
+  arbitrum,
   base,
   baseSepolia,
   chiliz,
@@ -23,7 +24,9 @@ export const MAINNET_RPC_URLS: Record<number, string> = {
   [mainnet.id]: `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
   [optimism.id]: `https://opt-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
   [base.id]: `https://base-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
-  [chiliz.id]: "https://rpc.ankr.com/chiliz" // Public RPC
+  [chiliz.id]: "https://rpc.ankr.com/chiliz", // Public RPC
+  [polygon.id]: `https://polygon-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`,
+  [arbitrum.id]: `https://arb-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}`
 }
 
 export const TESTNET_RPC_URLS: Record<number, string> = {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR enhances the `signPermitQuote` functionality to include a fallback mechanism to on-chain mode when permit signing fails. It modifies the return types and adds error handling for various scenarios, improving robustness in handling permit-related operations.

### Detailed summary
- Updated `signPermitQuote` to return either signed permit data or a fallback flag.
- Introduced fallback logic to on-chain signing in case of permit issues.
- Enhanced error handling in `prepareSignablePermitQuotePayload` to return fallback signals.
- Adjusted type definitions to accommodate new return types.
- Added tests for fallback scenarios in `getPermitQuote` and `signPermitQuote`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->