### PR TITLE
fix: mark typescript peer dependency as optional and widen version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,13 @@
     "@openzeppelin/merkle-tree": "1.0.8",
     "@metamask/delegation-toolkit": "^0.11.0",
     "@rhinestone/module-sdk": "0.4.0",
-    "typescript": "^5.8.2",
+    "typescript": ">=5.8.2",
     "viem": "^2.26.2"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "exports": {
     ".": {


### PR DESCRIPTION
Widened typescript peer dep from ^5.8.2 to >=5.8.2 to support TS 6.x+, and added peerDependenciesMeta to mark it optional so installs don't error when typescript is absent or at a non-matching version.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `package.json` file to modify the version specification for `typescript`, add `peerDependenciesMeta`, and include an `exports` section.

### Detailed summary
- Changed `typescript` version from `"^5.8.2"` to `">=5.8.2"`.
- Added `peerDependenciesMeta` for `typescript`, marking it as optional.
- Introduced an `exports` section with a path to the types file: `"./dist/_types/index.d.ts"`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->