### PR TITLE
feat: add Robinhood Chain (4663) to Cancun supported chains

### DIFF
--- a/src/sdk/account/utils/Utils.ts
+++ b/src/sdk/account/utils/Utils.ts
@@ -672,7 +672,11 @@ export async function supportsCancun({
     "143": true,
     "88882": false,
     "531050204": true,
-    "5010405": true
+    "5010405": true,
+    // Robinhood Chain (Arbitrum Orbit): supports Cancun (TSTORE/MCOPY verified on-chain),
+    // but like all Orbit chains its L2 blocks carry no blob-gas fields, so the dynamic
+    // block-header fallback below misdetects it - same reason 42161/33139 are listed.
+    "4663": true
   }
 
   if (cancunSupportedChains[chain.id.toString()]) {


### PR DESCRIPTION
`supportsCancun` short-circuits on a hardcoded allowlist and otherwise falls back to checking the latest block for `blobGasUsed`/`excessBlobGas`. Arbitrum Orbit chains never expose blob-gas fields in their L2 block headers, so the fallback misdetects them - which is why Arbitrum One (42161) and ApeChain (33139) are already hardcoded. Robinhood Chain (4663) is an Orbit chain with full Cancun support (TSTORE/TLOAD/MCOPY verified on-chain via bytecode-override eth_calls), but without an allowlist entry `toNexusAccount` rejects any MEE version >= 2.0.0 on it:

```
MEE version (2.2.1) is not supported for the Robinhood Chain chain. Please use a version earlier than 2.0.0 or a chain that supports Cancun.
```

With this entry, the full sponsored-supertransaction flow works end to end on Robinhood mainnet (verified against a patched 1.2.4 install: stx `0xe4551f316ae4863faf4b834e7426777bc11a878edf6a37c4481c6d62abbe5e6a`, MINED_SUCCESS).

Context: Robinhood Chain went live on the MEE node in v1.4.17 (bcnmy/mee-node#215); the V2_2_1 and current contract suites are deployed there at the canonical addresses.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `Utils.ts` file in the `src/sdk/account` directory by modifying a data structure related to chain support. It adds comments for clarification and includes new entries for specific chains.

### Detailed summary
- Added comments explaining support for the Robinhood Chain (Arbitrum Orbit) and its characteristics.
- Introduced a new entry `"4663": true` to the chain support data structure.
- Retained the entry `"5010405": true` with a trailing comma for consistency.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->