### PR TITLE
chore: refactor signPermitQuote not to use _account

### DIFF
--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -14,12 +14,14 @@ import {
   DEFAULT_GAS_LIMIT,
   type FeeTokenInfo,
   type Instruction,
+  type MultichainSmartAccountParams,
   type Trigger,
   executeSignedQuote,
   getFusionQuote,
   signPermitQuote,
   waitForSupertransactionReceipt
 } from "."
+import { getMeeVersionsForQuote } from "./signQuote"
 import {
   TESTNET_RPC_URLS,
   TEST_BLOCK_CONFIRMATIONS,
@@ -95,6 +97,21 @@ describe.runIf(runLifecycleTests)("mee.getPermitQuote", () => {
     })
     tokenAddress = mcUSDC.addressOn(paymentChain.id)
   })
+
+  const buildAccountParams = (
+    account: MultichainSmartAccount,
+    fusionQuote: { quote: { paymentInfo: { sponsored: boolean }; userOps: any[] }; trigger: { chainId: number } }
+  ): MultichainSmartAccountParams => {
+    const { trigger } = fusionQuote
+    const deployment = account.deploymentOn(trigger.chainId, true)
+    const startIndex = fusionQuote.quote.paymentInfo.sponsored ? 1 : 0
+    return {
+      owner: account.signer.address,
+      spender: deployment.address,
+      walletClient: deployment.walletClient,
+      meeVersions: getMeeVersionsForQuote(account, fusionQuote.quote.userOps.slice(startIndex))
+    }
+  }
 
   test("should resolve instructions", async () => {
     const trigger = {
@@ -379,7 +396,10 @@ describe.runIf(runLifecycleTests)("mee.getPermitQuote", () => {
     expect(fusionQuote.trigger.amount).toBe(maxAvailableBalance)
 
     const { fallbackToOnchainMode, signedPermitQuotePayload: signedQuote } =
-      await signPermitQuote(meeClient, { fusionQuote }) // Permit with 20k
+      await signPermitQuote({
+        fusionQuote,
+        account: buildAccountParams(mcNexus, fusionQuote)
+      }) // Permit with 20k
 
     if (fallbackToOnchainMode) {
       // This always fails here. This is being coded like this to avoid type issues
@@ -428,7 +448,10 @@ describe.runIf(runLifecycleTests)("mee.getPermitQuote", () => {
     })
 
     const { fallbackToOnchainMode, signedPermitQuotePayload: signedQuote } =
-      await signPermitQuote(meeClient, { fusionQuote }) // Permit with 20k
+      await signPermitQuote({
+        fusionQuote,
+        account: buildAccountParams(mcNexus, fusionQuote)
+      }) // Permit with 20k
 
     if (fallbackToOnchainMode) {
       // This always fails here. This is being coded like this to avoid type issues

--- a/src/sdk/clients/decorators/mee/index.ts
+++ b/src/sdk/clients/decorators/mee/index.ts
@@ -313,7 +313,7 @@ export const meeActions = (meeClient: BaseMeeClient): MeeActions => {
     signOnChainQuote: (params: SignOnChainQuoteParams) =>
       signOnChainQuote(meeClient, params),
     signPermitQuote: (params: SignPermitQuoteParams) =>
-      signPermitQuote(meeClient, params),
+      signPermitQuote(params),
     getPermitQuote: (params: GetPermitQuoteParams) =>
       getPermitQuote(meeClient, params),
     getFusionQuote: (params: GetFusionQuoteParams) =>

--- a/src/sdk/clients/decorators/mee/signFusionQuote.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.ts
@@ -106,8 +106,19 @@ export const signFusionQuote = async (
 
   switch (signatureType) {
     case "permit": {
+      const { trigger } = parameters.fusionQuote
+      const deployment = client.account.deploymentOn(trigger.chainId, true)
+
       const { fallbackToOnchainMode, signedPermitQuotePayload } =
-        await signPermitQuote(client, parameters)
+        await signPermitQuote({
+          fusionQuote: parameters.fusionQuote,
+          account: {
+            owner: client.account.signer.address,
+            spender: deployment.address,
+            walletClient: deployment.walletClient,
+            meeVersions
+          }
+        })
 
       // If there is any issue with permit fuctionality, the quote signing will fallback to onchain mode.
       // Fallback only happens if RPC issue, problem with permit values such as name, version, domain separator.

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -53,6 +53,7 @@ import { type FeeTokenInfo, getQuote } from "./getQuote"
 import { type QuoteType, getQuoteType } from "./getQuoteType"
 import signOnChainQuote from "./signOnChainQuote"
 import {
+  type MultichainSmartAccountParams,
   type TokenTrigger,
   type Trigger,
   formatSignedPermitQuotePayload,
@@ -119,6 +120,21 @@ describe("mee.signPermitQuote", () => {
     tokenAddress = mcUSDC.addressOn(paymentChain.id)
   })
 
+  const buildAccountParams = (
+    account: MultichainSmartAccount,
+    fusionQuote: { quote: { paymentInfo: { sponsored: boolean }; userOps: any[] }; trigger: { chainId: number } }
+  ): MultichainSmartAccountParams => {
+    const { trigger } = fusionQuote
+    const deployment = account.deploymentOn(trigger.chainId, true)
+    const startIndex = fusionQuote.quote.paymentInfo.sponsored ? 1 : 0
+    return {
+      owner: account.signer.address,
+      spender: deployment.address,
+      walletClient: deployment.walletClient,
+      meeVersions: getMeeVersionsForQuote(account, fusionQuote.quote.userOps.slice(startIndex))
+    }
+  }
+
   test.concurrent("should check permitTypehash is correct", async () => {
     const permitTypehash = keccak256(
       toBytes(
@@ -168,7 +184,10 @@ describe("mee.signPermitQuote", () => {
     const {
       fallbackToOnchainMode,
       signedPermitQuotePayload: signedPermitQuote
-    } = await signPermitQuote(meeClient, { fusionQuote })
+    } = await signPermitQuote({
+      fusionQuote,
+      account: buildAccountParams(mcNexus, fusionQuote)
+    })
 
     if (fallbackToOnchainMode) {
       // This always fails here. This is being coded like this to avoid type issues
@@ -225,7 +244,10 @@ describe("mee.signPermitQuote", () => {
 
       console.timeEnd("signPermitQuote:getQuote")
       const { fallbackToOnchainMode, signedPermitQuotePayload: signedQuote } =
-        await signPermitQuote(meeClient, { fusionQuote })
+        await signPermitQuote({
+          fusionQuote,
+          account: buildAccountParams(mcNexus, fusionQuote)
+        })
 
       if (fallbackToOnchainMode) {
         // This always fails here. This is being coded like this to avoid type issues
@@ -303,6 +325,21 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
       apiKey: "mee_3ZhZhHx3hmKrBQxacr283dHt"
     })
   })
+
+  const buildAccountParams = (
+    account: MultichainSmartAccount,
+    fusionQuote: { quote: { paymentInfo: { sponsored: boolean }; userOps: any[] }; trigger: { chainId: number } }
+  ): MultichainSmartAccountParams => {
+    const { trigger } = fusionQuote
+    const deployment = account.deploymentOn(trigger.chainId, true)
+    const startIndex = fusionQuote.quote.paymentInfo.sponsored ? 1 : 0
+    return {
+      owner: account.signer.address,
+      spender: deployment.address,
+      walletClient: deployment.walletClient,
+      meeVersions: getMeeVersionsForQuote(account, fusionQuote.quote.userOps.slice(startIndex))
+    }
+  }
 
   describe("custom approvalAmount", () => {
     test("should fail if approvalAmount is smaller than the trigger amount", async () => {
@@ -455,7 +492,10 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     const {
       fallbackToOnchainMode,
       signedPermitQuotePayload: signedPermitQuote
-    } = await signPermitQuote(meeClient, { fusionQuote })
+    } = await signPermitQuote({
+      fusionQuote,
+      account: buildAccountParams(mcNexus, fusionQuote)
+    })
 
     if (fallbackToOnchainMode) {
       // This always fails here. This is being coded like this to avoid type issues
@@ -494,8 +534,9 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
       account: walletClient.account!
     })
 
+    const accountParams = buildAccountParams(mcNexus, fusionQuote)
     const manuallySignedPermitQuote = formatSignedPermitQuotePayload(
-      mcNexus,
+      accountParams.meeVersions,
       fusionQuote,
       metadata,
       signature
@@ -619,7 +660,10 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     }
 
     const { fallbackToOnchainMode, signedPermitQuotePayload } =
-      await signPermitQuote(meeClient, { fusionQuote: modifiedFusionQuote })
+      await signPermitQuote({
+        fusionQuote: modifiedFusionQuote,
+        account: buildAccountParams(mcNexus, modifiedFusionQuote)
+      })
 
     expect(fallbackToOnchainMode).to.be.eq(true)
     expect(signedPermitQuotePayload).to.be.eq(undefined)
@@ -661,7 +705,10 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
     }
 
     const { fallbackToOnchainMode, signedPermitQuotePayload } =
-      await signPermitQuote(meeClient, { fusionQuote: modifiedFusionQuote })
+      await signPermitQuote({
+        fusionQuote: modifiedFusionQuote,
+        account: buildAccountParams(mcNexus, modifiedFusionQuote)
+      })
 
     expect(fallbackToOnchainMode).to.be.eq(true)
     expect(signedPermitQuotePayload).to.be.eq(undefined)

--- a/src/sdk/clients/decorators/mee/signPermitQuote.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.ts
@@ -14,14 +14,27 @@ import {
 } from "viem"
 import { multicall } from "viem/actions"
 import type { EIP712DomainReturn } from "../../../account"
-import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusAccount"
+import type { MeeVersionsWithChainId } from "../../../account/utils/getVersion"
 import { versionIsAtLeast } from "../../../account/utils/getVersion"
 import { MEEVersion, PERMIT_TYPEHASH } from "../../../constants"
 import { TokenWithPermitAbi } from "../../../constants/abi/TokenWithPermitAbi"
-import type { BaseMeeClient } from "../../createMeeClient"
 import type { GetPermitQuotePayload } from "./getPermitQuote"
 import type { AbstractCall, GetQuotePayload } from "./getQuote"
-import { getMeeVersionsForQuote } from "./signQuote"
+
+/**
+ * Minimal set of fields extracted from MultichainSmartAccount needed for signing permit quotes.
+ * This avoids a dependency on the full MultichainSmartAccount object.
+ */
+export type MultichainSmartAccountParams = {
+  /** The EOA signer/owner address */
+  owner: Address
+  /** The SCA address on the trigger chain (spender) */
+  spender: Address
+  /** The wallet client for the trigger chain */
+  walletClient: WalletClient
+  /** MEE versions for the chains involved in the quote */
+  meeVersions: MeeVersionsWithChainId
+}
 
 /**
  * Represents the payload for a signable permit quote, omitting the "account" field from SignTypedDataParameters.
@@ -133,10 +146,9 @@ export type SignPermitQuoteParams = {
    */
   fusionQuote: GetPermitQuotePayload
   /**
-   * Optional companion smart account to execute the superTxn
-   * If not provided, uses the client's default account
+   * Account params extracted from MultichainSmartAccount, needed for signing.
    */
-  companionAccount?: MultichainSmartAccount
+  account: MultichainSmartAccountParams
 }
 
 /**
@@ -622,18 +634,12 @@ export const prepareSignablePermitQuotePayload = async (
  * ```
  */
 export const formatSignedPermitQuotePayload = (
-  account_: MultichainSmartAccount,
+  meeVersions: MeeVersionsWithChainId,
   quoteParams: GetPermitQuotePayload,
   metadata: PermitMetadata,
   signature: Hex
 ): SignPermitQuotePayload => {
   const { quote, trigger } = quoteParams
-
-  const startIndex = quote.paymentInfo.sponsored ? 1 : 0
-  const meeVersions = getMeeVersionsForQuote(
-    account_,
-    quote.userOps.slice(startIndex)
-  )
 
   let encodedSignature: `0x${string}`
 
@@ -722,7 +728,6 @@ export const formatSignedPermitQuotePayload = (
  * ```
  */
 export const signPermitQuote = async (
-  client: BaseMeeClient,
   parameters: SignPermitQuoteParams
 ): Promise<
   OneOf<
@@ -730,19 +735,7 @@ export const signPermitQuote = async (
     | { fallbackToOnchainMode: true }
   >
 > => {
-  const {
-    companionAccount: account_ = client.account,
-    fusionQuote: { trigger }
-  } = parameters
-
-  const signer = account_.signer
-
-  const { walletClient, address: spender } = account_.deploymentOn(
-    trigger.chainId,
-    true
-  )
-
-  const owner = signer.address
+  const { owner, spender, walletClient, meeVersions } = parameters.account
 
   const { fallbackToOnchainMode, signablePayload, metadata } =
     await prepareSignablePermitQuotePayload(
@@ -762,7 +755,7 @@ export const signPermitQuote = async (
   })
 
   const signedPermitQuotePayload = formatSignedPermitQuotePayload(
-    account_,
+    meeVersions,
     parameters.fusionQuote,
     metadata,
     signature


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on refactoring the `signPermitQuote` functionality to simplify how account parameters are handled, enhancing code readability and maintainability. It introduces a new `MultichainSmartAccountParams` type and modifies several functions and tests accordingly.

### Detailed summary
- Refactored `signPermitQuote` to accept an `account` parameter of type `MultichainSmartAccountParams`.
- Introduced `buildAccountParams` function to create account parameters from `MultichainSmartAccount`.
- Updated calls to `signPermitQuote` throughout the codebase to use the new structure.
- Modified test cases in `getPermitQuote.test.ts` and `signPermitQuote.test.ts` to align with the new parameter format.
- Added a new type `Trigger` and updated related types for better clarity.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->