### PR TITLE
feat: add MEE version 2.2.3 (Nexus 1.3.3)

### DIFF
--- a/scripts/fund:nexus.ts
+++ b/scripts/fund:nexus.ts
@@ -24,7 +24,10 @@ import { type MEEVersionConfig, toNexusAccount } from "../src/sdk/account"
 import { getChain } from "../src/sdk/account/utils/getChain"
 import { MEEVersion, TokenWithPermitAbi } from "../src/sdk/constants"
 import { mcUSDC } from "../src/sdk/constants/tokens"
-import { getMEEVersion } from "../src/sdk/modules/utils/getMeeConfig"
+import {
+  getLegacyMEEVersion,
+  getMEEVersion
+} from "../src/sdk/modules/utils/getMeeConfig"
 import { testnetMcTestUSDC, testnetMcTestUSDCP } from "../src/test/testTokens"
 
 dotenv.config()
@@ -78,31 +81,39 @@ async function main() {
     // Default: Index zero will be used for most of the tests
     await processChain(chainId, account, {
       accountIndex: ACCOUNT_INDEX,
-      version: getMEEVersion(MEEVersion.V2_0_0)
+      version: getLegacyMEEVersion(MEEVersion.V2_0_0)
     })
     await processChain(chainId, account, {
       accountIndex: ACCOUNT_INDEX_ONE,
-      version: getMEEVersion(MEEVersion.V2_0_0)
+      version: getLegacyMEEVersion(MEEVersion.V2_0_0)
     })
     await processChain(chainId, account, {
       accountIndex: ACCOUNT_INDEX,
-      version: getMEEVersion(MEEVersion.V2_1_0)
+      version: getLegacyMEEVersion(MEEVersion.V2_1_0)
     })
     await processChain(chainId, account, {
       accountIndex: ACCOUNT_INDEX,
-      version: getMEEVersion(MEEVersion.V2_2_1)
+      version: getLegacyMEEVersion(MEEVersion.V2_2_1)
     })
     await processChain(chainId, account, {
       accountIndex: ACCOUNT_INDEX_ONE,
-      version: getMEEVersion(MEEVersion.V2_2_2)
+      version: getLegacyMEEVersion(MEEVersion.V2_2_2)
     })
     await processChain(chainId, account, {
       accountIndex: ACCOUNT_INDEX,
-      version: getMEEVersion(MEEVersion.V1_1_0)
+      version: getLegacyMEEVersion(MEEVersion.V1_1_0)
     })
     await processChain(chainId, account, {
       accountIndex: ACCOUNT_INDEX,
-      version: getMEEVersion(MEEVersion.V1_0_0)
+      version: getLegacyMEEVersion(MEEVersion.V1_0_0)
+    })
+    await processChain(chainId, account, {
+      accountIndex: ACCOUNT_INDEX,
+      version: getMEEVersion(MEEVersion.V2_2_3)
+    })
+    await processChain(chainId, account, {
+      accountIndex: ACCOUNT_INDEX_ONE,
+      version: getMEEVersion(MEEVersion.V2_2_3)
     })
   }
 }

--- a/src/sdk/account/decorators/instructions/buildComposable.test.ts
+++ b/src/sdk/account/decorators/instructions/buildComposable.test.ts
@@ -49,6 +49,7 @@ import {
   type ExecutionCondition,
   type RuntimeValue,
   createCondition,
+  getLegacyMEEVersion,
   getMEEVersion,
   greaterThanOrEqualTo,
   greaterThanOrEqualToSigned,
@@ -127,7 +128,7 @@ describe.runIf(runLifecycleTests)("mee.buildComposable", () => {
         {
           chain: chain,
           transport: http(network.rpcUrl),
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         }
       ]
     })
@@ -139,7 +140,7 @@ describe.runIf(runLifecycleTests)("mee.buildComposable", () => {
         {
           chain: chain,
           transport: http(network.rpcUrl),
-          version: getMEEVersion(MEEVersion.V2_2_2)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_2)
         }
       ]
     })

--- a/src/sdk/account/decorators/instructions/buildNativeTokenTransfer.test.ts
+++ b/src/sdk/account/decorators/instructions/buildNativeTokenTransfer.test.ts
@@ -7,7 +7,11 @@ import {
   createMeeClient
 } from "../../../clients/createMeeClient"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
-import { getMEEVersion, runtimeNativeBalanceOf } from "../../../modules"
+import {
+  getLegacyMEEVersion,
+  getMEEVersion,
+  runtimeNativeBalanceOf
+} from "../../../modules"
 import {
   type MultichainSmartAccount,
   toMultichainNexusAccount
@@ -131,7 +135,7 @@ describe("mee.buildNativeTokenTransfer", () => {
         {
           chain: chain,
           transport: http(network.rpcUrl),
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         }
       ]
     })

--- a/src/sdk/account/toMultiChainNexusAccount.test.ts
+++ b/src/sdk/account/toMultiChainNexusAccount.test.ts
@@ -21,7 +21,10 @@ import type { NetworkConfig } from "../../test/testUtils"
 import { createMeeClient } from "../clients/createMeeClient"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../constants"
 import { mcUSDC } from "../constants/tokens"
-import { getMEEVersion } from "../modules/utils/getMeeConfig"
+import {
+  getLegacyMEEVersion,
+  getMEEVersion
+} from "../modules/utils/getMeeConfig"
 import {
   type MultichainSmartAccount,
   toMultichainNexusAccount
@@ -192,7 +195,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
             chain: base,
             transport: http(MAINNET_RPC_URLS[base.id]),
             version: {
-              ...getMEEVersion(MEEVersion.V2_0_0),
+              ...getLegacyMEEVersion(MEEVersion.V2_0_0),
               // Forcefully override this address, so it doesn't have any byte code.
               // This indirectly tests the MEE version contract unavailability for brand new chains
               implementationAddress:
@@ -210,7 +213,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
           chainConfiguration: {
             chain: notCancunChain,
             transport: http(MAINNET_RPC_URLS[notCancunChain.id]),
-            version: getMEEVersion(MEEVersion.V2_0_0)
+            version: getLegacyMEEVersion(MEEVersion.V2_0_0)
           }
         })
       ).rejects.toThrow(
@@ -224,7 +227,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
           {
             chain: baseSepolia,
             transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-            version: getMEEVersion(MEEVersion.V1_0_0)
+            version: getLegacyMEEVersion(MEEVersion.V1_0_0)
           },
           {
             chain: base,
@@ -293,7 +296,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
             {
               chain: baseSepolia,
               transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-              version: getMEEVersion(MEEVersion.V1_0_0)
+              version: getLegacyMEEVersion(MEEVersion.V1_0_0)
             }
           ]
         })
@@ -306,7 +309,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
             {
               chain: baseSepolia,
               transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-              version: getMEEVersion(MEEVersion.V1_1_0)
+              version: getLegacyMEEVersion(MEEVersion.V1_1_0)
             }
           ]
         })
@@ -319,7 +322,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
             {
               chain: baseSepolia,
               transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-              version: getMEEVersion(MEEVersion.V2_0_0)
+              version: getLegacyMEEVersion(MEEVersion.V2_0_0)
             }
           ]
         })
@@ -333,7 +336,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
             {
               chain: baseSepolia,
               transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-              version: getMEEVersion(MEEVersion.V2_1_0)
+              version: getLegacyMEEVersion(MEEVersion.V2_1_0)
             }
           ]
         })
@@ -347,7 +350,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
             {
               chain: baseSepolia,
               transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-              version: getMEEVersion(MEEVersion.V2_2_1)
+              version: getLegacyMEEVersion(MEEVersion.V2_2_1)
             }
           ]
         })
@@ -364,7 +367,7 @@ describe("mee.toMultiChainNexusAccount", async () => {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
           version: {
-            ...getMEEVersion(MEEVersion.V2_0_0),
+            ...getLegacyMEEVersion(MEEVersion.V2_0_0),
             factoryAddress: "0x0000006648ED9B2B842552BE63Af870bC74af837"
           }
         }

--- a/src/sdk/account/toMultiChainNexusAccount.ts
+++ b/src/sdk/account/toMultiChainNexusAccount.ts
@@ -312,12 +312,12 @@ export type MultichainSmartAccount = BaseMultichainSmartAccount & {
  *     {
  *       chain: optimism,
  *       transport: http(),
- *       version: getMEEVersion(MEEversion.V2_1_0)
+ *       version: getMEEVersion(MEEVersion.V2_2_3)
  *     },
  *     {
  *       chain: base,
  *       transport: http(),
- *       version: getMEEVersion(MEEversion.V2_1_0)
+ *       version: getMEEVersion(MEEVersion.V2_2_3)
  *     }
  *   ]
  * });

--- a/src/sdk/account/toNexusAccount.addresses.test.ts
+++ b/src/sdk/account/toNexusAccount.addresses.test.ts
@@ -20,7 +20,7 @@ import {
   createSmartAccountClient
 } from "../clients/createBicoBundlerClient"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../constants"
-import { getMEEVersion } from "../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../modules"
 import { type NexusAccount, toNexusAccount } from "./toNexusAccount"
 
 describe("nexus.account.addresses", async () => {
@@ -57,7 +57,7 @@ describe("nexus.account.addresses", async () => {
       chainConfiguration: {
         chain,
         transport: http(network.rpcUrl),
-        version: getMEEVersion(MEEVersion.V1_0_0)
+        version: getLegacyMEEVersion(MEEVersion.V1_0_0)
       }
     })
 
@@ -82,7 +82,7 @@ describe("nexus.account.addresses", async () => {
       chainConfiguration: {
         chain,
         transport: http(network.rpcUrl),
-        version: getMEEVersion(MEEVersion.V1_0_0),
+        version: getLegacyMEEVersion(MEEVersion.V1_0_0),
         accountAddress: someoneElsesNexusAddress
       }
     })

--- a/src/sdk/account/toNexusAccount.test.ts
+++ b/src/sdk/account/toNexusAccount.test.ts
@@ -45,7 +45,7 @@ import {
 } from "../clients/createBicoBundlerClient"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../constants"
 import { TokenWithPermitAbi } from "../constants/abi/TokenWithPermitAbi"
-import { getMEEVersion } from "../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../modules"
 import { toOwnableModule } from "../modules/validators/ownable"
 import { type NexusAccount, toNexusAccount } from "./toNexusAccount"
 import {
@@ -488,7 +488,7 @@ describe("nexus.account - signing methods", async () => {
       chainConfiguration: {
         chain,
         transport: http(network.rpcUrl),
-        version: getMEEVersion(MEEVersion.V3_0_0)
+        version: getLegacyMEEVersion(MEEVersion.V3_0_0)
       },
       index: 200n
     })

--- a/src/sdk/clients/decorators/mee/executeQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/executeQuote.test.ts
@@ -21,7 +21,7 @@ import {
 } from "../../../account/toMultiChainNexusAccount"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
-import { getMEEVersion } from "../../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../../modules"
 import {
   type MeeClient,
   createMeeClient,
@@ -87,12 +87,12 @@ describe("mee.executeQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         }
       ]
     })
@@ -156,7 +156,7 @@ describe("mee.executeQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })

--- a/src/sdk/clients/decorators/mee/getQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuote.test.ts
@@ -30,7 +30,7 @@ import type { MultichainSmartAccount } from "../../../account/toMultiChainNexusA
 import { toMultichainNexusAccount } from "../../../account/toMultiChainNexusAccount"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
-import { getMEEVersion } from "../../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../../modules"
 import {
   DEFAULT_MEE_SPONSORSHIP_CHAIN_ID,
   DEFAULT_MEE_SPONSORSHIP_PAYMASTER_ACCOUNT,
@@ -218,12 +218,12 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         }
       ]
     })
@@ -1319,13 +1319,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -1436,13 +1436,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -1553,13 +1553,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -1643,13 +1643,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -1737,13 +1737,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: newEoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: newEoaAccount.address
         }
       ]
@@ -1850,13 +1850,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -1923,13 +1923,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2004,13 +2004,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2083,7 +2083,7 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2140,13 +2140,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2202,13 +2202,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2271,13 +2271,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2382,13 +2382,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2481,13 +2481,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2572,13 +2572,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]
@@ -2653,13 +2653,13 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: randomAddressOne.address
         },
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: randomAddressTwo.address
         }
       ]
@@ -2680,7 +2680,7 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })
@@ -2718,7 +2718,7 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })
@@ -2777,7 +2777,7 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })
@@ -2839,7 +2839,7 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })
@@ -2890,7 +2890,7 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })
@@ -2963,7 +2963,7 @@ describe("mee.getQuote", () => {
         {
           chain: baseSepolia,
           transport: http(TESTNET_RPC_URLS[baseSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })

--- a/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
+++ b/src/sdk/clients/decorators/mee/getQuoteSimulations.test.ts
@@ -46,6 +46,7 @@ import {
   testnetMcUSDC
 } from "../../../constants"
 import {
+  getLegacyMEEVersion,
   getMEEVersion,
   meeSessionActions,
   runtimeNativeBalanceOf
@@ -586,7 +587,7 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
         {
           chain: chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         }
       ]
     })
@@ -639,7 +640,7 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
         {
           chain: chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           // Overriden with EOA address
           accountAddress: eoaAccount.address
         }
@@ -680,7 +681,7 @@ describe("mee.getQuote({ simulations }) - Single Chain Simulation Scenarios", ()
         {
           chain: chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           accountAddress: eoaAccount.address
         }
       ]

--- a/src/sdk/clients/decorators/mee/getSessionQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/getSessionQuote.test.ts
@@ -65,6 +65,7 @@ import {
 } from "../../../constants"
 import {
   type AnyData,
+  getLegacyMEEVersion,
   getMEEVersion,
   meeSessionActions
 } from "../../../modules"
@@ -906,13 +907,13 @@ describe("getSessionValidatorInitData", () => {
   const redeemer = "0x1234567890abcdef1234567890abcdef12345678" as Address
 
   test("should return raw redeemer address for pre-V3 versions (K1 validator)", () => {
-    const versionConfig = getMEEVersion(MEEVersion.V2_0_0)
+    const versionConfig = getLegacyMEEVersion(MEEVersion.V2_0_0)
     const initData = getSessionValidatorInitData(versionConfig, redeemer)
     expect(initData).to.eq(redeemer)
   })
 
   test("should return encodePacked init data for V3_0_0 (STX validator)", () => {
-    const versionConfig = getMEEVersion(MEEVersion.V3_0_0)
+    const versionConfig = getLegacyMEEVersion(MEEVersion.V3_0_0)
     const initData = getSessionValidatorInitData(versionConfig, redeemer)
 
     const expected = encodePacked(

--- a/src/sdk/clients/decorators/mee/signFusionQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signFusionQuote.test.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../account/toMultiChainNexusAccount"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
 import { mcUSDC } from "../../../constants/tokens"
-import { getMEEVersion } from "../../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../../modules"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import { executeSignedQuote } from "./executeSignedQuote"
 import getFusionQuote from "./getFusionQuote"
@@ -67,12 +67,12 @@ describe("mee.signFusionQuote", () => {
         {
           chain: paymentChain,
           transport: paymentChainTransport,
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         },
         {
           chain: targetChain,
           transport: targetChainTransport,
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         }
       ]
     })

--- a/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signOnChainQuote.test.ts
@@ -32,7 +32,7 @@ import {
 } from "../../../account/toMultiChainNexusAccount"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
 import { mcUSDC, mcUSDT } from "../../../constants/tokens"
-import { getMEEVersion } from "../../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../../modules"
 import { runtimeNativeBalanceOf } from "../../../modules/utils/composabilityCalls"
 import {
   type MeeClient,
@@ -597,7 +597,7 @@ describe.runIf(runLifecycleTests)("mee.signOnChainQuote - testnet", () => {
           {
             chain: network.chain,
             transport: http(network.rpcUrl),
-            version: getMEEVersion(MEEVersion.V2_2_1)
+            version: getLegacyMEEVersion(MEEVersion.V2_2_1)
           }
         ]
       })

--- a/src/sdk/clients/decorators/mee/signQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signQuote.test.ts
@@ -20,7 +20,7 @@ import { SIG_TYPE_SIMPLE_P256 } from "../../../account/utils/Constants"
 import { versionIsAtLeast } from "../../../account/utils/getVersion"
 import { toP256Signer } from "../../../account/utils/toP256Signer"
 import { DEFAULT_MEE_VERSION, MEEVersion } from "../../../constants"
-import { getMEEVersion } from "../../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../../modules"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import type { Instruction } from "./getQuote"
 import { getQuoteType } from "./getQuoteType"
@@ -60,7 +60,7 @@ describe("mee.signQuote", () => {
         {
           chain: optimismSepolia,
           transport: http(TESTNET_RPC_URLS[optimismSepolia.id]),
-          version: getMEEVersion(MEEVersion.V2_2_1)
+          version: getLegacyMEEVersion(MEEVersion.V2_2_1)
         }
       ]
     })
@@ -236,7 +236,7 @@ describe("mee.signQuote", () => {
     // manually compose MeeVersionsWithChainId array
     const expectedMeeVersions = [
       {
-        version: getMEEVersion(MEEVersion.V2_2_1),
+        version: getLegacyMEEVersion(MEEVersion.V2_2_1),
         chainId: optimismSepolia.id
       }
     ]
@@ -274,7 +274,7 @@ describe("mee.signQuote", () => {
           {
             chain: chain,
             transport: http(network.rpcUrl),
-            version: getMEEVersion(MEEVersion.V3_0_0)
+            version: getLegacyMEEVersion(MEEVersion.V3_0_0)
           }
         ]
       })

--- a/src/sdk/clients/decorators/mee/signSafeQuote.test.ts
+++ b/src/sdk/clients/decorators/mee/signSafeQuote.test.ts
@@ -30,7 +30,7 @@ import {
 } from "../../../account/toMultiChainNexusAccount"
 import { MEEVersion } from "../../../constants"
 import { ForwarderAbi } from "../../../constants/abi/ForwarderAbi"
-import { getMEEVersion } from "../../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../../modules"
 import type { BaseMeeClient } from "../../createMeeClient"
 import { type MeeClient, createMeeClient } from "../../createMeeClient"
 import type { GetQuotePayload } from "./getQuote"
@@ -626,16 +626,16 @@ describe("mee.signSafeQuote", () => {
         {
           chain: baseSepolia,
           transport: http(baseSepoliaRpcUrl),
-          version: getMEEVersion(MEEVersion.V3_0_0)
+          version: getLegacyMEEVersion(MEEVersion.V3_0_0)
         },
         {
           chain: optimismSepolia,
           transport: http(opSepoliaRpcUrl),
-          version: getMEEVersion(MEEVersion.V3_0_0)
+          version: getLegacyMEEVersion(MEEVersion.V3_0_0)
         }
       ],
       defaultModuleParameters: {
-        statelessValidator: getMEEVersion(MEEVersion.V3_0_0).submodules
+        statelessValidator: getLegacyMEEVersion(MEEVersion.V3_0_0).submodules
           ?.SafeAccountSubmodule as Address,
         ownershipData: encodePacked(["address"], [predictedSafeAddress])
       }

--- a/src/sdk/clients/decorators/mee/signSafeQuote.ts
+++ b/src/sdk/clients/decorators/mee/signSafeQuote.ts
@@ -410,8 +410,8 @@ export function getDataToPrepareSafeTransaction(
  * const mcNexus = await toMultichainNexusAccount({
  *   signer: safeSigner,
  *   chainConfigurations: [
- *     { chain: baseSepolia, transport: http(), version: getMEEVersion(MEEVersion.V2_3_0) },
- *     { chain: optimismSepolia, transport: http(), version: getMEEVersion(MEEVersion.V2_3_0) }
+ *     { chain: baseSepolia, transport: http(), version: getMEEVersion(MEEVersion.V2_2_3) },
+ *     { chain: optimismSepolia, transport: http(), version: getMEEVersion(MEEVersion.V2_2_3) }
  *   ]
  * })
  *

--- a/src/sdk/clients/decorators/mee/upgradeSmartAccount.test.ts
+++ b/src/sdk/clients/decorators/mee/upgradeSmartAccount.test.ts
@@ -25,7 +25,7 @@ import {
   toMultichainNexusAccount
 } from "../../../account"
 import { MEEVersion, NexusBootstrapAbi } from "../../../constants"
-import { getMEEVersion } from "../../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../../modules"
 import { createBicoBundlerClient } from "../../createBicoBundlerClient"
 import { createMeeClient } from "../../createMeeClient"
 
@@ -97,7 +97,7 @@ describe("mee.upgradeSmartAccount", () => {
         {
           chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V1_0_0)
+          version: getLegacyMEEVersion(MEEVersion.V1_0_0)
         }
       ],
       index: accountIndex
@@ -195,7 +195,7 @@ describe("mee.upgradeSmartAccount", () => {
         {
           chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_0_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_0_0),
           // Old nexus address is overriden here
           accountAddress: mcNexus1_0_0Address
         }
@@ -244,7 +244,7 @@ describe("mee.upgradeSmartAccount", () => {
         {
           chain,
           transport: http(TESTNET_RPC_URLS[chain.id]),
-          version: getMEEVersion(MEEVersion.V2_1_0),
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0),
           // Old nexus address is overriden here
           accountAddress: mcNexus1_0_0Address
         }

--- a/src/sdk/clients/test-versions/createSmartAccountClient_1_0_2.test.ts
+++ b/src/sdk/clients/test-versions/createSmartAccountClient_1_0_2.test.ts
@@ -32,7 +32,7 @@ import {
 } from "../../account/utils/Utils"
 import { getChain } from "../../account/utils/getChain"
 import { MEEVersion } from "../../constants"
-import { getMEEVersion } from "../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../modules"
 import {
   type NexusClient,
   createSmartAccountClient
@@ -75,7 +75,7 @@ describe("nexus.client.1.0.2", async () => {
       chainConfiguration: {
         chain: chain_1_0_2,
         transport: http(network_1_0_2.rpcUrl),
-        version: getMEEVersion(MEEVersion.V1_0_0)
+        version: getLegacyMEEVersion(MEEVersion.V1_0_0)
       }
     })
 
@@ -291,7 +291,7 @@ describe("nexus.client.1.0.2", async () => {
       chainConfiguration: {
         chain: chain_1_0_2,
         transport: http(network_1_0_2.rpcUrl),
-        version: getMEEVersion(MEEVersion.V1_0_0)
+        version: getLegacyMEEVersion(MEEVersion.V1_0_0)
       }
     })
 
@@ -317,7 +317,7 @@ describe("nexus.client.1.0.2", async () => {
       chainConfiguration: {
         chain: chain_1_0_2,
         transport: http(network_1_0_2.rpcUrl),
-        version: getMEEVersion(MEEVersion.V1_0_0)
+        version: getLegacyMEEVersion(MEEVersion.V1_0_0)
       }
     })
 
@@ -332,7 +332,7 @@ describe("nexus.client.1.0.2", async () => {
       chainConfiguration: {
         chain: chain_1_0_2,
         transport: http(network_1_0_2.rpcUrl),
-        version: getMEEVersion(MEEVersion.V1_0_0)
+        version: getLegacyMEEVersion(MEEVersion.V1_0_0)
       }
     })
 

--- a/src/sdk/constants/index.ts
+++ b/src/sdk/constants/index.ts
@@ -66,12 +66,35 @@ export enum ComposabilityVersion {
   V1_0_0 = "1.0.0"
 }
 
-// NOTE: Update this description, whenever changing the new default version
-/** Default version is 2.0.0.
- * Major release, featuring Nexus 1.2.0 with ERC-7702 support and native composability.
- * MEE K1 Validator is pre-installed as a default validator module.
+/**
+ * MEE versions approved for creating new accounts.
+ *
+ * Membership is decided per implementation bytecode, not by version ordering.
+ * Version numbers do not imply membership: 2.3.0 and 3.0.0 sort above 2.2.3 but
+ * are built on Nexus 1.3.1, so they are not listed here. Add a version only after
+ * its deployed implementation has been verified on chain.
  */
-export const DEFAULT_MEE_VERSION: MEEVersion = MEEVersion.V2_0_0
+export const SAFE_MEE_VERSIONS = [MEEVersion.V2_2_3] as const
+
+/** A MEE version that may be used to create new accounts. */
+export type SafeMEEVersion = (typeof SAFE_MEE_VERSIONS)[number]
+
+/**
+ * A MEE version that may no longer be used to create new accounts.
+ *
+ * These remain reachable through {@link getLegacyMEEVersion} because deriving an
+ * existing account's address requires the version it was created with. Deploying,
+ * sweeping or upgrading an existing account all depend on that derivation.
+ */
+export type LegacyMEEVersion = Exclude<MEEVersion, SafeMEEVersion>
+
+// NOTE: Update this description, whenever changing the new default version
+/** Default version is 2.2.3.
+ * Nexus 1.3.3, Composability 1.1.1. Account initialization is single-use per transaction.
+ *
+ * Prefer selecting a version explicitly; this default exists for internal fallbacks.
+ */
+export const DEFAULT_MEE_VERSION: SafeMEEVersion = MEEVersion.V2_2_3
 
 export const ENTRY_POINT_ADDRESS: Address =
   "0x0000000071727De22E5E9d8BAf0edAc6f37da032"

--- a/src/sdk/constants/index.ts
+++ b/src/sdk/constants/index.ts
@@ -19,6 +19,12 @@ export enum MEEVersion {
    **/
   V2_3_0 = "2.3.0",
   /**
+   * Nexus 1.3.3
+   * - Composability 1.1.1
+   * - Account initialization is single-use per transaction
+   **/
+  V2_2_3 = "2.2.3",
+  /**
    * Nexus 1.3.2
    * - Composability 1.1.1
    * - New composability features - signed integer and OR flow
@@ -106,6 +112,17 @@ export const DEFAULT_CONFIGURATIONS_BY_MEE_VERSION: Record<
     defaultValidatorAddress: zeroAddress,
     ethForwarderAddress: "0x000000C48Cdf2b46bEc062483dBD27046dfE3b8d",
     composabilityVersion: ComposabilityVersion.V1_1_0
+  },
+  [MEEVersion.V2_2_3]: {
+    version: MEEVersion.V2_2_3,
+    accountId: "biconomy.nexus.1.3.3",
+    factoryAddress: "0x0000b1C08f1418dA76B5E99c1Bf5718486cf8c53", // Nexus Account Factory Address
+    bootStrapAddress: "0x0000B1c0A80cb7DD166a15e7390b8A4Ced4500C6",
+    implementationAddress: "0x0000B1c01cB3b5770D8806f0D214d50131a08a5B", // Nexus 1.3.3
+    validatorAddress: "0x0000B1C0790E5a28293276C320d2B95D651dBaD6", // MEE K1 Validator Address
+    defaultValidatorAddress: zeroAddress,
+    ethForwarderAddress: "0x0000B1C0Fc7015Effa85892426FAEd8211B2d62E",
+    composabilityVersion: ComposabilityVersion.V1_1_1
   },
   [MEEVersion.V2_2_2]: {
     version: MEEVersion.V2_2_2,

--- a/src/sdk/index.ts
+++ b/src/sdk/index.ts
@@ -27,6 +27,7 @@ export {
   toComposableFallback,
   toEmptyHook,
   getMEEVersion,
+  getLegacyMEEVersion,
   createCondition,
   createConditionInputParam,
   ConditionType,

--- a/src/sdk/integration-tests/mee-versions/safe-mode.integration.test.ts
+++ b/src/sdk/integration-tests/mee-versions/safe-mode.integration.test.ts
@@ -55,7 +55,7 @@ import {
   getMockSafeSigner
 } from "../../clients/decorators/mee/signSafeQuote"
 import { MEEVersion } from "../../constants"
-import { getMEEVersion } from "../../modules"
+import { getLegacyMEEVersion, getMEEVersion } from "../../modules"
 
 const modes = [
   {
@@ -297,16 +297,16 @@ describe("Safe Account Mode Integration Tests", () => {
         {
           chain: baseSepolia,
           transport: http(baseSepoliaRpcUrl),
-          version: getMEEVersion(MEEVersion.V3_0_0)
+          version: getLegacyMEEVersion(MEEVersion.V3_0_0)
         },
         {
           chain: optimismSepolia,
           transport: http(opSepoliaRpcUrl),
-          version: getMEEVersion(MEEVersion.V3_0_0)
+          version: getLegacyMEEVersion(MEEVersion.V3_0_0)
         }
       ],
       defaultModuleParameters: {
-        statelessValidator: getMEEVersion(MEEVersion.V3_0_0).submodules
+        statelessValidator: getLegacyMEEVersion(MEEVersion.V3_0_0).submodules
           ?.SafeAccountSubmodule as Address,
         ownershipData: encodePacked(["address"], [safeAddress])
       }

--- a/src/sdk/integration-tests/mee-versions/setupMultiVersion.ts
+++ b/src/sdk/integration-tests/mee-versions/setupMultiVersion.ts
@@ -15,8 +15,16 @@ import {
 } from "../../account/utils/toP256Signer"
 import type { MeeClient } from "../../clients/createMeeClient"
 import { createMeeClient } from "../../clients/createMeeClient"
-import { MEEVersion } from "../../constants"
-import { getMEEVersion } from "../../modules"
+import { MEEVersion, SAFE_MEE_VERSIONS } from "../../constants"
+import type { SafeMEEVersion } from "../../constants"
+import { getLegacyMEEVersion, getMEEVersion } from "../../modules"
+
+// These suites deliberately exercise every MEE version, including ones no longer
+// approved for new accounts, so they resolve configs through both entry points.
+const resolveVersionConfig = (version: MEEVersion) =>
+  SAFE_MEE_VERSIONS.includes(version as SafeMEEVersion)
+    ? getMEEVersion(version as SafeMEEVersion)
+    : getLegacyMEEVersion(version as Exclude<MEEVersion, SafeMEEVersion>)
 
 // RPC URLs for testnets
 const TESTNET_RPC_URLS: Record<number, string> = {
@@ -103,7 +111,7 @@ export async function setupMultiVersionAccounts(
       chainConfigurations: chains.map((chain: Chain) => ({
         chain,
         transport: http(TESTNET_RPC_URLS[chain.id]),
-        version: getMEEVersion(version)
+        version: resolveVersionConfig(version)
       }))
     })
 
@@ -192,7 +200,7 @@ export async function setupAccountsWithSigner(
       chainConfigurations: chains.map((chain: Chain) => ({
         chain,
         transport: http(TESTNET_RPC_URLS[chain.id]),
-        version: getMEEVersion(version)
+        version: resolveVersionConfig(version)
       }))
     })
 

--- a/src/sdk/modules/index.ts
+++ b/src/sdk/modules/index.ts
@@ -18,7 +18,7 @@ export { toValidator } from "./validators/toValidator"
 export { toComposableExecutor } from "./toComposableExecutor"
 export { toComposableFallback } from "./toComposableFallback"
 export { toEmptyHook } from "./toEmptyHook"
-export { getMEEVersion } from "./validators/smartSessions"
+export { getMEEVersion, getLegacyMEEVersion } from "./validators/smartSessions"
 
 // Session management and action functions
 export {

--- a/src/sdk/modules/utils/getMeeConfig.test.ts
+++ b/src/sdk/modules/utils/getMeeConfig.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest"
+import {
+  DEFAULT_MEE_VERSION,
+  MEEVersion,
+  SAFE_MEE_VERSIONS
+} from "../../constants"
+import { getLegacyMEEVersion, getMEEVersion } from "./getMeeConfig"
+
+/**
+ * Only versions built on Nexus 1.3.3 may create new accounts.
+ *
+ * Version ordering does not imply safety: 2.3.0 and 3.0.0 sort above 2.2.3 but are
+ * built on Nexus 1.3.1. Membership of the allowlist is therefore pinned to the
+ * implementation address, verified on chain, rather than derived by comparison.
+ */
+const NEXUS_133_IMPLEMENTATION = "0x0000B1c01cB3b5770D8806f0D214d50131a08a5B"
+
+describe("getMEEVersion", () => {
+  test("every allowlisted version resolves to the Nexus 1.3.3 implementation", () => {
+    expect(SAFE_MEE_VERSIONS.length).toBeGreaterThan(0)
+
+    for (const version of SAFE_MEE_VERSIONS) {
+      expect(getMEEVersion(version).implementationAddress).toBe(
+        NEXUS_133_IMPLEMENTATION
+      )
+    }
+  })
+
+  test("the default version is allowlisted", () => {
+    expect(SAFE_MEE_VERSIONS).toContain(DEFAULT_MEE_VERSION)
+  })
+
+  test("rejects versions that cannot create new accounts", () => {
+    // @ts-expect-error V2_0_0 is not assignable to SafeMEEVersion — this is the
+    // compile-time guard clients hit. The runtime throw covers JavaScript callers.
+    expect(() => getMEEVersion(MEEVersion.V2_0_0)).toThrow(
+      /cannot be used to create new accounts/
+    )
+  })
+
+  test("the rejection points at the migration entry point", () => {
+    // @ts-expect-error see above
+    expect(() => getMEEVersion(MEEVersion.V2_2_1)).toThrow(
+      /getLegacyMEEVersion/
+    )
+  })
+
+  test("versions ordering above the allowlist are still rejected", () => {
+    // 2.3.0 sorts above 2.2.3 but runs Nexus 1.3.1.
+    // @ts-expect-error see above
+    expect(() => getMEEVersion(MEEVersion.V2_3_0)).toThrow(
+      /cannot be used to create new accounts/
+    )
+  })
+})
+
+describe("getLegacyMEEVersion", () => {
+  test("resolves earlier versions so existing accounts stay derivable", () => {
+    // An existing account's address comes from the factory of the version that
+    // created it, so migration flows must be able to resolve these.
+    expect(getLegacyMEEVersion(MEEVersion.V2_1_0).factoryAddress).toBe(
+      "0x0000006648ED9B2B842552BE63Af870bC74af837"
+    )
+    expect(getLegacyMEEVersion(MEEVersion.V2_0_0).accountId).toBe(
+      "biconomy.nexus.1.2.0"
+    )
+  })
+
+  test("earlier versions resolve to a different factory than the current one", () => {
+    // Why migration changes the account address rather than upgrading in place.
+    const legacyFactory = getLegacyMEEVersion(MEEVersion.V2_1_0).factoryAddress
+    const currentFactory = getMEEVersion(MEEVersion.V2_2_3).factoryAddress
+    expect(legacyFactory).not.toBe(currentFactory)
+  })
+})

--- a/src/sdk/modules/utils/getMeeConfig.ts
+++ b/src/sdk/modules/utils/getMeeConfig.ts
@@ -4,31 +4,73 @@ import {
 } from "../../account/utils/getVersion"
 import {
   DEFAULT_CONFIGURATIONS_BY_MEE_VERSION,
-  type MEEVersion
+  type LegacyMEEVersion,
+  type MEEVersion,
+  SAFE_MEE_VERSIONS,
+  type SafeMEEVersion
 } from "../../constants"
 
-/**
- * Returns the appropriate configuration based on the SDK version
- * @param version - The SDK version string (e.g., "0.2.0")
- * @returns The configuration containing important smart contract addresses: Nexus implementation, validator, factory, and others
- * @throws Error if the version is not supported
- */
-export function getMEEVersion(meeVersion: MEEVersion): MEEVersionConfig {
-  // If the version is explicitly provided in the DEFAULT_CONFIGURATIONS_BY_VERSION mapping
+const MIGRATION_GUIDE = "https://docs.biconomy.io/upgrade-migrate"
+
+function lookup(meeVersion: MEEVersion): MEEVersionConfig {
   if (meeVersion in DEFAULT_CONFIGURATIONS_BY_MEE_VERSION) {
     return DEFAULT_CONFIGURATIONS_BY_MEE_VERSION[meeVersion]
   }
 
-  // If the version is not explicitly listed, find the closest compatible version
-  // Sort the available versions in descending order
+  // Sort the available versions in descending order for the error message
   const allVersions = Object.keys(DEFAULT_CONFIGURATIONS_BY_MEE_VERSION).sort(
     (a, b) => semverCompare(b, a)
   )
 
-  // If no compatible version is found, throw an error
   throw new Error(
     `Unsupported MEE version: ${meeVersion}. Compatible versions are: ${allVersions.join(
       ", "
     )}`
   )
+}
+
+/**
+ * Returns the configuration for a MEE version approved for creating new accounts.
+ *
+ * Only versions in {@link SAFE_MEE_VERSIONS} are accepted. Passing any other version
+ * is a compile-time error, and is also rejected at runtime for JavaScript callers.
+ *
+ * To derive, deploy or upgrade an account that already exists on an earlier version,
+ * use {@link getLegacyMEEVersion} instead.
+ *
+ * @param meeVersion - The MEE version to use for new accounts
+ * @returns The configuration containing important smart contract addresses: Nexus implementation, validator, factory, and others
+ * @throws Error if the version is not approved for new accounts
+ */
+export function getMEEVersion(meeVersion: SafeMEEVersion): MEEVersionConfig {
+  if (!SAFE_MEE_VERSIONS.includes(meeVersion)) {
+    throw new Error(
+      `MEE version ${meeVersion} cannot be used to create new accounts. ` +
+        `Use ${SAFE_MEE_VERSIONS.join(", ")}. ` +
+        `To derive or upgrade an account that already exists on ${meeVersion}, ` +
+        `use getLegacyMEEVersion("${meeVersion}") and see ${MIGRATION_GUIDE}.`
+    )
+  }
+
+  return lookup(meeVersion)
+}
+
+/**
+ * Returns the configuration for a MEE version that is no longer used for new accounts.
+ *
+ * An existing account's address is derived from the factory and bootstrap of the version
+ * it was created with, so that version is required to compute the address again. Use this
+ * to enumerate, deploy, sweep or upgrade accounts that already exist.
+ *
+ * Do not use this to create new accounts; use {@link getMEEVersion}.
+ *
+ * @param meeVersion - The MEE version the existing account was created with
+ * @returns The configuration containing important smart contract addresses: Nexus implementation, validator, factory, and others
+ * @throws Error if the version is not supported
+ * @see {@link MIGRATION_GUIDE}
+ */
+export function getLegacyMEEVersion(
+  meeVersion: LegacyMEEVersion
+): MEEVersionConfig {
+  return lookup(meeVersion)
 }

--- a/src/sdk/modules/validators/smartSessions/index.ts
+++ b/src/sdk/modules/validators/smartSessions/index.ts
@@ -2,7 +2,7 @@ export * from "./Helpers"
 export * from "./Types"
 export * from "./toSmartSessionsModule"
 export * from "./decorators"
-export { getMEEVersion } from "../../utils/getMeeConfig"
+export { getMEEVersion, getLegacyMEEVersion } from "../../utils/getMeeConfig"
 
 import { toDisableActionPoliciesCalls } from "./decorators/toDisableActionPoliciesCalls"
 import { toDisableERC1271PoliciesCalls } from "./decorators/toDisableERC1271PoliciesCalls"

--- a/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
+++ b/src/sdk/modules/validators/smartSessions/toMultichainSmartSessions.test.ts
@@ -59,7 +59,7 @@ import {
   testnetMcUSDC
 } from "../../../constants"
 import { CounterAbi } from "../../../constants/abi/CounterAbi"
-import { getMEEVersion } from "../../utils"
+import { getLegacyMEEVersion, getMEEVersion } from "../../utils"
 import type { AnyData } from "../../utils/Types"
 import type { Validator } from "../toValidator"
 import { meeSessionActions } from "./decorators/mee"
@@ -125,12 +125,12 @@ describe("mee.multichainSmartSessions (Legacy)", () => {
         {
           chain: baseSepolia,
           transport: paymentChainTransport,
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         },
         {
           chain: optimismSepolia,
           transport: targetChainTransport,
-          version: getMEEVersion(MEEVersion.V2_1_0)
+          version: getLegacyMEEVersion(MEEVersion.V2_1_0)
         }
       ]
     })


### PR DESCRIPTION
## Summary

Adds `MEEVersion.V2_2_3` for the Nexus 1.3.3 contract suite.

| Contract | Address | Change |
|---|---|---|
| Nexus implementation | `0x0000B1c01cB3b5770D8806f0D214d50131a08a5B` | new (Nexus 1.3.3) |
| NexusAccountFactory | `0x0000b1C08f1418dA76B5E99c1Bf5718486cf8c53` | new (rebound to the new implementation) |
| NexusBootstrap | `0x0000B1c0A80cb7DD166a15e7390b8A4Ced4500C6` | unchanged from 2.2.2 |
| MEE K1 Validator | `0x0000B1C0790E5a28293276C320d2B95D651dBaD6` | unchanged |
| ETH Forwarder | `0x0000B1C0Fc7015Effa85892426FAEd8211B2d62E` | unchanged |

`accountId` is `biconomy.nexus.1.3.3`; composability stays at `V1_1_1`.

`NexusAccountFactory` takes the implementation as a constructor immutable, which is why its address changes alongside the implementation. All other contracts in the suite are byte-identical to 2.2.2 and keep their existing addresses.

## Defaults unchanged

`DEFAULT_MEE_VERSION` still resolves to `2.0.0`. This is deliberate: it is a public export, and changing it would change derived account addresses for any integration that does not pin a version, making existing accounts appear undeployed. Steering new integrations to 2.2.3 is handled server-side and in the docs instead.

## Why this needs to land first

`stx-api` consumes `MEEVersion` from this package, so `2.2.3` has to be published here before `stx-api` can reference it.

## Verification

The contracts are deployed deterministically via CREATE2 and confirmed on chain — implementation returns `accountId() == "biconomy.nexus.1.3.3"` and the factory reports the new implementation address.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces the `getLegacyMEEVersion` function to manage legacy MEE versions, alongside updates to various files to replace calls to `getMEEVersion` with `getLegacyMEEVersion` where appropriate. It also updates the default MEE version to `V2_2_3`.

### Detailed summary
- Added `getLegacyMEEVersion` function to handle legacy MEE versions.
- Updated `src/sdk/index.ts` to export `getLegacyMEEVersion`.
- Modified version references in multiple files to use `getLegacyMEEVersion` instead of `getMEEVersion`.
- Changed default MEE version to `V2_2_3` in `src/sdk/constants/index.ts`.
- Updated version references in tests and implementations across various files to align with the new legacy handling.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->