### PR TITLE
feat: smart sessions timeframe policy fix

### DIFF
--- a/src/sdk/account/decorators/buildActionPolicy.ts
+++ b/src/sdk/account/decorators/buildActionPolicy.ts
@@ -329,10 +329,9 @@ export const buildActionPolicy = (
       return getUniversalPolicy(parameters)
     }
     case "timeframe": {
-      // Convert Unix timestamp into milliseconds
       return getTimeFramePolicy({
-        validAfter: parameters.validAfter * 1000,
-        validUntil: parameters.validUntil * 1000
+        validAfter: parameters.validAfter,
+        validUntil: parameters.validUntil
       })
     }
     case "usageLimit": {

--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -1540,7 +1540,7 @@ describe.runIf(runLifecycleTests)("mee.buildComposable", () => {
         const { hash } = await testMeeClient.executeFusionQuote({ fusionQuote })
 
         console.log("waiting for supertransaction receipt")
-        await new Promise((resolve) => setTimeout(resolve, 75_000)) // 75s timeout
+        await new Promise((resolve) => setTimeout(resolve, 80_000)) // 80s timeout
         // should fail since condition not met
         const stxStatus = await getStxStatus(testMeeClient, hash)
         expect(stxStatus).to.be.eq("FAILED")

--- a/src/sdk/account/utils/getMultichainContract.ts
+++ b/src/sdk/account/utils/getMultichainContract.ts
@@ -93,8 +93,7 @@ function createChainSpecificContract<TAbi extends Abi>(
         gasLimit = LARGE_DEFAULT_GAS_LIMIT,
         value = 0n
       }: {
-        // biome-ignore lint/suspicious/noExplicitAny: <explanation>
-        args: any[] // This will be typed by the ChainSpecificContract type
+        args: AnyData[] // This will be typed by the ChainSpecificContract type
         gasLimit?: bigint
         value?: bigint
       }) => {

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -49,10 +49,9 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
   const signP256 = (hash: Hex): Hex => {
     const hashBytesArray = hexToBytes(hash)
     // sign returns compact format (r || s, 64 bytes) by default with prehash: false
-    const sigBytes = p256
-      .sign(hashBytesArray, privateKeyBytesArray, {
-        prehash: false
-      });
+    const sigBytes = p256.sign(hashBytesArray, privateKeyBytesArray, {
+      prehash: false
+    })
 
     return toHex(sigBytes.toCompactRawBytes())
   }

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -10,6 +10,7 @@ import {
   toHex
 } from "viem"
 import { toAccount } from "viem/accounts"
+import type { AnyData } from "../../modules"
 
 export type P256Signer = LocalAccount<"p256">
 
@@ -49,12 +50,12 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
   const signP256 = (hash: Hex): Hex => {
     const hashBytesArray = hexToBytes(hash)
     // sign returns compact format (r || s, 64 bytes) by default with prehash: false
-    const signature = p256.sign(hashBytesArray, privateKeyBytesArray, {
+    const sigBytes = p256.sign(hashBytesArray, privateKeyBytesArray, {
       prehash: false
     })
-    const compactSig = signature.toCompactRawBytes()
 
-    return toHex(compactSig)
+    // This has some type issues and it is bypassed but still everything works
+    return toHex(sigBytes as AnyData)
   }
 
   const account = toAccount({

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -50,12 +50,12 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
   const signP256 = (hash: Hex): Hex => {
     const hashBytesArray = hexToBytes(hash)
     // sign returns compact format (r || s, 64 bytes) by default with prehash: false
-    const sigBytes = p256.sign(hashBytesArray, privateKeyBytesArray, {
+    const sig = p256.sign(hashBytesArray, privateKeyBytesArray, {
       prehash: false
     })
 
     // The type system doesn't satisfy for some reason but the flow works as expected
-    return toHex(sigBytes.toCompactRawBytes() as AnyData)
+    return toHex((sig as AnyData).toCompactRawBytes())
   }
 
   const account = toAccount({

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -49,13 +49,12 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
   const signP256 = (hash: Hex): Hex => {
     const hashBytesArray = hexToBytes(hash)
     // sign returns compact format (r || s, 64 bytes) by default with prehash: false
-    const sigHex = p256
+    const sigBytes = p256
       .sign(hashBytesArray, privateKeyBytesArray, {
         prehash: false
-      })
-      .toCompactHex() as Hex
+      });
 
-    return sigHex
+    return toHex(sigBytes.toCompactRawBytes())
   }
 
   const account = toAccount({

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -49,13 +49,13 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
   const signP256 = (hash: Hex): Hex => {
     const hashBytesArray = hexToBytes(hash)
     // sign returns compact format (r || s, 64 bytes) by default with prehash: false
-    const sigBytes = p256
+    const sigHex = p256
       .sign(hashBytesArray, privateKeyBytesArray, {
         prehash: false
       })
-      .toCompactRawBytes()
+      .toCompactHex() as Hex
 
-    return toHex(sigBytes)
+    return sigHex
   }
 
   const account = toAccount({

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -10,7 +10,6 @@ import {
   toHex
 } from "viem"
 import { toAccount } from "viem/accounts"
-import type { AnyData } from "../../modules"
 
 export type P256Signer = LocalAccount<"p256">
 
@@ -50,12 +49,12 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
   const signP256 = (hash: Hex): Hex => {
     const hashBytesArray = hexToBytes(hash)
     // sign returns compact format (r || s, 64 bytes) by default with prehash: false
-    const sig = p256.sign(hashBytesArray, privateKeyBytesArray, {
+    const signature = p256.sign(hashBytesArray, privateKeyBytesArray, {
       prehash: false
-    })
+    });
+    const compactSig = signature.toCompactRawBytes();
 
-    // The type system doesn't satisfy for some reason but the flow works as expected
-    return toHex((sig as AnyData).toCompactRawBytes())
+    return toHex(compactSig)
   }
 
   const account = toAccount({

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -10,7 +10,7 @@ import {
   toHex
 } from "viem"
 import { toAccount } from "viem/accounts"
-import { AnyData } from "../../modules"
+import type { AnyData } from "../../modules"
 
 export type P256Signer = LocalAccount<"p256">
 

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -10,6 +10,7 @@ import {
   toHex
 } from "viem"
 import { toAccount } from "viem/accounts"
+import { AnyData } from "../../modules"
 
 export type P256Signer = LocalAccount<"p256">
 
@@ -53,7 +54,8 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
       prehash: false
     })
 
-    return toHex(sigBytes.toCompactRawBytes())
+    // The type system doesn't satisfy for some reason but the flow works as expected
+    return toHex(sigBytes.toCompactRawBytes() as AnyData)
   }
 
   const account = toAccount({

--- a/src/sdk/account/utils/toP256Signer.ts
+++ b/src/sdk/account/utils/toP256Signer.ts
@@ -51,8 +51,8 @@ export const toP256Signer = (privateKey: Hex): P256Signer => {
     // sign returns compact format (r || s, 64 bytes) by default with prehash: false
     const signature = p256.sign(hashBytesArray, privateKeyBytesArray, {
       prehash: false
-    });
-    const compactSig = signature.toCompactRawBytes();
+    })
+    const compactSig = signature.toCompactRawBytes()
 
     return toHex(compactSig)
   }

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -34,7 +34,7 @@ import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusA
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { DEFAULT_MEE_VERSION } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
-import { AnyData, getMEEVersion } from "../../../modules"
+import { type AnyData, getMEEVersion } from "../../../modules"
 import {
   greaterThanOrEqualTo,
   runtimeERC20BalanceOf

--- a/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getPermitQuote.test.ts
@@ -34,7 +34,7 @@ import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusA
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { DEFAULT_MEE_VERSION } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
-import { getMEEVersion } from "../../../modules"
+import { AnyData, getMEEVersion } from "../../../modules"
 import {
   greaterThanOrEqualTo,
   runtimeERC20BalanceOf
@@ -101,7 +101,7 @@ describe.runIf(runLifecycleTests)("mee.getPermitQuote", () => {
   const buildAccountParams = (
     account: MultichainSmartAccount,
     fusionQuote: {
-      quote: { paymentInfo: { sponsored: boolean }; userOps: any[] }
+      quote: { paymentInfo: { sponsored: boolean }; userOps: AnyData[] }
       trigger: { chainId: number }
     }
   ): MultichainSmartAccountParams => {

--- a/src/sdk/clients/decorators/mee/getSessionQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getSessionQuote.test.ts
@@ -867,6 +867,39 @@ describe("mee.getSessionQuote", () => {
     expect(policyData.paramRules.rules[1].isLimited).to.eq(false)
     expect(policyData.paramRules.rules[1].usage.limit).to.eq(0n)
   })
+
+  test("Smart sessions (New): Should enable 25 complex actions with proper gas estimations", async () => {
+    // New orchestrator account
+    const { mcNexus, meeClient } = await getNewUserMcNexusAndMeeClient({
+      useSponsorship: true
+    })
+
+    const transferAction = mcNexus.buildSessionAction({
+      type: "transfer",
+      data: {
+        chainIds: [paymentChain.id],
+        contractAddress: testnetMcTestUSDC.addressOn(paymentChain.id),
+        recipientAddress: "0x0000000000000000000000000000000000000001",
+        amountLimitPerAction: parseUnits("0.5", 6),
+        maxAmountLimit: parseUnits("0.5", 6),
+        usageLimit: 3n,
+        validAfter: Math.floor(Date.now() / 1000),
+        validUntil: Math.floor(Date.now() / 1000) + 3600 // 1 hour
+      }
+    })
+
+    // 25 transferActions
+    const actions = Array.from({ length: 25 }, () => transferAction).flat()
+
+    const { txHash, sessionDetails } = await prepareAndEnableSession(
+      meeClient,
+      actions,
+      { useSponsorship: true }
+    )
+
+    expect(txHash).toBeDefined()
+    expect(sessionDetails).toBeDefined()
+  })
 })
 
 describe("getSessionValidatorInitData", () => {

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -40,7 +40,7 @@ import {
   TokenWithPermitAbi
 } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
-import { getMEEVersion } from "../../../modules"
+import { AnyData, getMEEVersion } from "../../../modules"
 import {
   type MeeClient,
   createMeeClient,
@@ -124,7 +124,7 @@ describe("mee.signPermitQuote", () => {
   const buildAccountParams = (
     account: MultichainSmartAccount,
     fusionQuote: {
-      quote: { paymentInfo: { sponsored: boolean }; userOps: any[] }
+      quote: { paymentInfo: { sponsored: boolean }; userOps: AnyData[] }
       trigger: { chainId: number }
     }
   ): MultichainSmartAccountParams => {
@@ -323,7 +323,7 @@ describe.runIf(runLifecycleTests)("mee.signPermitQuote - testnet", () => {
   const buildAccountParams = (
     account: MultichainSmartAccount,
     fusionQuote: {
-      quote: { paymentInfo: { sponsored: boolean }; userOps: any[] }
+      quote: { paymentInfo: { sponsored: boolean }; userOps: AnyData[] }
       trigger: { chainId: number }
     }
   ): MultichainSmartAccountParams => {

--- a/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signPermitQuote.test.ts
@@ -40,7 +40,7 @@ import {
   TokenWithPermitAbi
 } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
-import { AnyData, getMEEVersion } from "../../../modules"
+import { type AnyData, getMEEVersion } from "../../../modules"
 import {
   type MeeClient,
   createMeeClient,

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -1052,7 +1052,7 @@ describe("mee.multichainSmartSessions (Legacy)", () => {
           maxAmountLimit: parseUnits("0.5", 6),
           usageLimit: 3n,
           validAfter: Math.floor(Date.now() / 1000),
-          validUntil: Math.floor(Date.now() / 1000) + 3600, // 1 hour
+          validUntil: Math.floor(Date.now() / 1000) + 3600 // 1 hour
         }
       })
     ].flat()

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -1050,7 +1050,9 @@ describe("mee.multichainSmartSessions (Legacy)", () => {
           recipientAddress: "0x0000000000000000000000000000000000000001",
           amountLimitPerAction: parseUnits("0.5", 6),
           maxAmountLimit: parseUnits("0.5", 6),
-          usageLimit: 3n
+          usageLimit: 3n,
+          validAfter: Math.floor(Date.now() / 1000),
+          validUntil: Math.floor(Date.now() / 1000) + 3600, // 1 hour
         }
       })
     ].flat()


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR focuses on enhancing type safety by replacing `any` with `AnyData` in multiple files, improving code clarity and maintainability. Additionally, it introduces new test cases and modifies existing ones to account for updated parameters and timeout values.

### Detailed summary
- Changed `args: any[]` to `args: AnyData[]` in `src/sdk/account/utils/getMultichainContract.ts`.
- Added `validAfter` and `validUntil` to the test case in `src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts`.
- Updated `validAfter` and `validUntil` handling in `src/sdk/account/decorators/buildActionPolicy.ts`.
- Increased timeout from 75 seconds to 80 seconds in `src/sdk/account/decorators/instructions/buildComposable.test.ts`.
- Replaced `userOps: any[]` with `userOps: AnyData[]` in multiple instances in `src/sdk/clients/decorators/mee/getPermitQuote.test.ts` and `src/sdk/clients/decorators/mee/signPermitQuote.test.ts`.
- Added a new test case for smart sessions in `src/sdk/clients/decorators/mee/getSessionQuote.test.ts`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->