### PR TITLE
feat: added the support for instruction level timestamps

### DIFF
--- a/src/sdk/account/decorators/buildBridgeInstructions.ts
+++ b/src/sdk/account/decorators/buildBridgeInstructions.ts
@@ -1,5 +1,8 @@
 import type { Address } from "viem"
-import type { Instruction } from "../../clients/decorators/mee/getQuote"
+import type {
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../clients/decorators/mee/getQuote"
 import type { InstructionMetadata } from "../../clients/decorators/mee/types/instruction-metadata.type"
 import { toAcrossPlugin } from "../utils/toAcrossPlugin"
 import type { UnifiedERC20Balance } from "./getUnifiedERC20Balance"
@@ -57,7 +60,7 @@ export type MultichainBridgingParams = {
   feeData?: FeeData
   mode?: "DEBIT" | "OPTIMISTIC"
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Result of a bridging plugin operation
@@ -169,7 +172,9 @@ export const buildBridgeInstructions = async (
     bridgingPlugins = [toAcrossPlugin()],
     feeData,
     mode = "DEBIT",
-    metadata
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   } = params
 
   const tokenMapping = {
@@ -277,7 +282,9 @@ export const buildBridgeInstructions = async (
 
         const instruction: Instruction = {
           ...result.userOp,
-          metadata: metadata || result.userOp.metadata || customMetadata
+          metadata: metadata || result.userOp.metadata || customMetadata,
+          lowerBoundTimestamp,
+          upperBoundTimestamp
         }
 
         return {

--- a/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildAcrossIntentComposable.ts
@@ -8,7 +8,10 @@ import {
   parseAbi,
   zeroAddress
 } from "viem"
-import type { Instruction } from "../../../clients/decorators/mee"
+import type {
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import {
   type RuntimeBalanceOfParams,
@@ -86,7 +89,7 @@ export type BuildAcrossIntentComposableParams = {
   gasLimit?: bigint
   fees?: SuggestedFeesReturnType
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Builds an instruction for across
@@ -110,7 +113,9 @@ export const buildAcrossIntentComposable = async (
     gasLimit,
     pool = acrossSpokePool[originChainId],
     fees: fees_,
-    metadata
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   } = parameters
 
   // sanity checks
@@ -137,7 +142,9 @@ export const buildAcrossIntentComposable = async (
       chainId: originChainId,
       tokenAddress: inputToken,
       amount: runtimeERC20BalanceOf(inputAmountRuntimeParams), // use without changes
-      recipient: acrossIntentWrapperOnOrigin
+      recipient: acrossIntentWrapperOnOrigin,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     },
     composabilityParams
   )
@@ -224,7 +231,9 @@ export const buildAcrossIntentComposable = async (
       ],
       chainId: originChainId,
       gasLimit,
-      metadata: metadata || bridgeMetadata
+      metadata: metadata || bridgeMetadata,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     },
     composabilityParams
   )

--- a/src/sdk/account/decorators/instructions/buildApprove.ts
+++ b/src/sdk/account/decorators/instructions/buildApprove.ts
@@ -1,5 +1,9 @@
 import { type Address, encodeFunctionData, erc20Abi } from "viem"
-import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
+import type {
+  AbstractCall,
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import type { AnyData } from "../../../modules/utils/Types"
 import {
@@ -38,7 +42,7 @@ export type BuildApproveParameters = TokenParams & {
   spender: Address
   /** Custom metadata override for instruction */
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Parameters for the buildApprove function
@@ -96,8 +100,16 @@ export const buildApprove = async (
   composabilityParams?: ComposabilityParams
 ): Promise<Instruction[]> => {
   const { currentInstructions = [], accountAddress } = baseParams
-  const { chainId, tokenAddress, amount, gasLimit, spender, metadata } =
-    parameters
+  const {
+    chainId,
+    tokenAddress,
+    amount,
+    gasLimit,
+    spender,
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
+  } = parameters
   const { forceComposableEncoding } = composabilityParams ?? {
     forceComposableEncoding: false
   }
@@ -176,7 +188,9 @@ export const buildApprove = async (
       calls: approvalCall,
       chainId,
       isComposable: isComposableCall,
-      metadata: metadata || defaultMetadata
+      metadata: metadata || defaultMetadata,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     }
   ]
 }

--- a/src/sdk/account/decorators/instructions/buildBatch.ts
+++ b/src/sdk/account/decorators/instructions/buildBatch.ts
@@ -57,6 +57,35 @@ export const buildBatch = async (
 
   const resolvedInstructions = await resolveInstructions(instructions)
 
+  let maxTimeWindow = 0
+  let finalLowerBoundTimestamp = 0
+  let finalUpperBoundTimestamp = 0
+
+  for (const {
+    lowerBoundTimestamp,
+    upperBoundTimestamp
+  } of resolvedInstructions) {
+    if (
+      lowerBoundTimestamp !== undefined &&
+      upperBoundTimestamp !== undefined
+    ) {
+      if (upperBoundTimestamp <= lowerBoundTimestamp) {
+        throw new Error("Invalid lowerbound and upperbound timestamps.")
+      }
+
+      const timeWindow = upperBoundTimestamp - lowerBoundTimestamp
+
+      // The last defined max execution window will be considered
+      const isMax = timeWindow >= maxTimeWindow
+
+      if (isMax) {
+        maxTimeWindow = timeWindow
+        finalLowerBoundTimestamp = lowerBoundTimestamp
+        finalUpperBoundTimestamp = upperBoundTimestamp
+      }
+    }
+  }
+
   if (
     resolvedInstructions.some(
       ({ chainId }) =>
@@ -94,7 +123,13 @@ export const buildBatch = async (
         : (calls as AbstractCall[]),
       chainId: resolvedInstructions[0].chainId, // Batch instructions must be on the same chain
       isComposable,
-      metadata
+      metadata,
+      ...(finalLowerBoundTimestamp !== 0
+        ? { lowerBoundTimestamp: finalLowerBoundTimestamp }
+        : {}),
+      ...(finalUpperBoundTimestamp !== 0
+        ? { upperBoundTimestamp: finalUpperBoundTimestamp }
+        : {})
     }
   ]
 }

--- a/src/sdk/account/decorators/instructions/buildComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.ts
@@ -8,7 +8,10 @@ import {
   isAddress
 } from "viem"
 import { isNativeToken } from "../../../account/utils"
-import type { Instruction } from "../../../clients/decorators/mee"
+import type {
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import { ComposabilityVersion } from "../../../constants"
 import { functionNameToLabel } from "../../../modules/utils/Helpers"
@@ -77,7 +80,7 @@ export type BuildComposableParameters = {
    * Optional metadata describing the instruction for display purposes
    */
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 export type BuildNativeTokenTransferComposableParameters = {
   to: Address | RuntimeValue
@@ -345,7 +348,7 @@ export const buildComposableUtil = async (
   composabilityParams: ComposabilityParams
 ): Promise<Instruction[]> => {
   const { currentInstructions = [] } = baseParams
-  const { metadata } = parameters
+  const { metadata, lowerBoundTimestamp, upperBoundTimestamp } = parameters
 
   const calls = await buildComposableCall(parameters, composabilityParams)
 
@@ -363,7 +366,9 @@ export const buildComposableUtil = async (
       calls: calls,
       chainId: parameters.chainId,
       isComposable: true,
-      metadata: metadata || defaultMetadata
+      metadata: metadata || defaultMetadata,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     }
   ]
 }

--- a/src/sdk/account/decorators/instructions/buildIntent.ts
+++ b/src/sdk/account/decorators/instructions/buildIntent.ts
@@ -1,5 +1,8 @@
 import type { Address } from "viem"
-import type { Instruction } from "../../../clients/decorators/mee"
+import type {
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import type { BaseMultichainSmartAccount } from "../../toMultiChainNexusAccount"
 import type { MultichainToken } from "../../utils/Types"
@@ -29,7 +32,7 @@ export type BuildIntentParameters = {
   toChainId: number
   mode?: "DEBIT" | "OPTIMISTIC"
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Parameters for building bridge intent instructions
@@ -89,7 +92,9 @@ export const buildIntent = async (
     depositor,
     recipient,
     mode,
-    metadata
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   } = parameters
 
   const { instructions } = await buildBridgeInstructions({
@@ -99,7 +104,9 @@ export const buildIntent = async (
     toChainId,
     unifiedBalance,
     mode,
-    metadata
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   })
 
   return [...currentInstructions, ...instructions]

--- a/src/sdk/account/decorators/instructions/buildMultichainInstructions.ts
+++ b/src/sdk/account/decorators/instructions/buildMultichainInstructions.ts
@@ -1,5 +1,9 @@
 import type { OneOf } from "viem"
-import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
+import type {
+  AbstractCall,
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { Call } from "../../utils/Types"
 import type { BaseInstructionsParams } from "../build"
 
@@ -40,7 +44,8 @@ export type BuildMultichainInstructionsParameters = {
       parameters: ArgumentTypes<(typeof GLOBAL_COMPOSABLE_CALLS)[SupportedCall]>
       metadata?: InstructionMetadata[]
     }
->
+> &
+  InstructionLevelTimeBounds
 
 export const buildMultichainInstructions = async (
   baseParams: BaseInstructionsParams,
@@ -52,7 +57,9 @@ export const buildMultichainInstructions = async (
     type,
     parameters: parametersForType,
     account,
-    metadata: metadataOverride
+    metadata: metadataOverride,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   } = parameters
 
   const instructions = await Promise.all(
@@ -91,7 +98,9 @@ export const buildMultichainInstructions = async (
       return {
         calls: callsPerChain,
         chainId,
-        metadata: metadataOverride || metadata
+        metadata: metadataOverride || metadata,
+        lowerBoundTimestamp,
+        upperBoundTimestamp
       }
     })
   )

--- a/src/sdk/account/decorators/instructions/buildNativeTokenTransfer.ts
+++ b/src/sdk/account/decorators/instructions/buildNativeTokenTransfer.ts
@@ -10,7 +10,10 @@
  */
 
 import { type Address, zeroAddress } from "viem"
-import type { Instruction } from "../../../clients/decorators/mee"
+import type {
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import { ComposabilityVersion, ForwarderAbi } from "../../../constants"
 import { type RuntimeValue, isRuntimeComposableValue } from "../../../modules"
@@ -32,7 +35,7 @@ export type BuildNativeTokenTransferParameters = {
   value: bigint | RuntimeValue
   chainId: number
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Builds an instruction for transferring native tokens (e.g., ETH) from the account to a recipient.
@@ -68,7 +71,9 @@ export const buildNativeTokenTransfer = async (
     value,
     gasLimit,
     to,
-    metadata: metadataOverride
+    metadata: metadataOverride,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   } = parameters
   const { forceComposableEncoding } = composabilityParams ?? {
     forceComposableEncoding: false
@@ -138,7 +143,9 @@ export const buildNativeTokenTransfer = async (
         value,
         args: [to],
         chainId,
-        metadata: metadataOverride || metadata
+        metadata: metadataOverride || metadata,
+        lowerBoundTimestamp,
+        upperBoundTimestamp
       },
       composabilityParams
     )
@@ -166,7 +173,9 @@ export const buildNativeTokenTransfer = async (
         ],
         metadata: metadataOverride || metadata,
         isComposable: false,
-        chainId
+        chainId,
+        lowerBoundTimestamp,
+        upperBoundTimestamp
       }
     ]
   }

--- a/src/sdk/account/decorators/instructions/buildRawComposable.ts
+++ b/src/sdk/account/decorators/instructions/buildRawComposable.ts
@@ -1,5 +1,8 @@
 import type { Address, Hex } from "viem"
-import type { Instruction } from "../../../clients/decorators/mee"
+import type {
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import {
   type ComposableCall,
@@ -20,7 +23,7 @@ export type BuildRawComposableParameters = {
   gasLimit?: bigint
   value?: bigint | RuntimeValue
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Builds an instruction for raw composable transaction. This is a generic function which creates the raw composable instructions
@@ -56,7 +59,16 @@ export const buildRawComposable = async (
   composabilityParameters: ComposabilityParams
 ): Promise<Instruction[]> => {
   const { currentInstructions = [] } = baseParams
-  const { to, calldata, gasLimit, value, chainId, metadata } = parameters
+  const {
+    to,
+    calldata,
+    gasLimit,
+    value,
+    chainId,
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
+  } = parameters
   const { composabilityVersion } = composabilityParameters
 
   if (calldata.length < 10 || !calldata.startsWith("0x")) {
@@ -96,7 +108,9 @@ export const buildRawComposable = async (
       calls: [composableCall],
       chainId,
       isComposable: true,
-      metadata: metadata || defaultMetadata
+      metadata: metadata || defaultMetadata,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     }
   ]
 }

--- a/src/sdk/account/decorators/instructions/buildTransfer.ts
+++ b/src/sdk/account/decorators/instructions/buildTransfer.ts
@@ -1,5 +1,9 @@
 import { type Address, encodeFunctionData } from "viem"
-import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
+import type {
+  AbstractCall,
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import { TokenWithPermitAbi } from "../../../constants/abi/TokenWithPermitAbi"
 import type { AnyData } from "../../../modules/utils/Types"
@@ -39,7 +43,7 @@ export type BuildTransferParameters = TokenParams & {
   recipient: Address
   /** Custom metadata override for instruction */
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Parameters for the buildTransfer function
@@ -88,8 +92,16 @@ export const buildTransfer = async (
   composabilityParams?: ComposabilityParams
 ): Promise<Instruction[]> => {
   const { currentInstructions = [], accountAddress } = baseParams
-  const { chainId, tokenAddress, amount, gasLimit, recipient, metadata } =
-    parameters
+  const {
+    chainId,
+    tokenAddress,
+    amount,
+    gasLimit,
+    recipient,
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
+  } = parameters
   const { forceComposableEncoding } = composabilityParams ?? {
     forceComposableEncoding: false
   }
@@ -168,7 +180,9 @@ export const buildTransfer = async (
       calls: triggerCalls,
       chainId,
       isComposable: isComposableCall,
-      metadata: metadata || defaultMetadata
+      metadata: metadata || defaultMetadata,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     }
   ]
 }

--- a/src/sdk/account/decorators/instructions/buildTransferFrom.ts
+++ b/src/sdk/account/decorators/instructions/buildTransferFrom.ts
@@ -1,5 +1,9 @@
 import { type Address, encodeFunctionData, erc20Abi } from "viem"
-import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
+import type {
+  AbstractCall,
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import type { AnyData } from "../../../modules/utils/Types"
 import {
@@ -43,7 +47,7 @@ export type BuildTransferFromParameters = TokenParams & {
   recipient: Address
   /** Custom metadata override for instruction */
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Parameters for the buildTransferFrom function
@@ -101,7 +105,9 @@ export const buildTransferFrom = async (
     gasLimit,
     sender,
     recipient,
-    metadata
+    metadata,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   } = parameters
   const { forceComposableEncoding } = composabilityParams ?? {
     forceComposableEncoding: false
@@ -181,7 +187,9 @@ export const buildTransferFrom = async (
       calls: transferFromCall,
       chainId,
       isComposable: isComposableCall,
-      metadata: metadata || defaultMetadata
+      metadata: metadata || defaultMetadata,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     }
   ]
 }

--- a/src/sdk/account/decorators/instructions/buildWithdrawal.ts
+++ b/src/sdk/account/decorators/instructions/buildWithdrawal.ts
@@ -1,5 +1,9 @@
 import { type Address, encodeFunctionData } from "viem"
-import type { AbstractCall, Instruction } from "../../../clients/decorators/mee"
+import type {
+  AbstractCall,
+  Instruction,
+  InstructionLevelTimeBounds
+} from "../../../clients/decorators/mee"
 import type { InstructionMetadata } from "../../../clients/decorators/mee/types/instruction-metadata.type"
 import { ComposabilityVersion, ForwarderAbi } from "../../../constants"
 import { TokenWithPermitAbi } from "../../../constants/abi/TokenWithPermitAbi"
@@ -42,7 +46,7 @@ export type BuildWithdrawalParameters = TokenParams & {
   recipient?: Address
   /** Custom metadata override for instruction */
   metadata?: InstructionMetadata[]
-}
+} & InstructionLevelTimeBounds
 
 /**
  * Parameters for the buildWithdrawal function
@@ -98,7 +102,9 @@ export const buildWithdrawal = async (
     amount,
     gasLimit,
     recipient = accountAddress, // EOA or owner account address
-    metadata: metadataOverride
+    metadata: metadataOverride,
+    lowerBoundTimestamp,
+    upperBoundTimestamp
   } = parameters
 
   const [meeVersionInfo] = meeVersions.filter(
@@ -160,7 +166,9 @@ export const buildWithdrawal = async (
           gasLimit,
           args: [recipient],
           chainId,
-          metadata: metadataOverride || metadata
+          metadata: metadataOverride || metadata,
+          lowerBoundTimestamp,
+          upperBoundTimestamp
         },
         composabilityParams
       )
@@ -222,7 +230,9 @@ export const buildWithdrawal = async (
           calls: withdrawalCall,
           chainId,
           isComposable: true,
-          metadata
+          metadata,
+          lowerBoundTimestamp,
+          upperBoundTimestamp
         }
       ]
     }
@@ -247,7 +257,9 @@ export const buildWithdrawal = async (
     {
       calls: withdrawalCall,
       chainId,
-      metadata
+      metadata,
+      lowerBoundTimestamp,
+      upperBoundTimestamp
     }
   ]
 }

--- a/src/sdk/account/utils/batchInstructions.test.ts
+++ b/src/sdk/account/utils/batchInstructions.test.ts
@@ -78,7 +78,9 @@ describe("utils.batchInstructions", () => {
 
   const createBaseApproval = (
     account: MultichainSmartAccount,
-    amount: string
+    amount: string,
+    lowerBoundTimestamp?: number,
+    upperBoundTimestamp?: number
   ) =>
     buildApprove(
       { accountAddress: account.signer.address, meeVersions },
@@ -86,13 +88,17 @@ describe("utils.batchInstructions", () => {
         chainId: base.id,
         tokenAddress: mcUSDC.addressOn(base.id),
         spender: account.addressOn(base.id, true),
-        amount: parseEther(amount)
+        amount: parseEther(amount),
+        lowerBoundTimestamp,
+        upperBoundTimestamp
       }
     )
 
   const createOptimismApproval = (
     account: MultichainSmartAccount,
-    amount: string
+    amount: string,
+    lowerBoundTimestamp?: number,
+    upperBoundTimestamp?: number
   ) =>
     buildApprove(
       { accountAddress: account.signer.address, meeVersions },
@@ -100,13 +106,17 @@ describe("utils.batchInstructions", () => {
         chainId: optimism.id,
         tokenAddress: mcUSDC.addressOn(optimism.id),
         spender: account.addressOn(optimism.id, true),
-        amount: parseEther(amount)
+        amount: parseEther(amount),
+        lowerBoundTimestamp,
+        upperBoundTimestamp
       }
     )
 
   const createMainnetApproval = (
     account: MultichainSmartAccount,
-    amount: string
+    amount: string,
+    lowerBoundTimestamp?: number,
+    upperBoundTimestamp?: number
   ) =>
     buildApprove(
       { accountAddress: account.signer.address, meeVersions },
@@ -114,7 +124,9 @@ describe("utils.batchInstructions", () => {
         chainId: mainnet.id,
         tokenAddress: mcUSDC.addressOn(mainnet.id),
         spender: account.addressOn(mainnet.id, true),
-        amount: parseEther(amount)
+        amount: parseEther(amount),
+        lowerBoundTimestamp,
+        upperBoundTimestamp
       }
     )
 
@@ -218,5 +230,138 @@ describe("utils.batchInstructions", () => {
     expect(result[0].chainId).toBe(base.id)
     expect(result[1].chainId).toBe(optimism.id)
     expect(result[2].chainId).toBe(mainnet.id)
+  })
+
+  test("Should use instruction level timestamps", async () => {
+    const lowerBoundTimestamp = Math.floor(Date.now() / 1000)
+    const upperBoundTimestamp = lowerBoundTimestamp + 300 // 5 mins
+
+    const instructions = [
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp,
+        upperBoundTimestamp
+      ),
+      createOptimismApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp,
+        upperBoundTimestamp
+      ),
+      createMainnetApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp,
+        upperBoundTimestamp
+      )
+    ]
+
+    const resolvedInstructions = await resolveInstructions(instructions)
+
+    expect(resolvedInstructions[0].lowerBoundTimestamp).to.eq(
+      lowerBoundTimestamp
+    )
+    expect(resolvedInstructions[0].upperBoundTimestamp).to.eq(
+      upperBoundTimestamp
+    )
+
+    expect(resolvedInstructions[1].lowerBoundTimestamp).to.eq(
+      lowerBoundTimestamp
+    )
+    expect(resolvedInstructions[1].upperBoundTimestamp).to.eq(
+      upperBoundTimestamp
+    )
+
+    expect(resolvedInstructions[2].lowerBoundTimestamp).to.eq(
+      lowerBoundTimestamp
+    )
+    expect(resolvedInstructions[2].upperBoundTimestamp).to.eq(
+      upperBoundTimestamp
+    )
+  })
+
+  test("Should use highest instruction level timestamps of batched instruction", async () => {
+    const lowerBoundTimestamp = Math.floor(Date.now() / 1000)
+    const upperBoundTimestamp = lowerBoundTimestamp + 300 // 5 mins
+
+    const highestUpperBoundTimestamp = upperBoundTimestamp + 300 // total 10 mins
+
+    const instructions = [
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp,
+        upperBoundTimestamp
+      ),
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp,
+        highestUpperBoundTimestamp
+      ),
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp,
+        upperBoundTimestamp
+      )
+    ]
+
+    const resolvedInstructions = await resolveInstructions(instructions)
+
+    const batchedInstructions = await batchInstructions({
+      accountAddress: mcNexus.signer.address,
+      meeVersions,
+      instructions: resolvedInstructions
+    })
+
+    expect(batchedInstructions[0].lowerBoundTimestamp).to.eq(
+      lowerBoundTimestamp
+    )
+    expect(batchedInstructions[0].upperBoundTimestamp).to.eq(
+      highestUpperBoundTimestamp
+    )
+  })
+
+  test("Should use the last timestamps if there are multiple same duration timestamps", async () => {
+    const lowerBoundTimestamp = Math.floor(Date.now() / 1000)
+    const upperBoundTimestamp = lowerBoundTimestamp + 300 // 5 mins
+
+    const instructions = [
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp,
+        upperBoundTimestamp
+      ),
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp + 120,
+        upperBoundTimestamp + 120
+      ),
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp + 180,
+        upperBoundTimestamp + 180
+      )
+    ]
+
+    const resolvedInstructions = await resolveInstructions(instructions)
+
+    const batchedInstructions = await batchInstructions({
+      accountAddress: mcNexus.signer.address,
+      meeVersions,
+      instructions: resolvedInstructions
+    })
+
+    expect(batchedInstructions[0].lowerBoundTimestamp).to.eq(
+      lowerBoundTimestamp + 180
+    )
+    expect(batchedInstructions[0].upperBoundTimestamp).to.eq(
+      upperBoundTimestamp + 180
+    )
   })
 })

--- a/src/sdk/account/utils/batchInstructions.test.ts
+++ b/src/sdk/account/utils/batchInstructions.test.ts
@@ -243,17 +243,23 @@ describe("utils.batchInstructions", () => {
         lowerBoundTimestamp,
         upperBoundTimestamp
       ),
+      createBaseApproval(
+        mcNexus,
+        "1.0",
+        lowerBoundTimestamp + 60,
+        upperBoundTimestamp + 60
+      ),
       createOptimismApproval(
         mcNexus,
         "1.0",
-        lowerBoundTimestamp,
-        upperBoundTimestamp
+        lowerBoundTimestamp + 70,
+        upperBoundTimestamp + 70
       ),
       createMainnetApproval(
         mcNexus,
         "1.0",
-        lowerBoundTimestamp,
-        upperBoundTimestamp
+        lowerBoundTimestamp + 80,
+        upperBoundTimestamp + 80
       )
     ]
 
@@ -267,17 +273,24 @@ describe("utils.batchInstructions", () => {
     )
 
     expect(resolvedInstructions[1].lowerBoundTimestamp).to.eq(
-      lowerBoundTimestamp
+      lowerBoundTimestamp + 60
     )
     expect(resolvedInstructions[1].upperBoundTimestamp).to.eq(
-      upperBoundTimestamp
+      upperBoundTimestamp + 60
     )
 
     expect(resolvedInstructions[2].lowerBoundTimestamp).to.eq(
-      lowerBoundTimestamp
+      lowerBoundTimestamp + 70
     )
     expect(resolvedInstructions[2].upperBoundTimestamp).to.eq(
-      upperBoundTimestamp
+      upperBoundTimestamp + 70
+    )
+
+    expect(resolvedInstructions[3].lowerBoundTimestamp).to.eq(
+      lowerBoundTimestamp + 80
+    )
+    expect(resolvedInstructions[3].upperBoundTimestamp).to.eq(
+      upperBoundTimestamp + 80
     )
   })
 

--- a/src/sdk/account/utils/batchInstructions.ts
+++ b/src/sdk/account/utils/batchInstructions.ts
@@ -51,12 +51,12 @@ export const batchInstructions = async (
     const batch = batchesByChainId.get(chainId) || []
 
     if (batch.length > 1) {
-      const [batchedOp] = await buildBatch(
+      const [batchedInx] = await buildBatch(
         { accountAddress, meeVersions },
         { instructions: batch }
       )
 
-      result.push(batchedOp)
+      result.push(batchedInx)
     } else {
       result.push(...batch)
     }

--- a/src/sdk/clients/decorators/mee/getQuote.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.ts
@@ -95,6 +95,19 @@ export type FeeTokenInfo = {
   gasRefundAddress?: Address
 }
 
+export interface InstructionLevelTimeBounds {
+  /**
+   * Lower bound execution timestamp to be applied for specific instruction. This will override the default and global timebound configurations
+   * If multiple instructions are batched together as single userOp which has multiple timebounds, the bigger timebound window will be used
+   */
+  lowerBoundTimestamp?: number
+  /**
+   * Upper bound execution timestamp to be applied for specific instruction. This will override the default and global timebound configurations
+   * If multiple instructions are batched together as single userOp which has multiple timebounds, the bigger timebound window will be used
+   */
+  upperBoundTimestamp?: number
+}
+
 /**
  * Information about the instructions to be executed in the transaction
  * @internal
@@ -113,8 +126,7 @@ export type Instruction = {
   metadata?: InstructionMetadata[]
   /** Simulation overrides */
   simulationOverrides?: Overrides
-}
-
+} & InstructionLevelTimeBounds
 /**
  * Represents a supertransaction, which is a collection of instructions
  * to be executed in a single transaction across multiple chains
@@ -292,11 +304,11 @@ export type GetQuoteParams = SupertransactionLike & {
    */
   eoa?: Address
   /**
-   * Lower bound execution timestamp to be applied to all user operations
+   * Lower bound execution timestamp to be applied to all user operations. This is a global configuration for timebound
    */
   lowerBoundTimestamp?: number
   /**
-   * Upper bound execution timestamp to be applied to all user operations
+   * Upper bound execution timestamp to be applied to all user operations. This is a global configuration for timebound
    */
   upperBoundTimestamp?: number
   /**
@@ -958,7 +970,9 @@ export const getQuote = async (
         nexusAccount,
         shortEncoding,
         metadata,
-        simulationOverrides
+        simulationOverrides,
+        lowerBoundTimestamp,
+        upperBoundTimestamp
       ]) => {
         let initDataOrUndefined: InitDataOrUndefined = undefined
 
@@ -1048,11 +1062,13 @@ export const getQuote = async (
         }
 
         return {
-          lowerBoundTimestamp: lowerBoundTimestamp_,
+          // Instruction level timebound will be considered first
+          lowerBoundTimestamp: lowerBoundTimestamp || lowerBoundTimestamp_,
           upperBoundTimestamp: isCleanUpUserOp
             ? upperBoundTimestamp_ +
               CLEANUP_USEROP_EXTENDED_EXEC_WINDOW_DURATION
-            : upperBoundTimestamp_,
+            : // Instruction level timebound will be considered first
+              upperBoundTimestamp || upperBoundTimestamp_,
           sender,
           callData,
           callGasLimit,
@@ -1403,7 +1419,9 @@ const prepareUserOps = async (
         deployment,
         shortEncoding,
         instruction.metadata,
-        instruction.simulationOverrides
+        instruction.simulationOverrides,
+        instruction.lowerBoundTimestamp,
+        instruction.upperBoundTimestamp
       ])
     })
   )


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces the handling of `lowerBoundTimestamp` and `upperBoundTimestamp` for instructions, ensuring that these timestamps can be specified at both the instruction and global levels. This enhances the flexibility and control over execution timing for batched operations.

### Detailed summary
- Renamed `batchedOp` to `batchedInx` in `src/sdk/account/utils/batchInstructions.ts`.
- Added `InstructionLevelTimeBounds` type to multiple files.
- Updated various functions to accept `lowerBoundTimestamp` and `upperBoundTimestamp` parameters.
- Modified logic in `buildBatch` to handle these timestamps.
- Enhanced unit tests in `src/sdk/account/utils/batchInstructions.test.ts` to validate timestamp functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->