### PR TITLE
chore: add safe typekit as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "yargs": "^17.7.2"
   },
   "peerDependencies": {
+    "@safe-global/types-kit": "3.0.0",
     "@metamask/delegation-toolkit": "^0.11.0",
     "@rhinestone/module-sdk": "0.4.0",
     "typescript": "^5.8.2",


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a new peer dependency to the `package.json` file, specifically `@safe-global/types-kit` version `3.0.0`, while maintaining existing dependencies.

### Detailed summary
- Added `@safe-global/types-kit` as a peer dependency with version `3.0.0`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->